### PR TITLE
Replace curl examples with orth CLI in SKILL.md files

### DIFF
--- a/skills/orthogonal-andi/SKILL.md
+++ b/skills/orthogonal-andi/SKILL.md
@@ -15,24 +15,12 @@ Fast, high-quality search with intelligent ranking, instant answers, and researc
 
 ### Web Search ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/andi/v1/search?query=how%20does%20RAG%20work" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run andi /v1/search --query 'query=how%20does%20RAG%20work'
 ```
 
 ### Search with Options
 ```bash
-curl "https://api.orth.sh/v1/run/andi/v1/search?query=best%20programming%20languages%202024&limit=10" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Simple search
-orth api run andi /v1/search --query 'query=latest%20AI%20news'
-
-# Search for technical content
-orth api run andi /v1/search --query 'query=kubernetes%20best%20practices'
+orth api run andi /v1/search --query query=best%20programming%20languages%202024 limit=10
 ```
 
 ## Use Cases

--- a/skills/orthogonal-andi/SKILL.md
+++ b/skills/orthogonal-andi/SKILL.md
@@ -9,18 +9,35 @@ Fast, high-quality search with intelligent ranking, instant answers, and researc
 
 ## Capabilities
 
-- **Search**: High-quality web search with AI-powered ranking ($0.01)
+- **Search**: Fast, high-quality search API with intelligent ranking, instant answers, and result enrichment ($0.01)
 
 ## Usage
 
-### Web Search ($0.01)
-```bash
-orth api run andi /v1/search --query 'query=how%20does%20RAG%20work'
-```
+### Search ($0.01)
+Fast, high-quality search API with intelligent ranking, instant answers, and result enrichment.
 
-### Search with Options
+Parameters:
+- q* (string) - Search query (or array of up to 5 queries)
+- limit (string) - Number of results (1-100)
+- depth (string) - Search depth: fast or deep
+- intent (string) - Search intent. Supported Intents: ImageSearchIntent - Prioritize image results, VideoSearchIntent - Prioritize video results, NewsSearchIntent - Prioritize news articles, WeatherSearchIntent - Weather information, ComputationIntent - Mathematical calculations and computations, NavigationalSearchIntent - Direct navigation to websites, Not detected or specified: FallbackSearchIntent - General web search (default)
+- metadata (string) - Metadata level: basic or full
+- format (string) - Response format: json
+- extracts (string) - Enable content extracts/highlights
+- safe (string) - Enable safe search filtering
+- country (string) - Country code (US, GB, etc.)
+- language (string) - Language code (en, es, fr, etc.)
+- units (string) - Units: metric or imperial
+- noCache  (string) - Force skip all caches
+- dateRange (string) - Date range filter. Restrict results to specific time periods using relative or absolute date filters: Relative date range (dateRange parameter): day or 24h - Last 24 hours; week or 7d - Last 7 days; month or 30d - Last 30 days; year or 1y - Last year; 90d - Last 90 days
+- includeDomains (string) - Comma-separated domains to include
+- excludeDomains (string) - Comma-separated domains to exclude
+- includeTerms (string) - Comma-separated terms/phrases to boost
+- excludeTerms (string) - Comma-separated terms/phrases to exclude
+- parseOperators (string) - Extract operators from query string
+
 ```bash
-orth api run andi /v1/search --query query=best%20programming%20languages%202024 limit=10
+orth api run andi /v1/search --query 'q=how%20does%20RAG%20work'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-apartment-hunter/SKILL.md
+++ b/skills/orthogonal-apartment-hunter/SKILL.md
@@ -13,55 +13,43 @@ Search for apartments matching your location, budget, and amenity requirements.
 Use Tavily to search for apartments:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "apartments for rent in San Francisco Mission District under $3000 1 bedroom pet friendly",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "apartments for rent in San Francisco Mission District under $3000 1 bedroom pet friendly",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Get Neighborhood Info
 Research the neighborhood:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Tell me about the Mission District in San Francisco - safety, walkability, restaurants, public transit, vibe"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Tell me about the Mission District in San Francisco - safety, walkability, restaurants, public transit, vibe"
+  }]
+}'
 ```
 
 ### Step 3: Extract Listing Details
 Use ScrapeGraph to get structured listing data:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://www.apartments.com/san-francisco-ca/",
-    "user_prompt": "Extract apartment listings with price, bedrooms, square footage, amenities, and contact info"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.apartments.com/san-francisco-ca/",
+  "user_prompt": "Extract apartment listings with price, bedrooms, square footage, amenities, and contact info"
+}'
 ```
 
 ### Step 4: Check Commute
 Research commute times:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "How long is the commute from Mission District SF to Financial District by BART and by car during rush hour?"
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "How long is the commute from Mission District SF to Financial District by BART and by car during rush hour?"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-apartment-hunter/SKILL.md
+++ b/skills/orthogonal-apartment-hunter/SKILL.md
@@ -48,7 +48,7 @@ Research commute times:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "How long is the commute from Mission District SF to Financial District by BART and by car during rush hour?"
+  "task": "How long is the commute from Mission District SF to Financial District by BART and by car during rush hour?"
 }'
 ```
 

--- a/skills/orthogonal-api-tester/SKILL.md
+++ b/skills/orthogonal-api-tester/SKILL.md
@@ -13,66 +13,51 @@ Test API endpoints, validate responses, and generate documentation examples.
 Make GET requests to test endpoints:
 
 ```bash
-curl "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://api.example.com/health"}'
+orth api run linkup /fetch --body '{"url": "https://api.example.com/health"}'
 ```
 
 ### Step 2: Test POST Endpoints
 Test POST requests by fetching API docs:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://api.example.com/docs",
-    "user_prompt": "Extract all API endpoints, methods, parameters, and example responses"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://api.example.com/docs",
+  "user_prompt": "Extract all API endpoints, methods, parameters, and example responses"
+}'
 ```
 
 ### Step 3: Get API Documentation
 Fetch and parse API docs:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/markdownify" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"website_url": "https://api.example.com/docs"}'
+orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://api.example.com/docs"}'
 ```
 
 ### Step 4: Generate Test Cases
 Use AI to create test scenarios:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Generate comprehensive test cases for a REST API user endpoint that supports GET, POST, PUT, DELETE. Include edge cases and error scenarios."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Generate comprehensive test cases for a REST API user endpoint that supports GET, POST, PUT, DELETE. Include edge cases and error scenarios."
+  }]
+}'
 ```
 
 ### Step 5: Validate Response Schema
 Check response structure:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/riveter/v1/run" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://api.example.com/endpoint",
-    "schema": {
-      "id": "string",
-      "name": "string",
-      "created_at": "string"
-    }
-  }'
+orth api run riveter /v1/run --body '{
+  "url": "https://api.example.com/endpoint",
+  "schema": {
+    "id": "string",
+    "name": "string",
+    "created_at": "string"
+  }
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -22,80 +22,55 @@ Extract comprehensive brand information from any domain - logos, colors, fonts, 
 
 ### Get Brand Info ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ### Get Simplified Brand ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve-simplified?domain=notion.so" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve-simplified --query 'domain=notion.so'
 ```
 
 ### Extract Style Guide ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/styleguide?domain=linear.app" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/styleguide --query 'domain=linear.app'
 ```
 
 ### Get Font Information ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/fonts?domain=vercel.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/fonts --query 'domain=vercel.com'
 ```
 
 ### Capture Screenshot ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/screenshot?domain=github.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/screenshot --query 'domain=github.com'
 ```
 
 ### NAICS Classification ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/naics?domain=openai.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/naics --query 'domain=openai.com'
 ```
 
 ### AI Query ($0.03)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/brand-dev/v1/brand/ai/query" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "domain": "anthropic.com",
-    "query": "What products does this company offer?"
-  }'
+orth api run brand-dev /v1/brand/ai/query --body '{
+  "domain": "anthropic.com",
+  "query": "What products does this company offer?"
+}'
 ```
 
 ### Find by Company Name ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve-by-name?name=Stripe" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve-by-name --query 'name=Stripe'
 ```
 
 ### Find by Email ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve-by-email?email=john@stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve-by-email --query 'email=john@stripe.com'
 ```
 
 ### Find by Stock Ticker ($0.03)
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve-by-ticker?ticker=AAPL" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Get comprehensive brand data
-orth api run brand-dev /v1/brand/retrieve --query 'domain=figma.com'
-
-# Extract style guide
-orth api run brand-dev /v1/brand/styleguide --query 'domain=tailwindcss.com'
-
-# Custom AI extraction
-orth api run brand-dev /v1/brand/ai/query --body '{"domain": "shopify.com", "query": "What is their pricing?"}'
+orth api run brand-dev /v1/brand/retrieve-by-ticker --query 'ticker=AAPL'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -9,68 +9,191 @@ Extract comprehensive brand information from any domain - logos, colors, fonts, 
 
 ## Capabilities
 
-- **Retrieve Brand**: Get logos, colors, industry, description ($0.03)
-- **Style Guide**: Extract design system information ($0.03)
-- **Fonts**: Get font information from websites ($0.03)
-- **Products**: Extract product information ($0.03)
-- **Screenshots**: Capture website screenshots ($0.03)
-- **NAICS Classification**: Classify into NAICS codes ($0.03)
-- **AI Query**: Extract custom data points ($0.03)
-- **Lookups**: Find by name, ticker, email, or ISIN ($0.03)
+- **Extract fonts from website**: Extract font information from a brand’s website including font families, usage statistics, fallbacks, and element/word counts ($0.03)
+- **Identify brand from transaction data**: Endpoint specially designed for platforms that want to identify transaction data by the transaction title ($0.03)
+- **Retrieve NAICS code for any brand**: Endpoint to classify any brand into a 2022 NAICS code ($0.03)
+- **Retrieve brand data by email address**: Retrieve brand information using an email address while detecting disposable and free email addresses ($0.03)
+- **Retrieve simplified brand data by domain**: Returns a simplified version of brand data containing only essential information: domain, title, colors, logos, and backdrops ($0.03)
+- **Retrieve brand data by ISIN**: Retrieve brand information using an ISIN (International Securities Identification Number) ($0.03)
+- **Extract products from a brand's website**: Beta feature: Extract product information from a brand’s website ($0.03)
+- **Retrieve brand data by domain**: Retrieve logos, backdrops, colors, industry, description, and more from any domain ($0.03)
+- **Retrieve brand data by company name**: Retrieve brand information using a company name ($0.03)
+- **Retrieve brand data by stock ticker**: Retrieve brand information using a stock ticker symbol ($0.03)
+- **Extract design system and styleguide from website**: Automatically extract comprehensive design system information from a brand’s website including colors, typography, spacing, shadows, and UI components ($0.03)
+- **Take screenshot of website**: Capture a screenshot of a website ($0.03)
+- **Query website data using AI**: Use AI to extract specific data points from a brand’s website ($0.03)
 
 ## Usage
 
-### Get Brand Info ($0.03)
-```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
-```
+### Extract fonts from website ($0.03)
+Extract font information from a brand’s website including font families, usage statistics, fallbacks, and element/word counts.
 
-### Get Simplified Brand ($0.03)
-```bash
-orth api run brand-dev /v1/brand/retrieve-simplified --query 'domain=notion.so'
-```
+Parameters:
+- domain* (string) - Domain name to extract fonts from (e.g., 'example.com', 'google.com'). The domain will be automatically normalized and validated.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
-### Extract Style Guide ($0.03)
-```bash
-orth api run brand-dev /v1/brand/styleguide --query 'domain=linear.app'
-```
-
-### Get Font Information ($0.03)
 ```bash
 orth api run brand-dev /v1/brand/fonts --query 'domain=vercel.com'
 ```
 
-### Capture Screenshot ($0.03)
+### Identify brand from transaction data ($0.03)
+Endpoint specially designed for platforms that want to identify transaction data by the transaction title.
+
+Parameters:
+- transaction_info* (string) - Transaction information to identify the brand
+- force_language (string) - Optional parameter to force the language of the retrieved brand data.
+- maxSpeed (boolean) - Optional parameter to optimize the API call for maximum speed. When set to true, the API will skip time-consuming operations for faster response at the cost of less comprehensive data.
+- country_gl (string) - Optional country code (GL parameter) to specify the country. This affects the geographic location used for search queries.
+- city (string) - Optional city name to prioritize when searching for the brand.
+- mcc (string) - Optional Merchant Category Code (MCC) to help identify the business category/industry.
+- phone (number) - Optional phone number from the transaction to help verify brand match.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
 ```bash
-orth api run brand-dev /v1/brand/screenshot --query 'domain=github.com'
+orth api run brand-dev /v1/brand/transaction_identifier --query 'transaction_title=STRIPE%20PAYMENT'
 ```
 
-### NAICS Classification ($0.03)
+### Retrieve NAICS code for any brand ($0.03)
+Endpoint to classify any brand into a 2022 NAICS code.
+
+Parameters:
+- input* (string) - Brand domain or title to retrieve NAICS code for. If a valid domain is provided in input, it will be used for classification, otherwise, we will search for the brand using the provided title.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+- minResults (integer) - Minimum number of NAICS codes to return. Must be at least 1. Defaults to 1.
+- maxResults (integer) - Maximum number of NAICS codes to return. Must be between 1 and 10. Defaults to 5.
+
 ```bash
 orth api run brand-dev /v1/brand/naics --query 'input=openai.com'
 ```
 
-### AI Query ($0.03)
+### Retrieve brand data by email address ($0.03)
+Retrieve brand information using an email address while detecting disposable and free email addresses. This endpoint extracts the domain from the email address and returns brand data for that domain. Disposable and free email addresses (like gmail.com, yahoo.com) will throw a 422 error.
+
+Parameters:
+- email* (string<email>) - Email address to retrieve brand data for (e.g., 'contact@example.com'). The domain will be extracted from the email. Free email providers (gmail.com, yahoo.com, etc.) and disposable email addresses are not allowed.
+- force_language (string) - Optional parameter to force the language of the retrieved brand data.
+- maxSpeed (boolean) - Optional parameter to optimize the API call for maximum speed. When set to true, the API will skip time-consuming operations for faster response at the cost of less comprehensive data.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
+```bash
+orth api run brand-dev /v1/brand/retrieve-by-email --query 'email=john@stripe.com'
+```
+
+### Retrieve simplified brand data by domain ($0.03)
+Returns a simplified version of brand data containing only essential information: domain, title, colors, logos, and backdrops. This endpoint is optimized for faster responses and reduced data transfer.
+
+Parameters:
+- domain* (string) - Domain name to retrieve simplified brand data for
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
+```bash
+orth api run brand-dev /v1/brand/retrieve-simplified --query 'domain=notion.so'
+```
+
+### Retrieve brand data by ISIN ($0.03)
+Retrieve brand information using an ISIN (International Securities Identification Number). This endpoint looks up the company associated with the ISIN and returns its brand data.
+
+Parameters:
+- isin* (string) - ISIN (International Securities Identification Number) to retrieve brand data for (e.g., 'AU000000IMD5', 'US0378331005'). Must be exactly 12 characters: 2 letters followed by 9 alphanumeric characters and ending with a digit.
+- force_language (string) - Optional parameter to force the language of the retrieved brand data.
+- maxSpeed (boolean) - Optional parameter to optimize the API call for maximum speed. When set to true, the API will skip time-consuming operations for faster response at the cost of less comprehensive data.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
+```bash
+orth api run brand-dev /v1/brand/retrieve-by-isin --query 'isin=US0378331005'
+```
+
+### Extract products from a brand's website ($0.03)
+Beta feature: Extract product information from a brand’s website. Brand.dev will analyze the website and return a list of products with details such as name, description, image, pricing, features, and more.
+
+Parameters:
+- domain* (string) - The domain name to analyze
+- maxProducts (integer) - Maximum number of products to extract.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
+```bash
+orth api run brand-dev /v1/brand/ai/products --body '{"domain": "stripe.com"}'
+```
+
+### Retrieve brand data by domain ($0.03)
+Retrieve logos, backdrops, colors, industry, description, and more from any domain
+
+Parameters:
+- domain* (string) - Domain name to retrieve brand data for (e.g., 'example.com', 'google.com'). Cannot be used with name or ticker parameters.
+- force_language (string) - Optional parameter to force the language of the retrieved brand data. Works with all three lookup methods.
+- maxSpeed (boolean) - Optional parameter to optimize the API call for maximum speed. When set to true, the API will skip time-consuming operations for faster response at the cost of less comprehensive data. Works with all three lookup methods.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
+```bash
+orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
+```
+
+### Retrieve brand data by company name ($0.03)
+Retrieve brand information using a company name. This endpoint searches for the company by name and returns its brand data.
+
+Parameters:
+- name* (string) - Company name to retrieve brand data for (e.g., 'Apple Inc', 'Microsoft Corporation'). Must be 3-30 characters.
+- force_language (string) - Optional parameter to force the language of the retrieved brand data.
+- maxSpeed (boolean) - Optional parameter to optimize the API call for maximum speed. When set to true, the API will skip time-consuming operations for faster response at the cost of less comprehensive data.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
+```bash
+orth api run brand-dev /v1/brand/retrieve-by-name --query 'name=Stripe'
+```
+
+### Retrieve brand data by stock ticker ($0.03)
+Retrieve brand information using a stock ticker symbol. This endpoint looks up the company associated with the ticker and returns its brand data.
+
+Parameters:
+- ticker* (string) - Stock ticker symbol to retrieve brand data for (e.g., 'AAPL', 'GOOGL', 'BRK.A'). Must be 1-15 characters, letters/numbers/dots only.
+- ticker_exchange (string) - Optional stock exchange for the ticker. Defaults to NASDAQ if not specified.
+- force_language (string) - Optional parameter to force the language of the retrieved brand data.
+- maxSpeed (boolean) - Optional parameter to optimize the API call for maximum speed. When set to true, the API will skip time-consuming operations for faster response at the cost of less comprehensive data.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+
+```bash
+orth api run brand-dev /v1/brand/retrieve-by-ticker --query 'ticker=AAPL'
+```
+
+### Extract design system and styleguide from website ($0.03)
+Automatically extract comprehensive design system information from a brand’s website including colors, typography, spacing, shadows, and UI components.
+
+Parameters:
+- domain* (string) - Domain name to extract styleguide from (e.g., 'example.com', 'google.com'). The domain will be automatically normalized and validated.
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+- prioritize (string) - Optional parameter to prioritize screenshot capture for styleguide extraction. If 'speed', optimizes for faster capture with basic quality. If 'quality', optimizes for higher quality with longer wait times. Defaults to 'quality' if not provided.
+
+```bash
+orth api run brand-dev /v1/brand/styleguide --query 'domain=linear.app'
+```
+
+### Take screenshot of website ($0.03)
+Capture a screenshot of a website. Supports both viewport (standard browser view) and full-page screenshots. Can also screenshot specific page types (login, pricing, etc.) by using heuristics to find the appropriate URL. Returns a URL to the uploaded screenshot image hosted on our CDN.
+
+Parameters:
+- domain* (string) - Domain name to take screenshot of (e.g., 'example.com', 'google.com'). The domain will be automatically normalized and validated.
+- fullScreenshot (string) - Optional parameter to determine screenshot type. If 'true', takes a full page screenshot capturing all content. If 'false' or not provided, takes a viewport screenshot (standard browser view).
+- page (string) - Optional parameter to specify which page type to screenshot. If provided, the system will scrape the domain's links and use heuristics to find the most appropriate URL for the specified page type (30 supported languages). If not provided, screenshots the main domain landing page.
+- prioritize (string) - Optional parameter to prioritize screenshot capture. If 'speed', optimizes for faster capture with basic quality. If 'quality', optimizes for higher quality with longer wait times. Defaults to 'quality' if not provided.
+
+```bash
+orth api run brand-dev /v1/brand/screenshot --query 'domain=github.com'
+```
+
+### Query website data using AI ($0.03)
+Use AI to extract specific data points from a brand’s website. The AI will crawl the website and extract the requested information based on the provided data points.
+
+Parameters:
+- domain* (string) - The domain name to analyze
+- data_to_extract* (object[]) - Array of data points to extract from the website
+- timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
+- specific_pages (object) - Optional object specifying which pages to analyze
+
 ```bash
 orth api run brand-dev /v1/brand/ai/query --body '{
   "domain": "anthropic.com",
   "data_to_extract": [{"name": "products", "description": "What products does this company offer?"}]
 }'
-```
-
-### Find by Company Name ($0.03)
-```bash
-orth api run brand-dev /v1/brand/retrieve-by-name --query 'name=Stripe'
-```
-
-### Find by Email ($0.03)
-```bash
-orth api run brand-dev /v1/brand/retrieve-by-email --query 'email=john@stripe.com'
-```
-
-### Find by Stock Ticker ($0.03)
-```bash
-orth api run brand-dev /v1/brand/retrieve-by-ticker --query 'ticker=AAPL'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -47,14 +47,14 @@ orth api run brand-dev /v1/brand/screenshot --query 'domain=github.com'
 
 ### NAICS Classification ($0.03)
 ```bash
-orth api run brand-dev /v1/brand/naics --query 'domain=openai.com'
+orth api run brand-dev /v1/brand/naics --query 'input=openai.com'
 ```
 
 ### AI Query ($0.03)
 ```bash
 orth api run brand-dev /v1/brand/ai/query --body '{
   "domain": "anthropic.com",
-  "query": "What products does this company offer?"
+  "data_to_extract": [{"name": "products", "description": "What products does this company offer?"}]
 }'
 ```
 

--- a/skills/orthogonal-bug-reporter/SKILL.md
+++ b/skills/orthogonal-bug-reporter/SKILL.md
@@ -13,71 +13,56 @@ Create detailed, actionable bug reports with all necessary information for debug
 Search for related issues or solutions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "React useState not updating TypeError common causes solutions",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "React useState not updating TypeError common causes solutions",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Find Similar Issues
 Check if issue is known:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "site:github.com/issues React useState batch updates bug",
-    "num_results": 20
-  }'
+orth api run exa /search --body '{
+  "query": "site:github.com/issues React useState batch updates bug",
+  "num_results": 20
+}'
 ```
 
 ### Step 3: Get Environment Info
 Research version compatibility:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "What are common compatibility issues between React 18 and older npm packages? What environment info should I include in a bug report?"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "What are common compatibility issues between React 18 and older npm packages? What environment info should I include in a bug report?"
+  }]
+}'
 ```
 
 ### Step 4: Generate Bug Report
 Create comprehensive bug report:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Help me write a detailed GitHub bug report for this issue:\n\nProblem: Button click doesn'\''t update state\nWhat I tried: useState, useReducer\nExpected: State updates on click\nActual: Nothing happens\n\nInclude: summary, environment, steps to reproduce, expected vs actual, possible causes"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Help me write a detailed GitHub bug report for this issue:\n\nProblem: Button click doesn'\''t update state\nWhat I tried: useState, useReducer\nExpected: State updates on click\nActual: Nothing happens\n\nInclude: summary, environment, steps to reproduce, expected vs actual, possible causes"
+  }]
+}'
 ```
 
 ### Step 5: Find Workarounds
 Search for temporary fixes:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "What are workarounds for React state not updating on click events?"
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "What are workarounds for React state not updating on click events?"
+}'
 ```
 
 ## Bug Report Template

--- a/skills/orthogonal-bug-reporter/SKILL.md
+++ b/skills/orthogonal-bug-reporter/SKILL.md
@@ -61,7 +61,7 @@ Search for temporary fixes:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "What are workarounds for React state not updating on click events?"
+  "task": "What are workarounds for React state not updating on click events?"
 }'
 ```
 

--- a/skills/orthogonal-changelog-writer/SKILL.md
+++ b/skills/orthogonal-changelog-writer/SKILL.md
@@ -13,65 +13,50 @@ Generate professional changelogs from git commits, PRs, and release information.
 Get recent commits from GitHub:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://github.com/user/repo/commits/main"}'
+orth api run linkup /fetch --body '{"url": "https://github.com/user/repo/commits/main"}'
 ```
 
 ### Step 2: Extract PR Information
 Get PR details and descriptions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://github.com/user/repo/pulls?state=closed",
-    "user_prompt": "Extract PR titles, numbers, descriptions, and labels for recently merged PRs"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://github.com/user/repo/pulls?state=closed",
+  "user_prompt": "Extract PR titles, numbers, descriptions, and labels for recently merged PRs"
+}'
 ```
 
 ### Step 3: Generate Changelog
 Use AI to write formatted changelog:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Write a professional changelog entry for version 2.1.0 based on these commits:\n\n- feat: add OAuth support\n- fix: resolve memory leak in parser\n- docs: update API documentation\n- chore: upgrade dependencies\n\nUse Keep a Changelog format with categories: Added, Changed, Fixed, Removed"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Write a professional changelog entry for version 2.1.0 based on these commits:\n\n- feat: add OAuth support\n- fix: resolve memory leak in parser\n- docs: update API documentation\n- chore: upgrade dependencies\n\nUse Keep a Changelog format with categories: Added, Changed, Fixed, Removed"
+  }]
+}'
 ```
 
 ### Step 4: Research Changelog Standards
 Find best practices:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "changelog best practices keepachangelog semantic versioning",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "changelog best practices keepachangelog semantic versioning",
+  "include_answer": true
+}'
 ```
 
 ### Step 5: Find Good Examples
 Learn from other projects:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "excellent open source project changelog examples CHANGELOG.md",
-    "num_results": 10
-  }'
+orth api run exa /search --body '{
+  "query": "excellent open source project changelog examples CHANGELOG.md",
+  "num_results": 10
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-code-reviewer/SKILL.md
+++ b/skills/orthogonal-code-reviewer/SKILL.md
@@ -56,7 +56,7 @@ Check for known vulnerabilities:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "What are the OWASP Top 10 vulnerabilities to check for in Python web applications?"
+  "task": "What are the OWASP Top 10 vulnerabilities to check for in Python web applications?"
 }'
 ```
 

--- a/skills/orthogonal-code-reviewer/SKILL.md
+++ b/skills/orthogonal-code-reviewer/SKILL.md
@@ -13,66 +13,51 @@ Review code for bugs, security issues, performance problems, and best practices.
 Get code from GitHub or other sources:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://raw.githubusercontent.com/user/repo/main/file.py"}'
+orth api run linkup /fetch --body '{"url": "https://raw.githubusercontent.com/user/repo/main/file.py"}'
 ```
 
 ### Step 2: Get AI Code Review
 Use Perplexity for comprehensive review:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Review this Python code for bugs, security issues, and improvements:\n\n```python\ndef process_user_input(data):\n    query = f\"SELECT * FROM users WHERE id = {data['id']}\"\n    return db.execute(query)\n```"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Review this Python code for bugs, security issues, and improvements:\n\n```python\ndef process_user_input(data):\n    query = f\"SELECT * FROM users WHERE id = {data['\''id'\'']}\"\n    return db.execute(query)\n```"
+  }]
+}'
 ```
 
 ### Step 3: Check for Best Practices
 Research language-specific best practices:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Python best practices security SQL injection prevention 2024",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "Python best practices security SQL injection prevention 2024",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 4: Find Similar Solutions
 Look for better implementations:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Python parameterized queries SQL best implementation example",
-    "num_results": 10,
-    "contents": {"text": true}
-  }'
+orth api run exa /search --body '{
+  "query": "Python parameterized queries SQL best implementation example",
+  "num_results": 10,
+  "contents": {"text": true}
+}'
 ```
 
 ### Step 5: Security Audit
 Check for known vulnerabilities:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "What are the OWASP Top 10 vulnerabilities to check for in Python web applications?"
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "What are the OWASP Top 10 vulnerabilities to check for in Python web applications?"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-company-intel/SKILL.md
+++ b/skills/orthogonal-company-intel/SKILL.md
@@ -13,88 +13,69 @@ Generate full intelligence reports on any company including overview, team, fund
 Get basic company information:
 
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ### Step 2: Deep Research
 Get comprehensive company analysis:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/research" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Stripe company complete analysis - history, products, revenue, funding, team, competitive position, recent news, future plans"
-  }'
+orth api run tavily /research --body '{
+  "query": "Stripe company complete analysis - history, products, revenue, funding, team, competitive position, recent news, future plans"
+}'
 ```
 
 ### Step 3: Find Leadership Team
 Get info on key executives:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/people-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "company_names": ["Stripe"],
-    "job_titles": ["CEO", "CTO", "CFO", "COO", "VP", "Head of"]
-  }'
+orth api run fiber /v1/people-search --body '{
+  "company_names": ["Stripe"],
+  "job_titles": ["CEO", "CTO", "CFO", "COO", "VP", "Head of"]
+}'
 ```
 
 ### Step 4: Funding History
 Research investment history:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "What is Stripe complete funding history? Include all rounds, amounts, valuations, and investors."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "What is Stripe complete funding history? Include all rounds, amounts, valuations, and investors."
+  }]
+}'
 ```
 
 ### Step 5: Product Analysis
 Analyze products and pricing:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://stripe.com/pricing",
-    "user_prompt": "Extract all products, pricing tiers, and features"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://stripe.com/pricing",
+  "user_prompt": "Extract all products, pricing tiers, and features"
+}'
 ```
 
 ### Step 6: Recent News
 Get latest company news:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Stripe news announcements updates 2024",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "Stripe news announcements updates 2024",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 7: Employee Count & Growth
 Track company growth:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/company-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "company_names": ["Stripe"]
-  }'
+orth api run fiber /v1/company-search --body '{
+  "company_names": ["Stripe"]
+}'
 ```
 
 ## Full Intelligence Report Pipeline

--- a/skills/orthogonal-company-intel/SKILL.md
+++ b/skills/orthogonal-company-intel/SKILL.md
@@ -21,7 +21,7 @@ Get comprehensive company analysis:
 
 ```bash
 orth api run tavily /research --body '{
-  "query": "Stripe company complete analysis - history, products, revenue, funding, team, competitive position, recent news, future plans"
+  "input": "Stripe company complete analysis - history, products, revenue, funding, team, competitive position, recent news, future plans"
 }'
 ```
 
@@ -30,8 +30,10 @@ Get info on key executives:
 
 ```bash
 orth api run fiber /v1/people-search --body '{
-  "company_names": ["Stripe"],
-  "job_titles": ["CEO", "CTO", "CFO", "COO", "VP", "Head of"]
+  "searchParams": {
+    "company_names": ["Stripe"],
+    "job_titles": ["CEO", "CTO", "CFO", "COO", "VP", "Head of"]
+  }
 }'
 ```
 
@@ -74,7 +76,9 @@ Track company growth:
 
 ```bash
 orth api run fiber /v1/company-search --body '{
-  "company_names": ["Stripe"]
+  "searchParams": {
+    "company_names": ["Stripe"]
+  }
 }'
 ```
 
@@ -89,10 +93,10 @@ COMPANY="Stripe"
 orth api run brand-dev /v1/brand/retrieve --query "domain=$DOMAIN"
 
 # 2. Deep research
-orth api run tavily /research --body "{\"query\": \"$COMPANY complete company analysis\"}"
+orth api run tavily /research --body "{\"input\": \"$COMPANY complete company analysis\"}"
 
 # 3. Leadership team
-orth api run fiber /v1/people-search --body "{\"company_names\": [\"$COMPANY\"], \"job_titles\": [\"CEO\", \"CTO\", \"CFO\"]}"
+orth api run fiber /v1/people-search --body "{\"searchParams\": {\"company_names\": [\"$COMPANY\"], \"job_titles\": [\"CEO\", \"CTO\", \"CFO\"]}}"
 
 # 4. Funding
 orth api run perplexity /chat/completions --body "{\"model\": \"sonar\", \"messages\": [{\"role\": \"user\", \"content\": \"$COMPANY funding history and investors\"}]}"

--- a/skills/orthogonal-competitor-research/SKILL.md
+++ b/skills/orthogonal-competitor-research/SKILL.md
@@ -13,73 +13,57 @@ Gather comprehensive intelligence on competitors including products, pricing, te
 Get basic company information:
 
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve?domain=competitor.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve --query 'domain=competitor.com'
 ```
 
 ### Step 2: Deep Research
 Use Tavily for comprehensive research:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/research" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Notion company analysis - products, pricing, funding, team size, recent news, competitive advantages"
-  }'
+orth api run tavily /research --body '{
+  "query": "Notion company analysis - products, pricing, funding, team size, recent news, competitive advantages"
+}'
 ```
 
 ### Step 3: Find Similar Companies
 Use Exa to find related competitors:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/findSimilar" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://notion.so",
-    "num_results": 10
-  }'
+orth api run exa /findSimilar --body '{
+  "url": "https://notion.so",
+  "num_results": 10
+}'
 ```
 
 ### Step 4: Get Product Details
 Scrape pricing and features:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://notion.so/pricing",
-    "user_prompt": "Extract all pricing tiers, features per tier, and any enterprise options"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://notion.so/pricing",
+  "user_prompt": "Extract all pricing tiers, features per tier, and any enterprise options"
+}'
 ```
 
 ### Step 5: Research Team
 Find key people at the company:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/people-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "company_names": ["Notion"],
-    "job_titles": ["CEO", "CTO", "VP Product", "VP Engineering"]
-  }'
+orth api run fiber /v1/people-search --body '{
+  "company_names": ["Notion"],
+  "job_titles": ["CEO", "CTO", "VP Product", "VP Engineering"]
+}'
 ```
 
 ### Step 6: Track News & Updates
 Search for recent news:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Notion news announcements updates 2024",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "Notion news announcements updates 2024",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-competitor-research/SKILL.md
+++ b/skills/orthogonal-competitor-research/SKILL.md
@@ -21,7 +21,7 @@ Use Tavily for comprehensive research:
 
 ```bash
 orth api run tavily /research --body '{
-  "query": "Notion company analysis - products, pricing, funding, team size, recent news, competitive advantages"
+  "input": "Notion company analysis - products, pricing, funding, team size, recent news, competitive advantages"
 }'
 ```
 
@@ -50,8 +50,10 @@ Find key people at the company:
 
 ```bash
 orth api run fiber /v1/people-search --body '{
-  "company_names": ["Notion"],
-  "job_titles": ["CEO", "CTO", "VP Product", "VP Engineering"]
+  "searchParams": {
+    "company_names": ["Notion"],
+    "job_titles": ["CEO", "CTO", "VP Product", "VP Engineering"]
+  }
 }'
 ```
 
@@ -71,7 +73,7 @@ orth api run tavily /search --body '{
 ```bash
 # Full competitor analysis
 orth api run tavily /research --body '{
-  "query": "Linear app complete analysis - product, pricing, investors, team, growth, market position vs Jira"
+  "input": "Linear app complete analysis - product, pricing, investors, team, growth, market position vs Jira"
 }'
 
 # Compare multiple competitors

--- a/skills/orthogonal-content-research/SKILL.md
+++ b/skills/orthogonal-content-research/SKILL.md
@@ -13,72 +13,57 @@ Research topics thoroughly for creating high-quality articles, blog posts, and s
 Get comprehensive information on your topic:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/research" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Complete guide to AI agents in 2024 - how they work, use cases, frameworks, best practices"
-  }'
+orth api run tavily /research --body '{
+  "query": "Complete guide to AI agents in 2024 - how they work, use cases, frameworks, best practices"
+}'
 ```
 
 ### Step 2: Find Related Content
 See what's already published:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "best articles about AI agents and autonomous systems",
-    "num_results": 20,
-    "contents": {"text": true}
-  }'
+orth api run exa /search --body '{
+  "query": "best articles about AI agents and autonomous systems",
+  "num_results": 20,
+  "contents": {"text": true}
+}'
 ```
 
 ### Step 3: Get Expert Opinions
 Find quotes and expert takes:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "What do AI researchers and industry experts say about the future of AI agents? Include specific quotes and sources."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "What do AI researchers and industry experts say about the future of AI agents? Include specific quotes and sources."
+  }]
+}'
 ```
 
 ### Step 4: Find Statistics
 Get data and stats to support your content:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "AI agents market size statistics growth projections 2024 2025",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "AI agents market size statistics growth projections 2024 2025",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 5: Generate Outline
 Get help structuring your content:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Create a detailed outline for a comprehensive blog post about AI agents. Include sections, key points, and suggested word counts."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Create a detailed outline for a comprehensive blog post about AI agents. Include sections, key points, and suggested word counts."
+  }]
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-content-research/SKILL.md
+++ b/skills/orthogonal-content-research/SKILL.md
@@ -14,7 +14,7 @@ Get comprehensive information on your topic:
 
 ```bash
 orth api run tavily /research --body '{
-  "query": "Complete guide to AI agents in 2024 - how they work, use cases, frameworks, best practices"
+  "input": "Complete guide to AI agents in 2024 - how they work, use cases, frameworks, best practices"
 }'
 ```
 

--- a/skills/orthogonal-date-night-planner/SKILL.md
+++ b/skills/orthogonal-date-night-planner/SKILL.md
@@ -38,7 +38,7 @@ Search for pre or post-dinner activities:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "What are unique date night activities in San Francisco this weekend? Comedy shows, jazz clubs, rooftop bars, or experiences."
+  "task": "What are unique date night activities in San Francisco this weekend? Comedy shows, jazz clubs, rooftop bars, or experiences."
 }'
 ```
 
@@ -56,7 +56,7 @@ orth api run tavily /search --body '{
 Check weather for outdoor activities:
 
 ```bash
-orth api run precip /api/v1/hourly --query lat=37.7749 lon=-122.4194 start=2024-02-14 end=2024-02-15
+orth api run precip /api/v1/hourly --query latitude=37.7749 longitude=-122.4194 start=2024-02-14 end=2024-02-15
 ```
 
 ## Example Usage
@@ -76,7 +76,7 @@ orth api run tavily /search --body '{
 
 # Outdoor date ideas
 orth api run olostep /v1/answers --body '{
-  "question": "Best sunset spots and romantic outdoor activities in San Diego"
+  "task": "Best sunset spots and romantic outdoor activities in San Diego"
 }'
 ```
 

--- a/skills/orthogonal-date-night-planner/SKILL.md
+++ b/skills/orthogonal-date-night-planner/SKILL.md
@@ -13,63 +13,50 @@ Plan complete date nights with restaurant reservations, activities, and entertai
 Search for romantic dining options:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "best romantic restaurants San Francisco intimate atmosphere good reviews reservations",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "best romantic restaurants San Francisco intimate atmosphere good reviews reservations",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Get Personalized Recommendations
 Use Perplexity for curated suggestions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Plan a special anniversary date night in San Francisco. Include a nice restaurant, pre-dinner activity, and after-dinner entertainment. Budget around $300."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Plan a special anniversary date night in San Francisco. Include a nice restaurant, pre-dinner activity, and after-dinner entertainment. Budget around $300."
+  }]
+}'
 ```
 
 ### Step 3: Find Activities
 Search for pre or post-dinner activities:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "What are unique date night activities in San Francisco this weekend? Comedy shows, jazz clubs, rooftop bars, or experiences."
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "What are unique date night activities in San Francisco this weekend? Comedy shows, jazz clubs, rooftop bars, or experiences."
+}'
 ```
 
 ### Step 4: Check Events
 Find special events or shows:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "live music events San Francisco this Saturday night jazz blues",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "live music events San Francisco this Saturday night jazz blues",
+  "include_answer": true
+}'
 ```
 
 ### Step 5: Get Weather
 Check weather for outdoor activities:
 
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/hourly?lat=37.7749&lon=-122.4194&start=2024-02-14&end=2024-02-15" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/hourly --query lat=37.7749 lon=-122.4194 start=2024-02-14 end=2024-02-15
 ```
 
 ## Example Usage

--- a/skills/orthogonal-deploy-checker/SKILL.md
+++ b/skills/orthogonal-deploy-checker/SKILL.md
@@ -13,54 +13,41 @@ Check deployment status by verifying endpoints, testing health checks, and valid
 Verify the health check endpoint:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://api.yourapp.com/health"}'
+orth api run linkup /fetch --body '{"url": "https://api.yourapp.com/health"}'
 ```
 
 ### Step 2: Validate Homepage
 Check if main page loads:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://yourapp.com",
-    "user_prompt": "Check if page loads correctly. Extract: page title, any error messages, main content presence"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://yourapp.com",
+  "user_prompt": "Check if page loads correctly. Extract: page title, any error messages, main content presence"
+}'
 ```
 
 ### Step 3: Test API Endpoints
 Verify critical API endpoints:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://api.yourapp.com/v1/status"}'
+orth api run linkup /fetch --body '{"url": "https://api.yourapp.com/v1/status"}'
 ```
 
 ### Step 4: Compare with Previous Version
 Check for breaking changes:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://yourapp.com/changelog",
-    "user_prompt": "Extract the latest release version and changes"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://yourapp.com/changelog",
+  "user_prompt": "Extract the latest release version and changes"
+}'
 ```
 
 ### Step 5: Capture Screenshot
 Get visual confirmation:
 
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/screenshot?domain=yourapp.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/screenshot --query 'domain=yourapp.com'
 ```
 
 ## Deployment Checklist

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -18,62 +18,31 @@ Verify user identities through phone/email OTP codes and screen against AML data
 
 ### Send Phone OTP ($0.30)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/didit/v3/phone/send/" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"phone_number": "+1234567890"}'
+orth api run didit /v3/phone/send/ --body '{"phone_number": "+1234567890"}'
 ```
 
 ### Verify Phone OTP (free)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/didit/v3/phone/check/" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"phone_number": "+1234567890", "code": "123456"}'
+orth api run didit /v3/phone/check/ --body '{"phone_number": "+1234567890", "code": "123456"}'
 ```
 
 ### Send Email OTP ($0.04)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/didit/v3/email/send/" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "user@example.com"}'
+orth api run didit /v3/email/send/ --body '{"email": "user@example.com"}'
 ```
 
 ### Verify Email OTP (free)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/didit/v3/email/check/" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "user@example.com", "code": "123456"}'
+orth api run didit /v3/email/check/ --body '{"email": "user@example.com", "code": "123456"}'
 ```
 
 ### Database Validation ($0.31)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/didit/v3/database-validation/" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"first_name": "John", "last_name": "Doe", "date_of_birth": "1990-01-15"}'
+orth api run didit /v3/database-validation/ --body '{"first_name": "John", "last_name": "Doe", "date_of_birth": "1990-01-15"}'
 ```
 
 ### AML Screening ($0.36)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/didit/v3/aml/" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "John Doe", "type": "individual"}'
-```
-
-## CLI Usage
-
-```bash
-# Send phone OTP
-orth api run didit /v3/phone/send/ --body '{"phone_number": "+1234567890"}'
-
-# Verify phone OTP
-orth api run didit /v3/phone/check/ --body '{"phone_number": "+1234567890", "code": "123456"}'
-
-# AML screening
 orth api run didit /v3/aml/ --body '{"name": "John Doe", "type": "individual"}'
 ```
 

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -18,32 +18,32 @@ Verify user identities through phone/email OTP codes and screen against AML data
 
 ### Send Phone OTP ($0.30)
 ```bash
-orth api run didit /v3/phone/send/ --body '{"phone_number": "+1234567890"}'
+orth api run didit /v3/phone/send --body '{"phone_number": "+1234567890"}'
 ```
 
 ### Verify Phone OTP (free)
 ```bash
-orth api run didit /v3/phone/check/ --body '{"phone_number": "+1234567890", "code": "123456"}'
+orth api run didit /v3/phone/check --body '{"phone_number": "+1234567890", "code": "123456"}'
 ```
 
 ### Send Email OTP ($0.04)
 ```bash
-orth api run didit /v3/email/send/ --body '{"email": "user@example.com"}'
+orth api run didit /v3/email/send --body '{"email": "user@example.com"}'
 ```
 
 ### Verify Email OTP (free)
 ```bash
-orth api run didit /v3/email/check/ --body '{"email": "user@example.com", "code": "123456"}'
+orth api run didit /v3/email/check --body '{"email": "user@example.com", "code": "123456"}'
 ```
 
 ### Database Validation ($0.31)
 ```bash
-orth api run didit /v3/database-validation/ --body '{"first_name": "John", "last_name": "Doe", "date_of_birth": "1990-01-15"}'
+orth api run didit /v3/database-validation --body '{"issuing_state": "ESP", "validation_type": "one_by_one", "identification_number": "12345678A"}'
 ```
 
 ### AML Screening ($0.36)
 ```bash
-orth api run didit /v3/aml/ --body '{"name": "John Doe", "type": "individual"}'
+orth api run didit /v3/aml --body '{"full_name": "John Doe", "entity_type": "person"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -9,41 +9,111 @@ Verify user identities through phone/email OTP codes and screen against AML data
 
 ## Capabilities
 
-- **Phone Verification**: Send and verify OTP codes via SMS
-- **Email Verification**: Send and verify OTP codes via email
-- **Database Validation**: Validate identity data against authoritative sources
-- **AML Screening**: Screen individuals/companies against global watchlists
+- **Send Email Code**: Send a one-time verification code to an email address ($0.04)
+- **Check Phone Code**: Verify a one-time code sent to a phone number (free)
+- **Send Phone Code**: Send a one-time verification code to a phone number ($0.30)
+- **AML Screening**: The AML Screening API allows you to screen individuals or companies against global watchlists and high-risk databases ($0.36)
+- **Check Email Code**: Verify a code sent to an email address (free)
+- **Database Validation API**: Validate user-provided identity data against authoritative national and global data sources ($0.31)
 
 ## Usage
 
-### Send Phone OTP ($0.30)
-```bash
-orth api run didit /v3/phone/send --body '{"phone_number": "+1234567890"}'
-```
+### Send Email Code ($0.04)
+Send a one-time verification code to an email address.
 
-### Verify Phone OTP (free)
-```bash
-orth api run didit /v3/phone/check --body '{"phone_number": "+1234567890", "code": "123456"}'
-```
+Parameters:
+- email* (string) - Email address to verify
+- options (object) - Options object with code_size (4-8, default 6) and locale (e.g. en-US)
+- signals (object) - Fraud detection signals: ip, device_id, user_agent
+- vendor_data (string) - Unique identifier for vendor/user (UUID or email) for session tracking
 
-### Send Email OTP ($0.04)
 ```bash
 orth api run didit /v3/email/send --body '{"email": "user@example.com"}'
 ```
 
-### Verify Email OTP (free)
+### Check Phone Code (free)
+Verify a one-time code sent to a phone number. Maximum of three verification attempts per code.
+
+Parameters:
+- phone_number* (string) - Phone number in E.164 format (e.g. +14155552671)
+- code* (string) - Verification code (4-8 characters)
+- duplicated_phone_number_action (string) - Action for duplicated numbers: NO_ACTION (default) or DECLINE
+- disposable_number_action (string) - Action for disposable numbers: NO_ACTION (default) or DECLINE
+- voip_number_action (string) - Action for VoIP numbers: NO_ACTION (default) or DECLINE
+
+```bash
+orth api run didit /v3/phone/check --body '{"phone_number": "+1234567890", "code": "123456"}'
+```
+
+### Send Phone Code ($0.30)
+Send a one-time verification code to a phone number.
+
+Parameters:
+- phone_number* (string) - Phone number in E.164 format (e.g. +14155552671)
+- options (object) - Options object with code_size (4-8, default 6), locale (e.g. en-US), preferred_channel (sms/whatsapp/telegram/voice, default whatsapp)
+- signals (object) - Fraud detection signals: ip, device_id, device_platform (android/ios/ipados/tvos/web), device_model, os_version, app_version, user_agent
+- vendor_data (string) - Unique identifier for vendor/user (UUID or email) for session tracking
+
+```bash
+orth api run didit /v3/phone/send --body '{"phone_number": "+1234567890"}'
+```
+
+### AML Screening ($0.36)
+The AML Screening API allows you to screen individuals or companies against global watchlists and high-risk databases. This API provides real-time screening capabilities to detect potential matches and mitigate risks associated with financial fraud and terrorism.
+
+Parameters:
+- full_name* (string) - Full name of the person or company to be screened.
+- entity_type (string) - Type of entity to screen. Either 'person' or 'company'. Defaults to 'person'.
+- date_of_birth (date) - Date of birth for persons or incorporation date for companies, with format: YYYY-MM-DD. For example, `1990-05-15`.
+- nationality (string) - Nationality of the person to be screened with format ISO 3166-1 alpha-2. For example: `ES`. Only applicable for person entity type.
+- document_number (string) - Document number of the person to be screened. Only applicable for person entity type.
+- aml_score_approve_threshold (number) - Score threshold below which hits are auto-approved (0-100). Hits with match scores below this threshold will be marked as approved. Default: 86.
+- aml_score_review_threshold (number) - Score threshold above which hits are auto-declined (0-100). Hits with match scores above this threshold will be declined. Scores between approve and review thresholds require manual review. Default: 100.
+- aml_name_weight (integer) - Weight for name similarity in match score calculation (0-100). The sum of aml_name_weight + aml_dob_weight + aml_country_weight must equal 100. Default: 60.
+- aml_dob_weight (integer) - Weight for date of birth in match score calculation (0-100). The sum of aml_name_weight + aml_dob_weight + aml_country_weight must equal 100. Default: 25.
+- aml_country_weight (integer) - Weight for country/nationality in match score calculation (0-100). The sum of aml_name_weight + aml_dob_weight + aml_country_weight must equal 100. Default: 15.
+- aml_match_score_threshold (integer) - Match score threshold (0-100) that determines if a hit is a False Positive or Unreviewed (Possible Match). Hits with match_score below this are marked as 'False Positive' and excluded from risk assessment. Hits at or above are 'Unreviewed' (Possible Match). Default: 93.
+- include_adverse_media (boolean) - Wheter to include adverse media in the screening. If included, the request will take approximately 10 seconds.
+- include_ongoing_monitoring (boolean) - Whether to include ongoing monitoring in the screening. If included, the save_api_request must be included as well, otherwise it will raise an error.
+- save_api_request (boolean) - Whether to save this API request. If true, then it will appear on the `Manual Checks` section in the Business Console.
+- vendor_data (string) - A unique identifier for the vendor or user, such as a UUID or email. This field enables proper session tracking and user data aggregation across multiple verification sessions.
+
+```bash
+orth api run didit /v3/aml --body '{"full_name": "John Doe"}'
+```
+
+### Check Email Code (free)
+Verify a code sent to an email address.
+
+Parameters:
+- email* (string) - Email address to verify
+- code* (string) - Verification code (4-8 characters)
+- duplicated_email_action (string) - Action for duplicated emails: NO_ACTION (default) or DECLINE
+- breached_email_action (string) - Action for breached emails: NO_ACTION (default) or DECLINE
+- disposable_email_action (string) - Action for disposable emails: NO_ACTION (default) or DECLINE
+- undeliverable_email_action (string) - Action for undeliverable emails: NO_ACTION (default) or DECLINE
+
 ```bash
 orth api run didit /v3/email/check --body '{"email": "user@example.com", "code": "123456"}'
 ```
 
-### Database Validation ($0.31)
+### Database Validation API ($0.31)
+Validate user-provided identity data against authoritative national and global data sources.
+
+Parameters:
+- issuing_state* (string) - ISO 3166-1 alpha-3 country code. Valid: ARG, BOL, BRA, CHL, COL, CRI, DOM, ECU, ESP, GTM, HND, MEX, PAN, PER, PRY, SLV, URY, VEN
+- validation_type* (string) - Validation type: one_by_one or two_by_two
+- identification_number* (string) - Universal ID field - auto-maps to country-specific format
+- document_type (string) - Document type: P (Passport), DL (Driver License), ID (National ID), RP (Residence Permit). Required for some countries.
+- expiration_date (string) - Document expiration date YYYY-MM-DD. Required for some countries (e.g. ESP).
+- first_name (string) - First name
+- last_name (string) - Last name
+- date_of_birth (string) - Date of birth YYYY-MM-DD
+- nationality (string) - ISO 3166-1 alpha-3 nationality code
+- address (string) - Residential address
+
 ```bash
 orth api run didit /v3/database-validation --body '{"issuing_state": "ESP", "validation_type": "one_by_one", "identification_number": "12345678A"}'
-```
-
-### AML Screening ($0.36)
-```bash
-orth api run didit /v3/aml --body '{"full_name": "John Doe", "entity_type": "person"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-docs-generator/SKILL.md
+++ b/skills/orthogonal-docs-generator/SKILL.md
@@ -13,64 +13,49 @@ Generate high-quality documentation from code, APIs, and specifications.
 Fetch and analyze code:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://raw.githubusercontent.com/user/repo/main/src/api.py"}'
+orth api run linkup /fetch --body '{"url": "https://raw.githubusercontent.com/user/repo/main/src/api.py"}'
 ```
 
 ### Step 2: Generate API Documentation
 Use AI to create comprehensive docs:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Generate comprehensive API documentation for this Python code. Include: function signatures, parameters, return types, examples, and error handling:\n\n[paste code]"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Generate comprehensive API documentation for this Python code. Include: function signatures, parameters, return types, examples, and error handling:\n\n[paste code]"
+  }]
+}'
 ```
 
 ### Step 3: Research Best Practices
 Find documentation standards:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "API documentation best practices examples OpenAPI Swagger 2024",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "API documentation best practices examples OpenAPI Swagger 2024",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 4: Find Similar Docs
 Learn from good documentation:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "excellent API documentation examples developer-friendly",
-    "num_results": 10,
-    "contents": {"text": true}
-  }'
+orth api run exa /search --body '{
+  "query": "excellent API documentation examples developer-friendly",
+  "num_results": 10,
+  "contents": {"text": true}
+}'
 ```
 
 ### Step 5: Convert Existing Docs
 Transform documentation format:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/markdownify" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"website_url": "https://docs.example.com/api"}'
+orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://docs.example.com/api"}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -21,75 +21,52 @@ Access data from Polymarket and Kalshi prediction markets.
 
 ### Search Polymarket Markets ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/polymarket/markets?search=election" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /polymarket/markets --query 'search=election'
 ```
 
 ### Search Kalshi Markets ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/kalshi/markets?search=fed%20rate" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /kalshi/markets --query 'search=fed%20rate'
 ```
 
 ### Get Market Price ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/polymarket/market-price/{token_id}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /polymarket/market-price/{token_id}
 ```
 
 ### Get Kalshi Price ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/kalshi/market-price/{market_ticker}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /kalshi/market-price/{market_ticker}
 ```
 
 ### Historical Candlesticks ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/polymarket/candlesticks/{condition_id}?interval=1h" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /polymarket/candlesticks/{condition_id} --query 'interval=1h'
 ```
 
 ### Order History ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/polymarket/orders?market={market_id}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /polymarket/orders --query 'market={market_id}'
 ```
 
 ### Wallet Positions ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/polymarket/positions/wallet/{wallet_address}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /polymarket/positions/wallet/{wallet_address}
 ```
 
 ### Wallet P&L ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/polymarket/wallet/pnl/{wallet_address}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /polymarket/wallet/pnl/{wallet_address}
 ```
 
 ### Sports Markets ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/matching-markets/sports" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run dome /matching-markets/sports
 ```
 
 ### Crypto Prices from Binance ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/dome/crypto-prices/binance?symbol=BTCUSDT" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Find election markets
-orth api run dome /polymarket/markets --query 'search=2024%20election'
-
-# Get market price history
-orth api run dome /polymarket/candlesticks/{condition_id} --query 'interval=1d'
-
-# Check wallet positions
-orth api run dome /polymarket/positions/wallet/{address}
+orth api run dome /crypto-prices/binance --query 'symbol=BTCUSDT'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -9,64 +9,252 @@ Access data from Polymarket and Kalshi prediction markets.
 
 ## Capabilities
 
-- **Market Search**: Find markets on Polymarket and Kalshi ($0.01)
-- **Price Data**: Current and historical prices ($0.01)
-- **Order Books**: Historical orderbook snapshots ($0.01)
-- **Trades**: Historical trade data ($0.01)
-- **Positions**: Wallet positions and P&L ($0.01)
-- **Crypto Prices**: Binance and Chainlink price feeds ($0.01)
-- **Sports Markets**: Cross-platform sports betting markets ($0.01)
+- **Orderbook History**: Fetches historical orderbook snapshots for a specific Kalshi market (ticker) over a specified time range ($0.01)
+- **Market Price**: Fetches the current market price for a market by token_id ($0.01)
+- **Market Price**: Fetches the current market price for a Kalshi market by market_ticker ($0.01)
+- **Trade History**: Fetches historical trade data for Kalshi markets with optional filtering by ticker and time range ($0.01)
+- **Sport by Date**: Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc ($0.01)
+- **Sports**: Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc ($0.01)
+- **Positions**: Fetches all Polymarket positions for a proxy wallet address ($0.01)
+- **Binance Prices**: Fetches historical crypto price data from Binance ($0.01)
+- **Activity**: Fetches activity data for a specific user with optional filtering by market, condition, and time range ($0.01)
+- **Markets**: Find markets on Polymarket using various filters including the ability to search ($0.01)
+- **Orderbook History**: Fetches historical orderbook snapshots for a specific asset (token ID) over a specified time range ($0.01)
+- **Wallet**: Fetches wallet information by providing either an EOA (Externally Owned Account) address or a proxy wallet address ($0.01)
+- **Candlesticks**: Fetches historical candlestick data for a market identified by condition_id, over a specified interval ($0.01)
+- **Chainlink Prices**: Fetches historical crypto price data from Chainlink ($0.01)
+- **Wallet Profit-and-Loss**: Fetches the realized profit and loss (PnL) for a specific wallet address over a specified time range and granularity ($0.01)
+- **Trade History**: Fetches historical trade data with optional filtering by market, condition, token, time range, and user’s wallet address ($0.01)
+- **Markets**: Find markets on Kalshi using various filters including market ticker, event ticker, status, and volume ($0.01)
 
 ## Usage
 
-### Search Polymarket Markets ($0.01)
+### Orderbook History ($0.01)
+Fetches historical orderbook snapshots for a specific Kalshi market (ticker) over a specified time range. If no start_time and end_time are provided, returns the latest orderbook snapshot for the market.
+
+Parameters:
+- ticker* (string) - The Kalshi market ticker
+- start_time (integer) - Start time in Unix timestamp (milliseconds). Optional - if not provided along with end_time, returns the latest orderbook snapshot.
+- end_time (integer) - End time in Unix timestamp (milliseconds). Optional - if not provided along with start_time, returns the latest orderbook snapshot.
+- limit (integer) - Maximum number of snapshots to return (default: 100, max: 200). Ignored when fetching the latest orderbook without start_time and end_time.
+
 ```bash
-orth api run dome /polymarket/markets --query 'search=election'
+orth api run dome /kalshi/orderbooks --query 'ticker={ticker}'
 ```
 
-### Search Kalshi Markets ($0.01)
-```bash
-orth api run dome /kalshi/markets --query 'search=fed%20rate'
-```
+### Market Price ($0.01)
+Fetches the current market price for a market by token_id. Allows historical lookups via the at_time query parameter.
 
-### Get Market Price ($0.01)
+Parameters:
+- at_time (integer) - Optional Unix timestamp (in seconds) to fetch a historical market price. If not provided, returns the most real-time price available.
+
 ```bash
 orth api run dome /polymarket/market-price/{token_id}
 ```
 
-### Get Kalshi Price ($0.01)
+### Market Price ($0.01)
+Fetches the current market price for a Kalshi market by market_ticker. Returns prices for both yes and no sides. Allows historical lookups via the at_time query parameter.
+
+Parameters:
+- at_time (integer) - Optional Unix timestamp (in seconds) to fetch a historical market price. If not provided, returns the most real-time price available.
+
 ```bash
 orth api run dome /kalshi/market-price/{market_ticker}
 ```
 
-### Historical Candlesticks ($0.01)
+### Trade History ($0.01)
+Fetches historical trade data for Kalshi markets with optional filtering by ticker and time range. Returns executed trades with pricing, volume, and taker side information. All timestamps are in seconds.
+
+Parameters:
+- ticker (string) - The Kalshi market ticker to filter trades
+- start_time (integer) - Start time in Unix timestamp (seconds)
+- end_time (integer) - End time in Unix timestamp (seconds)
+- limit (integer) - Maximum number of trades to return (default: 100)
+- offset (integer) - Number of trades to skip for pagination
+
 ```bash
-orth api run dome /polymarket/candlesticks/{condition_id} --query 'interval=1h'
+orth api run dome /kalshi/trades --query 'ticker={ticker}'
 ```
 
-### Order History ($0.01)
+### Sport by Date ($0.01)
+Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc.) for sports events by sport and date.
+
+Parameters:
+- date* (string) - The date to find matching markets for in YYYY-MM-DD format
+
 ```bash
-orth api run dome /polymarket/orders --query 'market={market_id}'
+orth api run dome /matching-markets/sports/nba --query 'date=2024-03-01'
 ```
 
-### Wallet Positions ($0.01)
-```bash
-orth api run dome /polymarket/positions/wallet/{wallet_address}
-```
+### Sports ($0.01)
+Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc.) for sports events using a Polymarket market slug or a Kalshi event ticker.
 
-### Wallet P&L ($0.01)
-```bash
-orth api run dome /polymarket/wallet/pnl/{wallet_address}
-```
+Parameters:
+- polymarket_market_slug (string[]) - The Polymarket market slug(s) to find matching markets for. To get multiple markets at once, provide the query param multiple times with different slugs. Can not be combined with kalshi_event_ticker.
+- kalshi_event_ticker (string[]) - The Kalshi event ticker(s) to find matching markets for. To get multiple markets at once, provide the query param multiple times with different tickers. Can not be combined with polymarket_market_slug.
 
-### Sports Markets ($0.01)
 ```bash
 orth api run dome /matching-markets/sports
 ```
 
-### Crypto Prices from Binance ($0.01)
+### Positions ($0.01)
+Fetches all Polymarket positions for a proxy wallet address. Returns positions with balance >= 10,000 shares (0.01 normalized) with market info.
+
+Parameters:
+- limit (integer) - Maximum number of positions to return per page. Defaults to 100, maximum 100.
+- pagination_key (string) - Pagination key returned from previous request to fetch next page of results
+
+```bash
+orth api run dome /polymarket/positions/wallet/{wallet_address}
+```
+
+### Binance Prices ($0.01)
+Fetches historical crypto price data from Binance. Returns price data for a specific currency pair over an optional time range. When no time range is provided, returns the most recent price. All timestamps are in Unix milliseconds.
+
+Parameters:
+- currency* (string) - The currency pair symbol. Must be lowercase alphanumeric with no separators (e.g., btcusdt, ethusdt, solusdt, xrpusdt).
+- start_time (integer) - Start time in Unix timestamp (milliseconds). If not provided along with end_time, returns the most recent price (limit 1).
+- end_time (integer) - End time in Unix timestamp (milliseconds). If not provided along with start_time, returns the most recent price (limit 1).
+- limit (integer) - Maximum number of prices to return (default: 100, max: 100). When no time range is provided, limit is automatically set to 1.
+- pagination_key (string) - Pagination key (base64-encoded) to fetch the next page of results. Returned in the response when more data is available.
+
 ```bash
 orth api run dome /crypto-prices/binance --query 'currency=btcusdt'
+```
+
+### Activity ($0.01)
+Fetches activity data for a specific user with optional filtering by market, condition, and time range. Returns trading activity including MERGES, SPLITS, and REDEEMS.
+
+Parameters:
+- user* (string) - User wallet address to fetch activity for
+- start_time (integer) - Filter activity from this Unix timestamp in seconds (inclusive)
+- end_time (integer) - Filter activity until this Unix timestamp in seconds (inclusive)
+- market_slug (string) - Filter activity by market slug
+- condition_id (string) - Filter activity by condition ID
+- limit (integer) - Number of activities to return (1-1000)
+- offset (integer) - Number of activities to skip for pagination
+
+```bash
+orth api run dome /polymarket/activity --query 'user={wallet_address}'
+```
+
+### Markets ($0.01)
+Find markets on Polymarket using various filters including the ability to search
+
+Parameters:
+- market_slug (string[]) - Filter markets by market slug(s). Can provide multiple values.
+- event_slug (string[]) - Filter markets by event slug(s). Can provide multiple values.
+- condition_id (string[]) - Filter markets by condition ID(s). Can provide multiple values.
+- tags (string[]) - Filter markets by tag(s). Can provide multiple values.
+- search (string) - Search markets by keywords in title and description. Must be URL encoded (e.g., 'bitcoin%20price' for 'bitcoin price').
+- status (enum<string>) - Filter markets by status (whether they're open or closed)
+- min_volume (number) - Filter markets with total trading volume greater than or equal to this amount (USD)
+- limit (integer) - Number of markets to return (1-100). Default: 10 for search, 10 for regular queries.
+- offset (integer) - Number of markets to skip for pagination
+- start_time (integer) - Filter markets from this Unix timestamp in seconds (inclusive)
+- end_time (integer) - Filter markets until this Unix timestamp in seconds (inclusive)
+
+```bash
+orth api run dome /polymarket/markets --query 'search=election' 'status=open'
+```
+
+### Orderbook History ($0.01)
+Fetches historical orderbook snapshots for a specific asset (token ID) over a specified time range. If no start_time and end_time are provided, returns the latest orderbook snapshot for the market.
+
+Parameters:
+- token_id* (string) - The token id (asset) for the Polymarket market
+- start_time (integer) - Start time in Unix timestamp (milliseconds). Optional - if not provided along with end_time, returns the latest orderbook snapshot.
+- end_time (integer) - End time in Unix timestamp (milliseconds). Optional - if not provided along with start_time, returns the latest orderbook snapshot.
+- limit (integer) - Maximum number of snapshots to return (default: 100, max: 200). Ignored when fetching the latest orderbook without start_time and end_time.
+- pagination_key (string) - Pagination key to get the next chunk of data. Ignored when fetching the latest orderbook without start_time and end_time.
+
+```bash
+orth api run dome /polymarket/orderbooks --query 'token_id={token_id}'
+```
+
+### Wallet ($0.01)
+Fetches wallet information by providing either an EOA (Externally Owned Account) address or a proxy wallet address. Returns the associated EOA, proxy, and wallet type. Optionally returns trading metrics including total volume, number of trades, and unique markets traded when with_metrics=true.
+
+Parameters:
+- eoa (string) - EOA (Externally Owned Account) wallet address. Either eoa or proxy must be provided, but not both.
+- proxy (string) - Proxy wallet address. Either eoa or proxy must be provided, but not both.
+- with_metrics (enum<string>) - Whether to include wallet trading metrics (total volume, trades, and markets). Pass true to include metrics. Metrics are computed only when explicitly requested for performance reasons.
+- start_time (integer) - Optional start date for metrics calculation (Unix timestamp in seconds). Only used when with_metrics=true.
+- end_time (integer) - Optional end date for metrics calculation (Unix timestamp in seconds). Only used when with_metrics=true.
+
+```bash
+orth api run dome /polymarket/wallet --query 'address={wallet_address}'
+```
+
+### Candlesticks ($0.01)
+Fetches historical candlestick data for a market identified by condition_id, over a specified interval.
+
+Parameters:
+- start_time* (integer) - Unix timestamp (in seconds) for start of time range
+- end_time* (integer) - Unix timestamp (in seconds) for end of time range
+- interval (enum<integer>) - Interval length: 1 = 1m, 60 = 1h, 1440 = 1d. Defaults to 1m. ⚠️ Note: There are range limits for interval — specifically: 1 (1m): max range 1 week 60 (1h): max range 1 month 1440 (1d): max range 1 year
+
+```bash
+orth api run dome /polymarket/candlesticks/{condition_id} --query 'interval=1h'
+```
+
+### Chainlink Prices ($0.01)
+Fetches historical crypto price data from Chainlink. Returns price data for a specific currency pair over an optional time range. When no time range is provided, returns the most recent price. All timestamps are in Unix milliseconds. Currency format: slash-separated (e.g., btc/usd, eth/usd).
+
+Parameters:
+- currency* (string) - The currency pair symbol. Must be slash-separated (e.g., btc/usd, eth/usd, sol/usd, xrp/usd).
+- start_time (integer) - Start time in Unix timestamp (milliseconds). If not provided along with end_time, returns the most recent price (limit 1).
+- end_time (integer) - End time in Unix timestamp (milliseconds). If not provided along with start_time, returns the most recent price (limit 1).
+- limit (integer) - Maximum number of prices to return (default: 100, max: 100). When no time range is provided, limit is automatically set to 1.
+- pagination_key (string) - Pagination key (base64-encoded) to fetch the next page of results. Returned in the response when more data is available.
+
+```bash
+orth api run dome /crypto-prices/chainlink --query 'currency=btc/usd'
+```
+
+### Wallet Profit-and-Loss ($0.01)
+Fetches the realized profit and loss (PnL) for a specific wallet address over a specified time range and granularity. Note: This will differ to what you see on Polymarket’s dashboard since Polymarket showcases historical unrealized PnL.
+
+Parameters:
+- granularity* (enum<string>) - Example: "day"
+- start_time (integer) - Defaults to first day of first trade if not provided.
+- end_time (integer) - Defaults to the current date if not provided.
+
+```bash
+orth api run dome /polymarket/wallet/pnl/{wallet_address}
+```
+
+### Trade History ($0.01)
+Fetches historical trade data with optional filtering by market, condition, token, time range, and user’s wallet address.
+
+Parameters:
+- market_slug (string) - Filter orders by market slug
+- condition_id (string) - Filter orders by condition ID
+- token_id (string) - Filter orders by token ID
+- start_time (integer) - Filter orders from this Unix timestamp in seconds (inclusive)
+- end_time (integer) - Filter orders until this Unix timestamp in seconds (inclusive)
+- limit (integer) - Number of orders to return (1-1000)
+- offset (integer) - Number of orders to skip for pagination
+- user (string) - Filter orders by user (wallet address)
+
+```bash
+orth api run dome /polymarket/orders --query 'market={market_id}'
+```
+
+### Markets ($0.01)
+Find markets on Kalshi using various filters including market ticker, event ticker, status, and volume
+
+Parameters:
+- market_ticker (string[]) - Filter markets by market ticker(s). Can provide multiple values.
+- event_ticker (string[]) - Filter markets by event ticker(s). Can provide multiple values.
+- search (string) - Search markets by keywords in title and description. Must be URL encoded (e.g., 'bitcoin%20price' for 'bitcoin price').
+- status (enum<string>) - Filter markets by status (whether they're open or closed)
+- min_volume (number) - Filter markets with total trading volume greater than or equal to this amount (in dollars)
+- limit (integer) - Number of markets to return (1-100). Default: 10.
+- offset (integer) - Number of markets to skip for pagination
+
+```bash
+orth api run dome /kalshi/markets --query 'search=fed%20rate'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -66,7 +66,7 @@ orth api run dome /matching-markets/sports
 
 ### Crypto Prices from Binance ($0.01)
 ```bash
-orth api run dome /crypto-prices/binance --query 'symbol=BTCUSDT'
+orth api run dome /crypto-prices/binance --query 'currency=btcusdt'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-email-campaign/SKILL.md
+++ b/skills/orthogonal-email-campaign/SKILL.md
@@ -42,9 +42,12 @@ Get info for personalized outreach:
 
 ```bash
 orth api run sixtyfour /enrich-lead --body '{
-  "first_name": "John",
-  "last_name": "Doe",
-  "company": "Stripe"
+  "lead_info": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "company": "Stripe"
+  },
+  "struct": {"email": "Work email", "phone": "Phone number"}
 }'
 ```
 
@@ -60,9 +63,11 @@ orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```bash
 # 1. Find target companies
 orth api run fiber /v1/company-search --body '{
-  "industries": ["SaaS"],
-  "employee_count_min": 50,
-  "employee_count_max": 500
+  "searchParams": {
+    "industries": ["SaaS"],
+    "employee_count_min": 50,
+    "employee_count_max": 500
+  }
 }'
 
 # 2. Get emails for each company
@@ -72,7 +77,7 @@ orth api run hunter /v2/domain-search --query 'domain=company.com'
 orth api run hunter /v2/email-verifier --query 'email=person@company.com'
 
 # 4. Enrich for personalization
-orth api run sixtyfour /enrich-lead --body '{"first_name": "John", "last_name": "Doe", "company": "Company"}'
+orth api run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John", "last_name": "Doe", "company": "Company"}, "struct": {"email": "Work email"}}'
 ```
 
 ## Tips

--- a/skills/orthogonal-email-campaign/SKILL.md
+++ b/skills/orthogonal-email-campaign/SKILL.md
@@ -13,56 +13,46 @@ Build targeted email campaigns with verified email addresses and personalized ou
 Get all emails for target companies:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/domain-search?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/domain-search --query 'domain=stripe.com'
 ```
 
 ### Step 2: Find Specific Person's Email
 Find email for specific contacts:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-finder?domain=stripe.com&first_name=John&last_name=Doe" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ### Step 3: Verify Emails
 Check deliverability before sending:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-verifier?email=john@stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/email-verifier --query 'email=john@stripe.com'
 ```
 
 ### Step 4: Batch Verification with Fiber
 Validate multiple emails:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/validate-email/single" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "john@stripe.com"}'
+orth api run fiber /v1/validate-email/single --body '{"email": "john@stripe.com"}'
 ```
 
 ### Step 5: Enrich for Personalization
 Get info for personalized outreach:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/enrich-lead" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "John",
-    "last_name": "Doe",
-    "company": "Stripe"
-  }'
+orth api run sixtyfour /enrich-lead --body '{
+  "first_name": "John",
+  "last_name": "Doe",
+  "company": "Stripe"
+}'
 ```
 
 ### Step 6: Get Company Context
 Research company for personalization:
 
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ## Campaign Building Pipeline

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -9,24 +9,100 @@ Neural search engine for finding similar content, extracting pages, and deep res
 
 ## Capabilities
 
-- **Search**: Neural search with content extraction ($0.01)
-- **Find Similar**: Find pages similar to a URL ($0.01)
-- **Contents**: Extract full page contents ($0.01)
-- **Answer**: LLM answers backed by search ($0.01)
+- **Exa Research**: Retrieve a paginated list of your research tasks ($0.01)
+- **Answer**: Get an LLM answer to a question informed by Exa search results ($0.01)
+- **Search**: The search endpoint lets you intelligently search the web and extract contents from the results ($0.01)
+- **Get a task**: Retrieve the status and results of a previously created research task ($0.01)
+- **Find similar links**: Find similar links to the link provided and optionally return the contents of the pages ($0.01)
+- **Create a task**: Create an asynchronous research task that explores the web, gathers sources, synthesizes findings, and returns results with citations ($0.01)
+- **Get contents**: Get the full page contents, summaries, and metadata for a list of URLs ($0.01)
+
 ## Usage
 
-### Neural Search ($0.01)
+### Exa Research ($0.01)
+Retrieve a paginated list of your research tasks. The response follows a cursor-based pagination pattern. Pass the `limit` parameter to control page size (max 50) and use the `cursor` token returned in the response to fetch subsequent pages.
+
+Parameters:
+- cursor (string) - The cursor to paginate through the results Minimum string length: `1`
+- limit (number) - Number of results per page (1-50) Required range: `1 <= x <= 50`
+
+```bash
+orth api run exa /research/v1
+```
+
+### Answer ($0.01)
+Get an LLM answer to a question informed by Exa search results. /answer performs an Exa search and uses an LLM to generate either:
+
+A direct answer for specific queries. (i.e.
+
+Parameters:
+- query* (string) - The question or query to answer.
+- stream (boolean) - If true, the response is returned as a server-sent events (SSS) stream.
+- text (boolean) - If true, the response includes full text content in the search results
+
+```bash
+orth api run exa /answer --body '{"query": "What are the best practices for prompt engineering?"}'
+```
+
+### Search ($0.01)
+The search endpoint lets you intelligently search the web and extract contents from the results.By default, it automatically chooses the best search method using Exa’s embeddings-based model and other techniques to find the most relevant results for your query.
+
+Parameters:
+- query* (string) - The query string for the search.
+- additionalQueries (string[]) - Additional query variations for deep search. Only works with type="deep". When provided, these queries are used alongside the main query for comprehensive results.
+- type (enum<string>) - The type of search. Neural uses an embeddings-based model, auto (default) intelligently combines neural and other search methods, fast uses streamlined versions of the search models, and deep provides comprehensive search with query expansion and detailed context.
+- category (enum<string>) - A data category to focus on. The people and company categories have improved quality for finding LinkedIn profiles and company pages. Note: The company and people categories only support a limited set of filters. The following parameters are NOT supported for these categories: startPublishedDate, endPublishedDate, startCrawlDate, endCrawlDate, includeText, excludeText, excludeDomains. For people category, includeDomains only accepts LinkedIn domains. Using unsupported parameters will result in a 400 error.
+- userLocation (string) - The two-letter ISO country code of the user, e.g. US.
+- numResults (integer) - Number of results to return. Limits vary by search type: With "neural": max 100 results With "deep": max 100 results If you want to increase the num results beyond these limits, contact sales (hello@exa.ai)
+- includeDomains (string[]) - List of domains to include in the search. If specified, results will only come from these domains.
+- excludeDomains (string[]) - List of domains to exclude from search results. If specified, no results will be returned from these domains.
+- startCrawlDate (string<date-time>) - Crawl date refers to the date that Exa discovered a link. Results will include links that were crawled after this date. Must be specified in ISO 8601 format.
+- endCrawlDate (string<date-time>) - Crawl date refers to the date that Exa discovered a link. Results will include links that were crawled before this date. Must be specified in ISO 8601 format.
+- startPublishedDate (string<date-time>) - Only links with a published date after this will be returned. Must be specified in ISO 8601 format.
+- endPublishedDate (string<date-time>) - Only links with a published date before this will be returned. Must be specified in ISO 8601 format.
+- includeText (string[]) - List of strings that must be present in webpage text of results. Currently, only 1 string is supported, of up to 5 words.
+- excludeText (string[]) - List of strings that must not be present in webpage text of results. Currently, only 1 string is supported, of up to 5 words. Checks from the first 1000 words of the webpage text.
+- context (string) - Return page contents as a context string for LLM. When true, combines all result contents into one string. We recommend using 10000+ characters for best results, though no limit works best. Context strings often perform better than highlights for RAG applications.
+- moderation (boolean) - Enable content moderation to filter unsafe content from search results.
+- contents (object)
+
 ```bash
 orth api run exa /search --body '{
   "query": "startups building AI coding assistants",
   "num_results": 10,
-  "contents": {
-    "text": true
-  }
+  "contents": {"text": true}
 }'
 ```
 
-### Find Similar Pages ($0.01)
+### Get a task ($0.01)
+Retrieve the status and results of a previously created research task.Use the unique researchId returned from POST /research/v1 to poll until the task is finished.
+
+Parameters:
+- stream (string) - Set to "true" to receive real-time updates via Server-Sent Events (SSE)
+- events (string) - Set to "true" to include the detailed event log of all operations performed
+
+```bash
+orth api run exa /research/v1/{researchId}
+```
+
+### Find similar links ($0.01)
+Find similar links to the link provided and optionally return the contents of the pages.
+
+Parameters:
+- url* (string) - The url for which you would like to find similar links.
+- numResults (integer) - Number of results to return. Limits vary by search type: With "neural": max 100 results With "deep": max 100 results If you want to increase the num results beyond these limits, contact sales (hello@exa.ai)
+- includeDomains (string[]) - List of domains to include in the search. If specified, results will only come from these domains.
+- excludeDomains (string[]) - List of domains to exclude from search results. If specified, no results will be returned from these domains.
+- startCrawlDate (string<date-time>) - Crawl date refers to the date that Exa discovered a link. Results will include links that were crawled after this date. Must be specified in ISO 8601 format.
+- endCrawlDate (string<date-time>) - Crawl date refers to the date that Exa discovered a link. Results will include links that were crawled before this date. Must be specified in ISO 8601 format.
+- startPublishedDate (string<date-time>) - Only links with a published date after this will be returned. Must be specified in ISO 8601 format.
+- endPublishedDate (string<date-time>) - Only links with a published date before this will be returned. Must be specified in ISO 8601 format.
+- includeText (string[]) - List of strings that must be present in webpage text of results. Currently, only 1 string is supported, of up to 5 words.
+- excludeText (string[]) - List of strings that must not be present in webpage text of results. Currently, only 1 string is supported, of up to 5 words. Checks from the first 1000 words of the webpage text.
+- context (string) - Return page contents as a context string for LLM. When true, combines all result contents into one string. We recommend using 10000+ characters for best results, though no limit works best. Context strings often perform better than highlights for RAG applications.
+- moderation (boolean) - Enable content moderation to filter unsafe content from search results.
+- contents (object)
+
 ```bash
 orth api run exa /findSimilar --body '{
   "url": "https://example.com/article",
@@ -34,18 +110,40 @@ orth api run exa /findSimilar --body '{
 }'
 ```
 
-### Get Page Contents ($0.01)
+### Create a task ($0.01)
+Create an asynchronous research task that explores the web, gathers sources, synthesizes findings, and returns results with citations.
+
+Parameters:
+- instructions* (string) - Instructions for what you would like research on. A good prompt clearly defines what information you want to find, how research should be conducted, and what the output should look like.
+- model (enum<string>) - Research model to use. exa-research is faster and cheaper, while exa-research-pro provides more thorough analysis and stronger reasoning.
+- outputSchema (object) - JSON Schema to enforce structured output. When provided, the research output will be validated against this schema and returned as parsed JSON.
+
+```bash
+orth api run exa /research/v1 --body '{"instructions": "Research the current state of AI coding assistants"}'
+```
+
+### Get contents ($0.01)
+Get the full page contents, summaries, and metadata for a list of URLs.Returns instant results from our cache, with automatic live crawling as fallback for uncached pages.
+
+Parameters:
+- urls* (string[]) - Array of URLs to crawl (backwards compatible with 'ids' parameter).
+- ids (string[]) - Deprecated - use 'urls' instead. Array of document IDs obtained from searches.
+- text (string) - If true, returns full page text with default settings. If false, disables text return.
+- highlights (object) - Text snippets the LLM identifies as most relevant from each page.
+- summary (object) - Summary of the webpage
+- livecrawl (enum<string>) - Options for livecrawling pages.'never': Disable livecrawling (default for neural search).'fallback': Livecrawl when cache is empty.'preferred': Always try to livecrawl, but fall back to cache if crawling fails.'always': Always live-crawl, never use cache. Only use if you cannot tolerate any cached content. This option is not recommended unless consulted with the Exa team.
+- livecrawlTimeout (integer) - The timeout for livecrawling in milliseconds.
+- subpages (integer) - The number of subpages to crawl. The actual number crawled may be limited by system constraints.
+- subpageTarget (string) - Term to find specific subpages of search results. Can be a single string or an array of strings, comma delimited.
+- extras (object) - Extra parameters to pass.
+- context (string) - Return page contents as a context string for LLM. When true, combines all result contents into one string. We recommend using 10000+ characters for best results, though no limit works best. Context strings often perform better than highlights for RAG applications.
+
 ```bash
 orth api run exa /contents --body '{
-  "ids": ["url1", "url2"],
+  "ids": ["https://example.com"],
   "text": true,
   "summary": true
 }'
-```
-
-### Get LLM Answer ($0.01)
-```bash
-orth api run exa /answer --body '{"query": "What are the best practices for prompt engineering?"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -13,8 +13,6 @@ Neural search engine for finding similar content, extracting pages, and deep res
 - **Find Similar**: Find pages similar to a URL ($0.01)
 - **Contents**: Extract full page contents ($0.01)
 - **Answer**: LLM answers backed by search ($0.01)
-- **Research**: Async deep research tasks ($0.01)
-
 ## Usage
 
 ### Neural Search ($0.01)
@@ -48,16 +46,6 @@ orth api run exa /contents --body '{
 ### Get LLM Answer ($0.01)
 ```bash
 orth api run exa /answer --body '{"query": "What are the best practices for prompt engineering?"}'
-```
-
-### Start Research Task ($0.01)
-```bash
-orth api run exa /research/v1 --body '{"query": "Comprehensive analysis of AI agent frameworks"}'
-```
-
-### Check Research Status ($0.01)
-```bash
-orth api run exa /research/v1/{researchId}
 ```
 
 ## Use Cases

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -19,74 +19,45 @@ Neural search engine for finding similar content, extracting pages, and deep res
 
 ### Neural Search ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "startups building AI coding assistants",
-    "num_results": 10,
-    "contents": {
-      "text": true
-    }
-  }'
+orth api run exa /search --body '{
+  "query": "startups building AI coding assistants",
+  "num_results": 10,
+  "contents": {
+    "text": true
+  }
+}'
 ```
 
 ### Find Similar Pages ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/findSimilar" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://example.com/article",
-    "num_results": 10
-  }'
+orth api run exa /findSimilar --body '{
+  "url": "https://example.com/article",
+  "num_results": 10
+}'
 ```
 
 ### Get Page Contents ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/contents" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "ids": ["url1", "url2"],
-    "text": true,
-    "summary": true
-  }'
+orth api run exa /contents --body '{
+  "ids": ["url1", "url2"],
+  "text": true,
+  "summary": true
+}'
 ```
 
 ### Get LLM Answer ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/answer" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "What are the best practices for prompt engineering?"}'
+orth api run exa /answer --body '{"query": "What are the best practices for prompt engineering?"}'
 ```
 
 ### Start Research Task ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/research/v1" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "Comprehensive analysis of AI agent frameworks"}'
+orth api run exa /research/v1 --body '{"query": "Comprehensive analysis of AI agent frameworks"}'
 ```
 
 ### Check Research Status ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/exa/research/v1/{researchId}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Neural search
-orth api run exa /search --body '{"query": "YC companies building developer tools", "num_results": 10}'
-
-# Find similar pages
-orth api run exa /findSimilar --body '{"url": "https://openai.com/blog/gpt-4", "num_results": 5}'
-
-# Get answer with sources
-orth api run exa /answer --body '{"query": "How does vector search work?"}'
+orth api run exa /research/v1/{researchId}
 ```
 
 ## Use Cases

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -9,27 +9,170 @@ Comprehensive search and enrichment for people, companies, investors, and jobs.
 
 ## Capabilities
 
-- **Natural Language Search**: Search people/companies using plain text ($0.54)
-- **People Search**: Find people with filters ($0.01)
-- **Company Search**: Find companies with filters ($0.01)
-- **Investor Search**: Find investors/VCs ($1.50)
-- **Job Search**: Search job postings ($0.50)
-- **Email Validation**: Check if emails bounce ($0.02)
-- **LinkedIn Live**: Fetch real-time LinkedIn data ($0.04)
+- **Search profiles from text**: Takes free-form text (e ($0.54)
+- **Search companies from text**: Takes free-form text (e ($0.54)
+- **Find person by email**: Do a reverse lookup: given an email address, find someone's LinkedIn profile and personal details ($0.04)
+- **Live fetch LinkedIn profile**: Returns an enriched profile with details for a given LinkedIn profile identifier ($0.04)
+- **Validate a single email**: Checks if a given email is likely to bounce using a waterfall of strategies ($0.02)
+- **Kitchen sink person lookup**: Search for a person using a variety of parameters such as LinkedIn slug, LinkedIn URL, or their current company information ($0.01)
+- **Kitchen sink company lookup**: Search for a company using a variety of parameters such as LinkedIn slug, LinkedIn URL, name, etc ($0.01)
+- **Investor search**: Search for investors with flexible filtering capabilities ($1.50)
+- **Fetch LinkedIn profile posts**: Fetches recent posts from a LinkedIn profile ($0.04)
+- **Live fetch LinkedIn company**: Returns an enriched company with details for a given LinkedIn company identifier ($0.04)
+- **People search**: Search for people using filters ($0.01)
+- **Fetch LinkedIn post comments**: Fetches paginated comments for a LinkedIn post ($0.04)
+- **Company search**: Search for companies using filters ($0.01)
+- **Convert text into company search filters**: Takes free-form text (e ($0.04)
+- **Convert text into profile search filters**: Takes free-form text (e ($0.04)
+- **Job postings search**: Search for job postings with flexible filtering capabilities ($0.50)
+- **Fetch LinkedIn post reactions**: Fetches paginated reactions of a specific type for a LinkedIn post ($0.04)
 
 ## Usage
 
-### Natural Language People Search ($0.54)
+### Search profiles from text ($0.54)
+Takes free-form text (e.g., 'Software engineers in US with 5+ years of experience') and returns a list of matching profiles.
+
+Parameters:
+- query* (string)
+- pageSize (integer) - The number of profiles to return, if you need to get more results, you can paginate.
+- getDetailedEducation (['boolean', 'null']) - Whether to include deep details about each educational item, like the school's LinkedIn URL, website, location, etc. That'll be put in the detailedEducation array. This slows down the API call, so only enable this if you need it.
+- getDetailedWorkExperience (['boolean', 'null']) - Whether to include deep details about each work experience item, like the company's LinkedIn URL, website, location, etc. That'll be put in the detailedWorkExperience array. This slows down the API call, so only enable this if you need it.
+- cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
+
 ```bash
 orth api run fiber /v1/natural-language-search/profiles --body '{"query": "Software engineers in San Francisco with 5+ years experience"}'
 ```
 
-### Natural Language Company Search ($0.54)
+### Search companies from text ($0.54)
+Takes free-form text (e.g., 'Series A startups in USA with 50–200 employees') and returns a list of matching companies.
+
+Parameters:
+- query* (string)
+- pageSize (integer) - The number of companies to return, if you need to get more results, you can paginate.
+- cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
+
 ```bash
 orth api run fiber /v1/natural-language-search/companies --body '{"query": "Series A startups in fintech with 50-200 employees"}'
 ```
 
-### People Search ($0.01)
+### Find person by email ($0.04)
+Do a reverse lookup: given an email address, find someone's LinkedIn profile and personal details. Note: if you also have the person's name, company, etc., you'll get better results with the Kitchen Sink endpoint, where you can pass all the information you have.
+
+Parameters:
+- email* (string) - The person's email address for which you want to do a reverse lookup
+- num_profiles (['number', 'null']) - Number of profiles to return. Maximum 10 profiles can be returned for given query. The returned profiles will be sorted by best match first.
+
+```bash
+orth api run fiber /v1/email-to-person/single --body '{"email": "john@company.com"}'
+```
+
+### Live fetch LinkedIn profile ($0.04)
+Returns an enriched profile with details for a given LinkedIn profile identifier
+
+Parameters:
+- identifier* (string) - Identifier can be a profile's LinkedIn slug (e.g. 'williamhgates' from <linkedin.com/in/williamhgates>), a Sales Navigator URN (e.g. 'ACwAAA.....'), or a full LinkedIn URL (e.g. 'https://www.linkedin.com/in/williamhgates/')
+- getDetailedEducation (['boolean', 'null']) - Whether to include deep details about each educational item, like the school's LinkedIn URL, website, location, etc. That'll be put in the detailedEducation array. This slows down the API call, so only enable this if you need it.
+- getDetailedWorkExperience (['boolean', 'null']) - Whether to include deep details about each work experience item, like the company's LinkedIn URL, website, location, etc. That'll be put in the detailedWorkExperience array. This slows down the API call, so only enable this if you need it.
+
+```bash
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
+```
+
+### Validate a single email ($0.02)
+Checks if a given email is likely to bounce using a waterfall of strategies. Works for catch-all email addresses, which are increasingly common yet hard for other APIs to validate.
+
+Parameters:
+- email* (string) - The email to validate
+
+```bash
+orth api run fiber /v1/validate-email/single --body '{"email": "john@example.com"}'
+```
+
+### Kitchen sink person lookup ($0.01)
+Search for a person using a variety of parameters such as LinkedIn slug, LinkedIn URL, or their current company information. Returns profile data for the person if found.
+
+Parameters:
+- profileIdentifier (string) - If provided and correct, we would always be able to find the profile. You do not need to pass in any other info if you pass this.
+- emailAddress (['string', 'null']) - The email address of the person to search for
+- personName (['object', 'null'])
+- jobTitle (['object', 'null'])
+- companyIdentifier (string) - The company the profile is currently working at. If provided the accuracy of the lookup increases. You do not need to pass in any other company parameters if you pass this.
+- companyName (['object', 'null'])
+- companyDomain (['object', 'null'])
+- numProfiles (integer) - The maximum number of profiles you want to fetch. Profiles are sorted by best match first.
+- liveFetch (['boolean', 'null']) - Whether to fetch the freshest copy of the found profiles's LinkedIn data (costs extra). If omitted or set to false, we'll give the cached data present in our database. The boolean flag is deprecated and will be removed in future. Please use the object instead.
+- forceCompanyMatch (['boolean', 'null']) - Whether to strictly match the company. If true, we will strictly lookup prospects which belong to given company details.
+- fuzzySearch (['boolean', 'null']) - Whether to use fuzzy search on names, job titles and other parameters. This is good if you are not sure about the exact name or job title.
+- getDetailedEducation (['boolean', 'null']) - Whether to include deep details about each educational item, like the school's LinkedIn URL, website, location, etc. That'll be put in the detailedEducation array. This slows down the API call, so only enable this if you need it.
+- getDetailedWorkExperience (['boolean', 'null']) - Whether to include deep details about each work experience item, like the company's LinkedIn URL, website, location, etc. That'll be put in the detailedWorkExperience array. This slows down the API call, so only enable this if you need it.
+
+```bash
+orth api run fiber /v1/kitchen-sink/person --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
+```
+
+### Kitchen sink company lookup ($0.01)
+Search for a company using a variety of parameters such as LinkedIn slug, LinkedIn URL, name, etc. Returns complete company data if found.
+
+Parameters:
+- companyIdentifier (string) - A unique identifier for the company. Accepts one of: linkedinSlug, linkedinUrl, or linkedinOrgID. Providing this increases the accuracy and speed of the lookup. If this is provided, you do not need to supply companyName or companyDomain.
+- companyName (['object', 'null'])
+- companyDomain (['object', 'null'])
+- numCompanies (integer) - The number of companies you want to fetch. Companies are sorted by best match first.
+
+```bash
+orth api run fiber /v1/kitchen-sink/company --body '{"domain": "openai.com"}'
+```
+
+### Investor search ($1.50)
+Search for investors with flexible filtering capabilities
+
+Parameters:
+- searchParams* (object) - Investor search filter parameters
+- pageSize (integer) - Number of investors to return per page (max 1000)
+- cursor (['string', 'null']) - Pagination cursor returned from a previous search response. Use this to fetch the next page of results. Null for the first page.
+
+```bash
+orth api run fiber /v1/investor-search --body '{
+  "searchParams": {
+    "investment_stages": ["Seed", "Series A"],
+    "industries": ["AI", "SaaS"]
+  }
+}'
+```
+
+### Fetch LinkedIn profile posts ($0.04)
+Fetches recent posts from a LinkedIn profile. Returns a paginated feed of posts with optional cursor for pagination. Each page returns up to 50 posts.
+
+Parameters:
+- identifier* (string) - Identifier can be a profile's LinkedIn slug (e.g. 'williamhgates' from <linkedin.com/in/williamhgates>), a Sales Navigator URN (e.g. 'ACwAAA.....'), or a full LinkedIn URL (e.g. 'https://www.linkedin.com/in/williamhgates/')
+- cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
+
+```bash
+orth api run fiber /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "https://linkedin.com/in/johndoe"}'
+```
+
+### Live fetch LinkedIn company ($0.04)
+Returns an enriched company with details for a given LinkedIn company identifier
+
+Parameters:
+- type* (string)
+- value* (string) - The company's LinkedIn slug (e.g., 'microsoft'), LinkedIn URL (e.g., 'https://www.linkedin.com/company/microsoft' or 'https://www.linkedin.com/company/1441'), LinkedIn organization ID (e.g., '1441' for Google), or Fiber company ID (e.g., 'comp_1441')
+
+```bash
+orth api run fiber /v1/linkedin-live-fetch/company/single --body '{"identifier": "https://linkedin.com/company/openai"}'
+```
+
+### People search ($0.01)
+Search for people using filters
+
+Parameters:
+- searchParams (object) - Search parameters for people search.
+- pageSize (integer) - The number of profiles to return, if you need to get more results, you can paginate.
+- cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
+- currentCompanies (['array', 'null']) - Filter people by the companies they are currently working for. If you want to search over many companies, we suggest using the Combined Search API, which is optimized for this use case.
+- prospectExclusionListIDs (['array', 'null']) - Filter out people which belong to the given prospect exclusion lists
+- companyExclusionListIDs (['array', 'null']) - Filter out people who work at companies which belong to the given company exclusion lists
+
 ```bash
 orth api run fiber /v1/people-search --body '{
   "searchParams": {
@@ -39,7 +182,26 @@ orth api run fiber /v1/people-search --body '{
 }'
 ```
 
-### Company Search ($0.01)
+### Fetch LinkedIn post comments ($0.04)
+Fetches paginated comments for a LinkedIn post. Each page contains up to 10 comments.
+
+Parameters:
+- contentId* (string) - You can get LinkedIn posts from the Profile or Company Posts endpoints. (e.g., 'urn:li:activity:7123456789012345678' or 'urn:li:ugcPost:7391650829398675456')
+- cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
+
+```bash
+orth api run fiber /v1/linkedin-live-fetch/post-comments --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
+```
+
+### Company search ($0.01)
+Search for companies using filters
+
+Parameters:
+- searchParams* (object) - Search parameters for company search API.
+- pageSize (integer) - The number of companies to return, if you need to get more results, you can paginate.
+- cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
+- companyExclusionListIDs (['array', 'null']) - Filter out companies which belong to the given company exclusion lists. You can create company exclusion lists via /v1/exclusions/companies/create-list
+
 ```bash
 orth api run fiber /v1/company-search --body '{
   "searchParams": {
@@ -50,17 +212,34 @@ orth api run fiber /v1/company-search --body '{
 }'
 ```
 
-### Investor Search ($1.50)
+### Convert text into company search filters ($0.04)
+Takes free-form text (e.g., 'Series A startups in USA with 50–200 employees') and converts it into a structured set of filters for company search.
+
+Parameters:
+- query* (string)
+
 ```bash
-orth api run fiber /v1/investor-search --body '{
-  "searchParams": {
-    "investment_stages": ["Seed", "Series A"],
-    "industries": ["AI", "SaaS"]
-  }
-}'
+orth api run fiber /v1/text-to-search-params/companies --body '{"query": "AI startups in healthcare"}'
 ```
 
-### Job Search ($0.50)
+### Convert text into profile search filters ($0.04)
+Takes free-form text (e.g., 'Software engineers in US with 5+ years of experience') and converts it into a structured set of filters for profile search.
+
+Parameters:
+- query* (string)
+
+```bash
+orth api run fiber /v1/text-to-search-params/profiles --body '{"query": "Senior engineers at FAANG companies"}'
+```
+
+### Job postings search ($0.50)
+Search for job postings with flexible filtering capabilities
+
+Parameters:
+- searchParams* (object) - Job search filter parameters
+- pageSize (integer) - Number of jobs to return per page (max 1000)
+- cursor (['string', 'null']) - Pagination cursor for fetching next page of results
+
 ```bash
 orth api run fiber /v1/job-search --body '{
   "searchParams": {
@@ -70,19 +249,16 @@ orth api run fiber /v1/job-search --body '{
 }'
 ```
 
-### Email Validation ($0.02)
-```bash
-orth api run fiber /v1/validate-email/single --body '{"email": "john@example.com"}'
-```
+### Fetch LinkedIn post reactions ($0.04)
+Fetches paginated reactions of a specific type for a LinkedIn post. Each page contains up to 10 reactions.
 
-### LinkedIn Profile Fetch ($0.04)
-```bash
-orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
-```
+Parameters:
+- contentId* (string) - You can get LinkedIn posts from the Profile or Company Posts endpoints. (e.g., 'urn:li:activity:7123456789012345678' or 'urn:li:ugcPost:7391650829398675456')
+- reactionType (['string', 'null']) - Type of reaction to fetch. If null, all reactions will be fetched.
+- cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
 
-### Reverse Email Lookup ($0.04)
 ```bash
-orth api run fiber /v1/email-to-person/single --body '{"email": "john@company.com"}'
+orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -21,100 +21,60 @@ Comprehensive search and enrichment for people, companies, investors, and jobs.
 
 ### Natural Language People Search ($0.54)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/natural-language-search/profiles" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "Software engineers in San Francisco with 5+ years experience"}'
+orth api run fiber /v1/natural-language-search/profiles --body '{"query": "Software engineers in San Francisco with 5+ years experience"}'
 ```
 
 ### Natural Language Company Search ($0.54)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/natural-language-search/companies" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "Series A startups in fintech with 50-200 employees"}'
+orth api run fiber /v1/natural-language-search/companies --body '{"query": "Series A startups in fintech with 50-200 employees"}'
 ```
 
 ### People Search ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/people-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "job_titles": ["CTO", "VP Engineering"],
-    "locations": ["San Francisco", "New York"]
-  }'
+orth api run fiber /v1/people-search --body '{
+  "job_titles": ["CTO", "VP Engineering"],
+  "locations": ["San Francisco", "New York"]
+}'
 ```
 
 ### Company Search ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/company-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "industries": ["Software", "AI"],
-    "employee_count_min": 50,
-    "employee_count_max": 500
-  }'
+orth api run fiber /v1/company-search --body '{
+  "industries": ["Software", "AI"],
+  "employee_count_min": 50,
+  "employee_count_max": 500
+}'
 ```
 
 ### Investor Search ($1.50)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/investor-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "investment_stages": ["Seed", "Series A"],
-    "industries": ["AI", "SaaS"]
-  }'
+orth api run fiber /v1/investor-search --body '{
+  "investment_stages": ["Seed", "Series A"],
+  "industries": ["AI", "SaaS"]
+}'
 ```
 
 ### Job Search ($0.50)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/job-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "job_titles": ["Software Engineer"],
-    "locations": ["Remote"]
-  }'
+orth api run fiber /v1/job-search --body '{
+  "job_titles": ["Software Engineer"],
+  "locations": ["Remote"]
+}'
 ```
 
 ### Email Validation ($0.02)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/validate-email/single" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "john@example.com"}'
+orth api run fiber /v1/validate-email/single --body '{"email": "john@example.com"}'
 ```
 
 ### LinkedIn Profile Fetch ($0.04)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/linkedin-live-fetch/profile/single" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
 ```
 
 ### Reverse Email Lookup ($0.04)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/email-to-person/single" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "john@company.com"}'
-```
-
-## CLI Usage
-
-```bash
-# Find engineers using natural language
-orth api run fiber /v1/natural-language-search/profiles --body '{"query": "AI researchers at Google"}'
-
-# Search for investors
-orth api run fiber /v1/investor-search --body '{"investment_stages": ["Series A"]}'
-
-# Validate an email
-orth api run fiber /v1/validate-email/single --body '{"email": "test@company.com"}'
+orth api run fiber /v1/email-to-person/single --body '{"email": "john@company.com"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -32,33 +32,41 @@ orth api run fiber /v1/natural-language-search/companies --body '{"query": "Seri
 ### People Search ($0.01)
 ```bash
 orth api run fiber /v1/people-search --body '{
-  "job_titles": ["CTO", "VP Engineering"],
-  "locations": ["San Francisco", "New York"]
+  "searchParams": {
+    "job_titles": ["CTO", "VP Engineering"],
+    "locations": ["San Francisco", "New York"]
+  }
 }'
 ```
 
 ### Company Search ($0.01)
 ```bash
 orth api run fiber /v1/company-search --body '{
-  "industries": ["Software", "AI"],
-  "employee_count_min": 50,
-  "employee_count_max": 500
+  "searchParams": {
+    "industries": ["Software", "AI"],
+    "employee_count_min": 50,
+    "employee_count_max": 500
+  }
 }'
 ```
 
 ### Investor Search ($1.50)
 ```bash
 orth api run fiber /v1/investor-search --body '{
-  "investment_stages": ["Seed", "Series A"],
-  "industries": ["AI", "SaaS"]
+  "searchParams": {
+    "investment_stages": ["Seed", "Series A"],
+    "industries": ["AI", "SaaS"]
+  }
 }'
 ```
 
 ### Job Search ($0.50)
 ```bash
 orth api run fiber /v1/job-search --body '{
-  "job_titles": ["Software Engineer"],
-  "locations": ["Remote"]
+  "searchParams": {
+    "job_titles": ["Software Engineer"],
+    "locations": ["Remote"]
+  }
 }'
 ```
 
@@ -69,7 +77,7 @@ orth api run fiber /v1/validate-email/single --body '{"email": "john@example.com
 
 ### LinkedIn Profile Fetch ($0.04)
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
 ### Reverse Email Lookup ($0.04)

--- a/skills/orthogonal-flight-search/SKILL.md
+++ b/skills/orthogonal-flight-search/SKILL.md
@@ -13,39 +13,30 @@ Search for flights and compare prices across airlines using Orthogonal APIs.
 Use Tavily or Andi to search for flight options:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "flights from SFO to NYC December 15 2024 round trip prices",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "flights from SFO to NYC December 15 2024 round trip prices",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Get Detailed Pricing
 Use Olostep AI answers for comprehensive flight info:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "What are the cheapest flights from San Francisco to New York on December 15, 2024? Include airline names and prices."
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "What are the cheapest flights from San Francisco to New York on December 15, 2024? Include airline names and prices."
+}'
 ```
 
 ### Step 3: Extract from Travel Sites
 Use ScrapeGraph to extract structured flight data:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://www.google.com/travel/flights",
-    "user_prompt": "Extract flight options with prices, airlines, departure times, and durations"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.google.com/travel/flights",
+  "user_prompt": "Extract flight options with prices, airlines, departure times, and durations"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-flight-search/SKILL.md
+++ b/skills/orthogonal-flight-search/SKILL.md
@@ -25,7 +25,7 @@ Use Olostep AI answers for comprehensive flight info:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "What are the cheapest flights from San Francisco to New York on December 15, 2024? Include airline names and prices."
+  "task": "What are the cheapest flights from San Francisco to New York on December 15, 2024? Include airline names and prices."
 }'
 ```
 
@@ -50,7 +50,7 @@ orth api run tavily /search --body '{
 
 # Get AI-powered flight comparison
 orth api run olostep /v1/answers --body '{
-  "question": "Compare Delta, United, and American flights from Chicago to Miami on Feb 1, 2025"
+  "task": "Compare Delta, United, and American flights from Chicago to Miami on Feb 1, 2025"
 }'
 ```
 

--- a/skills/orthogonal-gift-finder/SKILL.md
+++ b/skills/orthogonal-gift-finder/SKILL.md
@@ -69,7 +69,7 @@ orth api run tavily /search --body '{
 
 # Experience gifts
 orth api run olostep /v1/answers --body '{
-  "question": "Best experience gift ideas in San Francisco - cooking classes, spa, adventures"
+  "task": "Best experience gift ideas in San Francisco - cooking classes, spa, adventures"
 }'
 ```
 

--- a/skills/orthogonal-gift-finder/SKILL.md
+++ b/skills/orthogonal-gift-finder/SKILL.md
@@ -13,55 +13,43 @@ Find thoughtful gift ideas based on the recipient, occasion, and your budget.
 Search for gift suggestions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "best birthday gift ideas for 30 year old man who likes technology under $100",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "best birthday gift ideas for 30 year old man who likes technology under $100",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Get Personalized Recommendations
 Use Perplexity for tailored suggestions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Suggest 10 unique gift ideas for my mom who loves gardening and cooking. Budget $50-150. Include where to buy."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Suggest 10 unique gift ideas for my mom who loves gardening and cooking. Budget $50-150. Include where to buy."
+  }]
+}'
 ```
 
 ### Step 3: Compare Products
 Search for specific products and prices:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/searchscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_prompt": "Find the best wireless earbuds under $100 with good reviews and compare prices across Amazon, Best Buy"
-  }'
+orth api run scrapegraph /v1/searchscraper --body '{
+  "user_prompt": "Find the best wireless earbuds under $100 with good reviews and compare prices across Amazon, Best Buy"
+}'
 ```
 
 ### Step 4: Get Product Details
 Extract detailed product information:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://www.amazon.com/dp/B08XYZ",
-    "user_prompt": "Extract product name, price, features, ratings, and top reviews"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.amazon.com/dp/B08XYZ",
+  "user_prompt": "Extract product name, price, features, ratings, and top reviews"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-hotel-finder/SKILL.md
+++ b/skills/orthogonal-hotel-finder/SKILL.md
@@ -13,43 +13,34 @@ Find hotels matching your criteria using web search and AI extraction.
 Use Tavily to search for hotel options:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "best hotels in Tokyo Shibuya under $200 per night December 2024",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "best hotels in Tokyo Shibuya under $200 per night December 2024",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Get AI Recommendations
 Use Perplexity for personalized recommendations:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Recommend 5 boutique hotels in Paris near the Eiffel Tower with good reviews and breakfast included. Include prices."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Recommend 5 boutique hotels in Paris near the Eiffel Tower with good reviews and breakfast included. Include prices."
+  }]
+}'
 ```
 
 ### Step 3: Extract Hotel Details
 Use ScrapeGraph to get structured hotel data:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://www.booking.com/searchresults.html?dest=Tokyo",
-    "user_prompt": "Extract hotel names, prices, ratings, and key amenities"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.booking.com/searchresults.html?dest=Tokyo",
+  "user_prompt": "Extract hotel names, prices, ratings, and key amenities"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-hotel-finder/SKILL.md
+++ b/skills/orthogonal-hotel-finder/SKILL.md
@@ -54,7 +54,7 @@ orth api run tavily /search --body '{
 
 # Get local recommendations
 orth api run olostep /v1/answers --body '{
-  "question": "What are the best family-friendly hotels near Disneyland with shuttle service?"
+  "task": "What are the best family-friendly hotels near Disneyland with shuttle service?"
 }'
 ```
 

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -12,9 +12,7 @@ Find email addresses, verify deliverability, and discover companies.
 - **Domain Search**: Find all emails for a domain ($0.01)
 - **Email Finder**: Find email for a person at company ($0.01)
 - **Email Verifier**: Check if email is deliverable ($0.01)
-- **Person Lookup**: Get person info from email ($0.01)
 - **Company Lookup**: Get company info from domain ($0.01)
-- **Combined Lookup**: Get person + company from email ($0.01)
 - **Company Discovery**: Find companies matching criteria ($0.01)
 
 ## Usage
@@ -34,19 +32,9 @@ orth api run hunter /v2/email-finder --query domain=openai.com first_name=Sam la
 orth api run hunter /v2/email-verifier --query 'email=john@example.com'
 ```
 
-### Person Lookup ($0.01)
-```bash
-orth api run hunter /v2/people/find --query 'email=john@company.com'
-```
-
 ### Company Lookup ($0.01)
 ```bash
 orth api run hunter /v2/companies/find --query 'domain=anthropic.com'
-```
-
-### Combined Lookup ($0.01)
-```bash
-orth api run hunter /v2/combined/find --query 'email=jane@company.com'
 ```
 
 ### Discover Companies ($0.01)

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -9,54 +9,113 @@ Find email addresses, verify deliverability, and discover companies.
 
 ## Capabilities
 
-- **Domain Search**: Find all emails for a domain ($0.01)
-- **Email Finder**: Find email for a person at company ($0.01)
-- **Email Verifier**: Check if email is deliverable ($0.01)
-- **Person Lookup**: Get person info from email ($0.01)
-- **Company Lookup**: Get company info from domain ($0.01)
-- **Combined Lookup**: Get person + company from email ($0.01)
-- **Company Discovery**: Find companies matching criteria ($0.01)
+- **Combined Enrichment**: Get both person AND company information from an email address in a single request ($0.01)
+- **Email Enrichment**: Get detailed person information from an email address - name, location, employment, social profiles ($0.01)
+- **Email Count**: Get count of email addresses we have for a domain, broken down by department and seniority ($0.01)
+- **Discover Companies**: Find companies matching criteria using filters or natural language ($0.01)
+- **Company Enrichment**: Get detailed company information from a domain - industry, description, location, size, tech stack, funding ($0.01)
+- **Domain Search**: Find all email addresses for a domain ($0.01)
+- **Email Finder**: Find the most likely email address for a person given their name and company domain ($0.01)
+- **Email Verifier**: Verify if an email address is deliverable ($0.01)
 
 ## Usage
 
-### Domain Search ($0.01)
-```bash
-orth api run hunter /v2/domain-search --query 'domain=stripe.com'
-```
+### Combined Enrichment ($0.01)
+Get both person AND company information from an email address in a single request.
 
-### Find Email ($0.01)
-```bash
-orth api run hunter /v2/email-finder --query domain=openai.com first_name=Sam last_name=Altman
-```
+Parameters:
+- email* (string) - Email address to enrich
 
-### Verify Email ($0.01)
-```bash
-orth api run hunter /v2/email-verifier --query 'email=john@example.com'
-```
-
-### Person Lookup ($0.01)
-```bash
-orth api run hunter /v2/people/find --query 'email=john@company.com'
-```
-
-### Company Lookup ($0.01)
-```bash
-orth api run hunter /v2/companies/find --query 'domain=anthropic.com'
-```
-
-### Combined Lookup ($0.01)
 ```bash
 orth api run hunter /v2/combined/find --query 'email=jane@company.com'
 ```
 
+### Email Enrichment ($0.01)
+Get detailed person information from an email address - name, location, employment, social profiles.
+
+Parameters:
+- email (string) - Email address to enrich
+- linkedin_handle (string) - LinkedIn handle to enrich
+
+```bash
+orth api run hunter /v2/people/find --query 'email=john@company.com'
+```
+
+### Email Count ($0.01)
+Get count of email addresses we have for a domain, broken down by department and seniority. FREE endpoint.
+
+Parameters:
+- domain (string) - Domain to count emails for
+- company (string) - Company name (domain preferred)
+- type (string) - Filter: personal or generic
+
+```bash
+orth api run hunter /v2/email-count --query 'domain=google.com'
+```
+
 ### Discover Companies ($0.01)
+Find companies matching criteria using filters or natural language. Returns up to 100 companies per request. FREE endpoint.
+
+Parameters:
+- query (string) - Natural language search (e.g. Companies in Europe in Tech)
+- headquarters_location (object) - Filter by HQ location
+- industry (object) - Filter by industry
+- headcount (array) - Filter by employee count ranges
+- limit (integer) - Max results (default 100)
+- offset (integer) - Skip N results for pagination
+
 ```bash
 orth api run hunter /v2/discover --body '{"query": "AI startups in San Francisco"}'
 ```
 
-### Email Count ($0.01)
+### Company Enrichment ($0.01)
+Get detailed company information from a domain - industry, description, location, size, tech stack, funding.
+
+Parameters:
+- domain* (string) - Company domain to enrich (e.g. hunter.io)
+
 ```bash
-orth api run hunter /v2/email-count --query 'domain=google.com'
+orth api run hunter /v2/companies/find --query 'domain=anthropic.com'
+```
+
+### Domain Search ($0.01)
+Find all email addresses for a domain. Returns emails with sources, confidence scores, and verification status.
+
+Parameters:
+- domain* (string) - Domain to search (e.g. stripe.com)
+- limit (integer) - Max emails to return (default 10)
+- offset (integer) - Skip N emails
+- type (string) - Filter: personal or generic
+- seniority (string) - Filter: junior, senior, or executive
+- department (string) - Filter by department (sales, marketing, etc)
+
+```bash
+orth api run hunter /v2/domain-search --query 'domain=stripe.com'
+```
+
+### Email Finder ($0.01)
+Find the most likely email address for a person given their name and company domain.
+
+Parameters:
+- domain (string) - Company domain (e.g. reddit.com)
+- company (string) - Company name (domain preferred)
+- first_name (string) - Person first name
+- last_name (string) - Person last name
+- full_name (string) - Full name (if first/last not available)
+- linkedin_handle (string) - LinkedIn profile handle
+
+```bash
+orth api run hunter /v2/email-finder --query domain=openai.com first_name=Sam last_name=Altman
+```
+
+### Email Verifier ($0.01)
+Verify if an email address is deliverable. Returns status (valid, invalid, accept_all, webmail, disposable, unknown).
+
+Parameters:
+- email* (string) - Email address to verify
+
+```bash
+orth api run hunter /v2/email-verifier --query 'email=john@example.com'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -21,68 +21,42 @@ Find email addresses, verify deliverability, and discover companies.
 
 ### Domain Search ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/domain-search?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/domain-search --query 'domain=stripe.com'
 ```
 
 ### Find Email ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-finder?domain=openai.com&first_name=Sam&last_name=Altman" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/email-finder --query domain=openai.com first_name=Sam last_name=Altman
 ```
 
 ### Verify Email ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-verifier?email=john@example.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/email-verifier --query 'email=john@example.com'
 ```
 
 ### Person Lookup ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/people/find?email=john@company.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/people/find --query 'email=john@company.com'
 ```
 
 ### Company Lookup ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/companies/find?domain=anthropic.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/companies/find --query 'domain=anthropic.com'
 ```
 
 ### Combined Lookup ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/combined/find?email=jane@company.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/combined/find --query 'email=jane@company.com'
 ```
 
 ### Discover Companies ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/hunter/v2/discover" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "AI startups in San Francisco"}'
+orth api run hunter /v2/discover --body '{"query": "AI startups in San Francisco"}'
 ```
 
 ### Email Count ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-count?domain=google.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Find all emails for a domain
-orth api run hunter /v2/domain-search --query 'domain=notion.so'
-
-# Find specific person's email
-orth api run hunter /v2/email-finder --query 'domain=stripe.com&first_name=Patrick&last_name=Collison'
-
-# Verify email deliverability
-orth api run hunter /v2/email-verifier --query 'email=test@company.com'
-
-# Discover companies
-orth api run hunter /v2/discover --body '{"query": "fintech startups NYC"}'
+orth api run hunter /v2/email-count --query 'domain=google.com'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -12,7 +12,9 @@ Find email addresses, verify deliverability, and discover companies.
 - **Domain Search**: Find all emails for a domain ($0.01)
 - **Email Finder**: Find email for a person at company ($0.01)
 - **Email Verifier**: Check if email is deliverable ($0.01)
+- **Person Lookup**: Get person info from email ($0.01)
 - **Company Lookup**: Get company info from domain ($0.01)
+- **Combined Lookup**: Get person + company from email ($0.01)
 - **Company Discovery**: Find companies matching criteria ($0.01)
 
 ## Usage
@@ -32,9 +34,19 @@ orth api run hunter /v2/email-finder --query domain=openai.com first_name=Sam la
 orth api run hunter /v2/email-verifier --query 'email=john@example.com'
 ```
 
+### Person Lookup ($0.01)
+```bash
+orth api run hunter /v2/people/find --query 'email=john@company.com'
+```
+
 ### Company Lookup ($0.01)
 ```bash
 orth api run hunter /v2/companies/find --query 'domain=anthropic.com'
+```
+
+### Combined Lookup ($0.01)
+```bash
+orth api run hunter /v2/combined/find --query 'email=jane@company.com'
 ```
 
 ### Discover Companies ($0.01)

--- a/skills/orthogonal-image-analyzer/SKILL.md
+++ b/skills/orthogonal-image-analyzer/SKILL.md
@@ -13,65 +13,52 @@ Analyze images to extract text, describe content, and detect objects using AI.
 Fetch image content:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/image.jpg"}'
+orth api run linkup /fetch --body '{"url": "https://example.com/image.jpg"}'
 ```
 
 ### Step 2: Extract Text (OCR)
 Use AI to extract text from images:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://example.com/screenshot.png",
-    "user_prompt": "Extract all visible text from this image"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://example.com/screenshot.png",
+  "user_prompt": "Extract all visible text from this image"
+}'
 ```
 
 ### Step 3: Describe Image Content
 Get detailed image descriptions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Describe the contents of this image in detail: https://example.com/image.jpg"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Describe the contents of this image in detail: https://example.com/image.jpg"
+  }]
+}'
 ```
 
 ### Step 4: Extract Structured Data
 Get specific data from images:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/riveter/v1/run" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://example.com/receipt.jpg",
-    "schema": {
-      "store_name": "string",
-      "date": "string",
-      "items": [{"name": "string", "price": "number"}],
-      "total": "number"
-    }
-  }'
+orth api run riveter /v1/run --body '{
+  "url": "https://example.com/receipt.jpg",
+  "schema": {
+    "store_name": "string",
+    "date": "string",
+    "items": [{"name": "string", "price": "number"}],
+    "total": "number"
+  }
+}'
 ```
 
 ### Step 5: Capture Website Screenshots
 Get screenshots of web pages:
 
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/screenshot?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/screenshot --query 'domain=stripe.com'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-investor-research/SKILL.md
+++ b/skills/orthogonal-investor-research/SKILL.md
@@ -14,8 +14,10 @@ Find investors in your space:
 
 ```bash
 orth api run fiber /v1/investor-search --body '{
-  "investment_stages": ["Seed", "Series A"],
-  "industries": ["AI", "SaaS", "Developer Tools"]
+  "searchParams": {
+    "investment_stages": ["Seed", "Series A"],
+    "industries": ["AI", "SaaS", "Developer Tools"]
+  }
 }'
 ```
 
@@ -47,8 +49,10 @@ Get contact info for partners:
 
 ```bash
 orth api run fiber /v1/people-search --body '{
-  "company_names": ["Sequoia Capital"],
-  "job_titles": ["Partner", "General Partner", "Principal"]
+  "searchParams": {
+    "company_names": ["Sequoia Capital"],
+    "job_titles": ["Partner", "General Partner", "Principal"]
+  }
 }'
 ```
 
@@ -57,9 +61,11 @@ Find email for outreach:
 
 ```bash
 orth api run sixtyfour /find-email --body '{
-  "first_name": "Alfred",
-  "last_name": "Lin",
-  "company": "Sequoia Capital"
+  "lead": {
+    "first_name": "Alfred",
+    "last_name": "Lin",
+    "company": "Sequoia Capital"
+  }
 }'
 ```
 
@@ -79,14 +85,16 @@ orth api run tavily /search --body '{
 ```bash
 # Find AI-focused investors
 orth api run fiber /v1/investor-search --body '{
-  "industries": ["AI", "Machine Learning"],
-  "investment_stages": ["Seed"],
-  "locations": ["San Francisco", "New York"]
+  "searchParams": {
+    "industries": ["AI", "Machine Learning"],
+    "investment_stages": ["Seed"],
+    "locations": ["San Francisco", "New York"]
+  }
 }'
 
 # Research specific investor
 orth api run tavily /research --body '{
-  "query": "First Round Capital - investment thesis, notable exits, typical check size, portfolio companies"
+  "input": "First Round Capital - investment thesis, notable exits, typical check size, portfolio companies"
 }'
 
 # Find angels in your space

--- a/skills/orthogonal-investor-research/SKILL.md
+++ b/skills/orthogonal-investor-research/SKILL.md
@@ -13,83 +13,65 @@ Research venture capitalists, angel investors, and their investment patterns.
 Find investors in your space:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/investor-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "investment_stages": ["Seed", "Series A"],
-    "industries": ["AI", "SaaS", "Developer Tools"]
-  }'
+orth api run fiber /v1/investor-search --body '{
+  "investment_stages": ["Seed", "Series A"],
+  "industries": ["AI", "SaaS", "Developer Tools"]
+}'
 ```
 
 ### Step 2: Research Investment Thesis
 Understand investor focus:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "What is Andreessen Horowitz investment thesis for AI companies? What do they look for in founders and startups?"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "What is Andreessen Horowitz investment thesis for AI companies? What do they look for in founders and startups?"
+  }]
+}'
 ```
 
 ### Step 3: Find Portfolio Companies
 See their existing investments:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Sequoia Capital portfolio companies AI 2023 2024",
-    "num_results": 30
-  }'
+orth api run exa /search --body '{
+  "query": "Sequoia Capital portfolio companies AI 2023 2024",
+  "num_results": 30
+}'
 ```
 
 ### Step 4: Find Partner Contacts
 Get contact info for partners:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/people-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "company_names": ["Sequoia Capital"],
-    "job_titles": ["Partner", "General Partner", "Principal"]
-  }'
+orth api run fiber /v1/people-search --body '{
+  "company_names": ["Sequoia Capital"],
+  "job_titles": ["Partner", "General Partner", "Principal"]
+}'
 ```
 
 ### Step 5: Get Partner Email
 Find email for outreach:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/find-email" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "Alfred",
-    "last_name": "Lin",
-    "company": "Sequoia Capital"
-  }'
+orth api run sixtyfour /find-email --body '{
+  "first_name": "Alfred",
+  "last_name": "Lin",
+  "company": "Sequoia Capital"
+}'
 ```
 
 ### Step 6: Recent Activity
 Track recent investments:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Sequoia Capital recent investments 2024 AI startups announcements",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "Sequoia Capital recent investments 2024 AI startups announcements",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-jina-s/SKILL.md
+++ b/skills/orthogonal-jina-s/SKILL.md
@@ -9,18 +9,18 @@ Simple, fast web search using Jina's search foundation.
 
 ## Capabilities
 
-- **Search**: Get search engine results pages (SERP) ($0.01)
+- **Search**: Use s ($0.01)
 
 ## Usage
 
-### Web Search ($0.01)
+### Search ($0.01)
+Use s.jina.ai to search the web and get SERP
+
+Parameters:
+- q (string) - Search query
+
 ```bash
 orth api run jina-s / --query 'q=latest%20AI%20news'
-```
-
-### Search with Options
-```bash
-orth api run jina-s / --query q=machine%20learning%20tutorials num=10
 ```
 
 ## Use Cases

--- a/skills/orthogonal-jina-s/SKILL.md
+++ b/skills/orthogonal-jina-s/SKILL.md
@@ -15,24 +15,12 @@ Simple, fast web search using Jina's search foundation.
 
 ### Web Search ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/jina-s/?q=latest%20AI%20news" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run jina-s / --query 'q=latest%20AI%20news'
 ```
 
 ### Search with Options
 ```bash
-curl "https://api.orth.sh/v1/run/jina-s/?q=machine%20learning%20tutorials&num=10" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Simple search
-orth api run jina-s / --query 'q=best%20programming%20languages'
-
-# Technical search
-orth api run jina-s / --query 'q=kubernetes%20deployment%20guide'
+orth api run jina-s / --query q=machine%20learning%20tutorials num=10
 ```
 
 ## Use Cases

--- a/skills/orthogonal-job-search/SKILL.md
+++ b/skills/orthogonal-job-search/SKILL.md
@@ -14,9 +14,11 @@ Use Fiber to search for jobs:
 
 ```bash
 orth api run fiber /v1/job-search --body '{
-  "job_titles": ["Software Engineer", "Full Stack Developer"],
-  "locations": ["San Francisco", "Remote"],
-  "experience_level": "senior"
+  "searchParams": {
+    "job_titles": ["Software Engineer", "Full Stack Developer"],
+    "locations": ["San Francisco", "Remote"],
+    "experience_level": "senior"
+  }
 }'
 ```
 
@@ -25,7 +27,9 @@ Get company information for interesting roles:
 
 ```bash
 orth api run fiber /v1/company-search --body '{
-  "company_names": ["Stripe", "Figma", "Notion"]
+  "searchParams": {
+    "company_names": ["Stripe", "Figma", "Notion"]
+  }
 }'
 ```
 
@@ -41,8 +45,10 @@ Find people at the company to network with:
 
 ```bash
 orth api run fiber /v1/people-search --body '{
-  "company_names": ["Stripe"],
-  "job_titles": ["Engineering Manager", "VP Engineering", "CTO"]
+  "searchParams": {
+    "company_names": ["Stripe"],
+    "job_titles": ["Engineering Manager", "VP Engineering", "CTO"]
+  }
 }'
 ```
 
@@ -58,9 +64,11 @@ orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John l
 ```bash
 # Search for remote AI jobs
 orth api run fiber /v1/job-search --body '{
-  "job_titles": ["Machine Learning Engineer", "AI Engineer"],
-  "locations": ["Remote"],
-  "keywords": ["LLM", "generative AI"]
+  "searchParams": {
+    "job_titles": ["Machine Learning Engineer", "AI Engineer"],
+    "locations": ["Remote"],
+    "keywords": ["LLM", "generative AI"]
+  }
 }'
 
 # Research a company

--- a/skills/orthogonal-job-search/SKILL.md
+++ b/skills/orthogonal-job-search/SKILL.md
@@ -13,55 +13,44 @@ Search for jobs matching your skills, experience level, and location preferences
 Use Fiber to search for jobs:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/job-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "job_titles": ["Software Engineer", "Full Stack Developer"],
-    "locations": ["San Francisco", "Remote"],
-    "experience_level": "senior"
-  }'
+orth api run fiber /v1/job-search --body '{
+  "job_titles": ["Software Engineer", "Full Stack Developer"],
+  "locations": ["San Francisco", "Remote"],
+  "experience_level": "senior"
+}'
 ```
 
 ### Step 2: Research Companies
 Get company information for interesting roles:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/company-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "company_names": ["Stripe", "Figma", "Notion"]
-  }'
+orth api run fiber /v1/company-search --body '{
+  "company_names": ["Stripe", "Figma", "Notion"]
+}'
 ```
 
 ### Step 3: Get Company Intel
 Use Brand.dev for detailed company info:
 
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ### Step 4: Find Hiring Managers
 Find people at the company to network with:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/people-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "company_names": ["Stripe"],
-    "job_titles": ["Engineering Manager", "VP Engineering", "CTO"]
-  }'
+orth api run fiber /v1/people-search --body '{
+  "company_names": ["Stripe"],
+  "job_titles": ["Engineering Manager", "VP Engineering", "CTO"]
+}'
 ```
 
 ### Step 5: Get Contact Info
 Find email for outreach:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-finder?domain=stripe.com&first_name=John&last_name=Doe" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ## Example Usage

--- a/skills/orthogonal-lead-enrichment/SKILL.md
+++ b/skills/orthogonal-lead-enrichment/SKILL.md
@@ -13,63 +13,51 @@ Enrich partial lead data with emails, phone numbers, and company information usi
 Use Hunter to find email:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-finder?domain=stripe.com&first_name=John&last_name=Doe" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ### Step 2: Verify Email
 Verify the email is deliverable:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/email-verifier?email=john@stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/email-verifier --query 'email=john@stripe.com'
 ```
 
 ### Step 3: Get More Contact Info
 Use Sixtyfour for additional enrichment:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/enrich-lead" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "John",
-    "last_name": "Doe",
-    "company": "Stripe",
-    "linkedin_url": "https://linkedin.com/in/johndoe"
-  }'
+orth api run sixtyfour /enrich-lead --body '{
+  "first_name": "John",
+  "last_name": "Doe",
+  "company": "Stripe",
+  "linkedin_url": "https://linkedin.com/in/johndoe"
+}'
 ```
 
 ### Step 4: Find Phone Number
 Use Sixtyfour to find phone:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/find-phone" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "John",
-    "last_name": "Doe",
-    "company": "Stripe"
-  }'
+orth api run sixtyfour /find-phone --body '{
+  "first_name": "John",
+  "last_name": "Doe",
+  "company": "Stripe"
+}'
 ```
 
 ### Step 5: Enrich Company Data
 Get detailed company information:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/companies/find?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/companies/find --query 'domain=stripe.com'
 ```
 
 ### Step 6: Get LinkedIn Data
 Fetch real-time LinkedIn profile:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/linkedin-live-fetch/profile/single" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
 ```
 
 ## Full Enrichment Pipeline
@@ -81,7 +69,7 @@ export COMPANY="Stripe"
 export DOMAIN="stripe.com"
 
 # 2. Find email (Hunter)
-orth api run hunter /v2/email-finder --query "domain=$DOMAIN&first_name=John&last_name=Doe"
+orth api run hunter /v2/email-finder --query domain=$DOMAIN first_name=John last_name=Doe
 
 # 3. Verify email
 orth api run hunter /v2/email-verifier --query "email=john@stripe.com"

--- a/skills/orthogonal-lead-enrichment/SKILL.md
+++ b/skills/orthogonal-lead-enrichment/SKILL.md
@@ -28,10 +28,13 @@ Use Sixtyfour for additional enrichment:
 
 ```bash
 orth api run sixtyfour /enrich-lead --body '{
-  "first_name": "John",
-  "last_name": "Doe",
-  "company": "Stripe",
-  "linkedin_url": "https://linkedin.com/in/johndoe"
+  "lead_info": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "company": "Stripe",
+    "linkedin_url": "https://linkedin.com/in/johndoe"
+  },
+  "struct": {"email": "Work email", "phone": "Phone number"}
 }'
 ```
 
@@ -40,9 +43,11 @@ Use Sixtyfour to find phone:
 
 ```bash
 orth api run sixtyfour /find-phone --body '{
-  "first_name": "John",
-  "last_name": "Doe",
-  "company": "Stripe"
+  "lead": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "company": "Stripe"
+  }
 }'
 ```
 
@@ -57,7 +62,7 @@ orth api run hunter /v2/companies/find --query 'domain=stripe.com'
 Fetch real-time LinkedIn profile:
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
 ## Full Enrichment Pipeline
@@ -75,10 +80,10 @@ orth api run hunter /v2/email-finder --query domain=$DOMAIN first_name=John last
 orth api run hunter /v2/email-verifier --query "email=john@stripe.com"
 
 # 4. Get full lead profile (Sixtyfour)
-orth api run sixtyfour /enrich-lead --body '{"first_name": "John", "last_name": "Doe", "company": "Stripe"}'
+orth api run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John", "last_name": "Doe", "company": "Stripe"}, "struct": {"email": "Work email"}}'
 
 # 5. Find phone
-orth api run sixtyfour /find-phone --body '{"first_name": "John", "last_name": "Doe", "company": "Stripe"}'
+orth api run sixtyfour /find-phone --body '{"lead": {"first_name": "John", "last_name": "Doe", "company": "Stripe"}}'
 
 # 6. Get company details
 orth api run hunter /v2/companies/find --query "domain=stripe.com"

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -16,31 +16,15 @@ Search the web and fetch content from any URL.
 
 ### Search the Web ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "latest AI developments 2024",
-    "depth": "standard"
-  }'
+orth api run linkup /search --body '{
+  "query": "latest AI developments 2024",
+  "depth": "standard"
+}'
 ```
 
 ### Fetch URL Content ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/article"}'
-```
-
-## CLI Usage
-
-```bash
-# Search the web
-orth api run linkup /search --body '{"query": "best programming languages 2024"}'
-
-# Fetch content from URL
-orth api run linkup /fetch --body '{"url": "https://news.ycombinator.com"}'
+orth api run linkup /fetch --body '{"url": "https://example.com/article"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -9,12 +9,28 @@ Search the web and fetch content from any URL.
 
 ## Capabilities
 
-- **Search**: Retrieve web content via search queries ($0.01)
-- **Fetch**: Extract content from a specific URL ($0.01)
+- **Search**: The /search endpoint allows you to retrieve web content ($0.01)
+- **Fetch**: The /fetch endpoint allows you to fetch a single webpage from a given URL ($0.01)
 
 ## Usage
 
-### Search the Web ($0.01)
+### Search ($0.01)
+The /search endpoint allows you to retrieve web content.
+
+Parameters:
+- q* (string) - The natural language question for which you want to retrieve context.
+- depth* (string) - Defines the precision of the search. standard returns results faster; deep takes longer but yields more comprehensive results.
+- outputType* (string) - The type of output you want to get. Use structured for a custom-formatted response defined by structuredOutputSchema.
+- structuredOutputSchema (object) - Required only when outputType is structured. Provide a JSON schema (as a string) representing the desired response format. The root must be of type object.
+- includeSources (boolean) - Relevant only when outputType is structured. Defines whether the response should include sources. Please note that it modifies the schema of the response, see below
+- includeImages (boolean) - Defines whether the API should include images in its results.
+- fromDate (string) - The date from which the search results should be considered, in ISO 8601 format (YYYY-MM-DD). It must be before toDate, if provided, and later than 1970-01-01.
+- toDate (string) - The date until which the search results should be considered, in ISO 8601 format (YYYY-MM-DD). It must be later than fromDate, if provided, or than 1970-01-01.
+- includeDomains (string[]) - The domains you want to search on. By default, don't restrict the search. You can provide up to 100 domains.
+- excludeDomains (string[]) - The domains you want to exclude of the search. By default, don't restrict the search.
+- includeInlineCitations (boolean) - Relevant only when outputType is sourcedAnswer. Defines whether the answer should include inline citations.
+- maxResults (number) - The maximum number of results to return.
+
 ```bash
 orth api run linkup /search --body '{
   "q": "latest AI developments 2024",
@@ -23,7 +39,15 @@ orth api run linkup /search --body '{
 }'
 ```
 
-### Fetch URL Content ($0.01)
+### Fetch ($0.01)
+The /fetch endpoint allows you to fetch a single webpage from a given URL.
+
+Parameters:
+- url* (string) - The URL of the webpage you want to fetch.
+- renderJs (boolean) - Defines whether the API should render the JavaScript of the webpage.
+- includeRawHtml (boolean) - Defines whether the API should include the raw HTML of the webpage in its response.
+- extractImages (boolean) - Defines whether the API should extract the images from the webpage in its response.
+
 ```bash
 orth api run linkup /fetch --body '{"url": "https://example.com/article"}'
 ```

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -17,8 +17,9 @@ Search the web and fetch content from any URL.
 ### Search the Web ($0.01)
 ```bash
 orth api run linkup /search --body '{
-  "query": "latest AI developments 2024",
-  "depth": "standard"
+  "q": "latest AI developments 2024",
+  "depth": "standard",
+  "outputType": "sourcedAnswer"
 }'
 ```
 

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -15,12 +15,12 @@ Find company domains by searching brand names.
 
 ### Search for Domain ($0.01)
 ```bash
-orth api run logo /search --query 'query=Stripe'
+orth api run logo /search --query 'q=Stripe'
 ```
 
 ### Search Multiple
 ```bash
-orth api run logo /search --query 'query=OpenAI'
+orth api run logo /search --query 'q=OpenAI'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -9,18 +9,19 @@ Find company domains by searching brand names.
 
 ## Capabilities
 
-- **Search**: Find company domains from brand names ($0.01)
+- **Brand Search**: Search for company domains by brand name ($0.01)
 
 ## Usage
 
-### Search for Domain ($0.01)
+### Brand Search ($0.01)
+Search for company domains by brand name
+
+Parameters:
+- q* (string)
+- strategy (string)
+
 ```bash
 orth api run logo /search --query 'q=Stripe'
-```
-
-### Search Multiple
-```bash
-orth api run logo /search --query 'q=OpenAI'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -15,24 +15,12 @@ Find company domains by searching brand names.
 
 ### Search for Domain ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/logo/search?query=Stripe" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run logo /search --query 'query=Stripe'
 ```
 
 ### Search Multiple
 ```bash
-curl "https://api.orth.sh/v1/run/logo/search?query=OpenAI" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Find domain for a company
-orth api run logo /search --query 'query=Anthropic'
-
-# Search for brand
-orth api run logo /search --query 'query=Notion'
+orth api run logo /search --query 'query=OpenAI'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-market-research/SKILL.md
+++ b/skills/orthogonal-market-research/SKILL.md
@@ -14,7 +14,7 @@ Get comprehensive market analysis:
 
 ```bash
 orth api run tavily /research --body '{
-  "query": "AI software market size 2024 growth projections trends key players competitive landscape"
+  "input": "AI software market size 2024 growth projections trends key players competitive landscape"
 }'
 ```
 
@@ -56,7 +56,7 @@ Understand target customers:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "Who are the main customer segments for enterprise AI software? What are their pain points and buying criteria?"
+  "task": "Who are the main customer segments for enterprise AI software? What are their pain points and buying criteria?"
 }'
 ```
 
@@ -74,7 +74,7 @@ orth api run scrapegraph /v1/searchscraper --body '{
 ```bash
 # Quick market overview
 orth api run tavily /research --body '{
-  "query": "EdTech market analysis 2024 - size, growth, key players, trends, challenges"
+  "input": "EdTech market analysis 2024 - size, growth, key players, trends, challenges"
 }'
 
 # Compare market segments

--- a/skills/orthogonal-market-research/SKILL.md
+++ b/skills/orthogonal-market-research/SKILL.md
@@ -13,78 +13,60 @@ Research market size, trends, competitors, and growth opportunities for any indu
 Get comprehensive market analysis:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/research" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "AI software market size 2024 growth projections trends key players competitive landscape"
-  }'
+orth api run tavily /research --body '{
+  "query": "AI software market size 2024 growth projections trends key players competitive landscape"
+}'
 ```
 
 ### Step 2: Market Size & Statistics
 Find specific market data:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "What is the current market size of the AI software industry? Include TAM, SAM, growth rate, and projections for 2025-2030 with sources."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "What is the current market size of the AI software industry? Include TAM, SAM, growth rate, and projections for 2025-2030 with sources."
+  }]
+}'
 ```
 
 ### Step 3: Identify Key Players
 Find competitors in the market:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/natural-language-search/companies" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "AI software companies with over 100 employees, Series B or later funding"
-  }'
+orth api run fiber /v1/natural-language-search/companies --body '{
+  "query": "AI software companies with over 100 employees, Series B or later funding"
+}'
 ```
 
 ### Step 4: Analyze Trends
 Research emerging trends:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "emerging trends AI software industry 2024 2025 predictions experts",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "emerging trends AI software industry 2024 2025 predictions experts",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 5: Customer Segments
 Understand target customers:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "Who are the main customer segments for enterprise AI software? What are their pain points and buying criteria?"
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "Who are the main customer segments for enterprise AI software? What are their pain points and buying criteria?"
+}'
 ```
 
 ### Step 6: Pricing Analysis
 Research pricing models:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/searchscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_prompt": "Find and compare pricing for top AI software platforms - per seat, usage-based, enterprise pricing"
-  }'
+orth api run scrapegraph /v1/searchscraper --body '{
+  "user_prompt": "Find and compare pricing for top AI software platforms - per seat, usage-based, enterprise pricing"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-movie-night/SKILL.md
+++ b/skills/orthogonal-movie-night/SKILL.md
@@ -13,55 +13,43 @@ Discover movies, check local showtimes, and plan your perfect movie night.
 Search for movies based on genre, ratings, or what's playing:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "best movies in theaters now February 2024 ratings reviews",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "best movies in theaters now February 2024 ratings reviews",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Get Movie Recommendations
 Use Perplexity for personalized suggestions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Recommend 5 sci-fi movies from 2023-2024 with good reviews for someone who liked Dune and Interstellar"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Recommend 5 sci-fi movies from 2023-2024 with good reviews for someone who liked Dune and Interstellar"
+  }]
+}'
 ```
 
 ### Step 3: Check Showtimes
 Search for local showtimes:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "What are the showtimes for Dune Part 2 at AMC theaters in San Francisco this weekend?"
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "What are the showtimes for Dune Part 2 at AMC theaters in San Francisco this weekend?"
+}'
 ```
 
 ### Step 4: Get Movie Details
 Extract comprehensive movie information:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://www.imdb.com/title/tt123456",
-    "user_prompt": "Extract movie title, rating, runtime, cast, director, plot summary, and user reviews"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.imdb.com/title/tt123456",
+  "user_prompt": "Extract movie title, rating, runtime, cast, director, plot summary, and user reviews"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-movie-night/SKILL.md
+++ b/skills/orthogonal-movie-night/SKILL.md
@@ -38,7 +38,7 @@ Search for local showtimes:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "What are the showtimes for Dune Part 2 at AMC theaters in San Francisco this weekend?"
+  "task": "What are the showtimes for Dune Part 2 at AMC theaters in San Francisco this weekend?"
 }'
 ```
 

--- a/skills/orthogonal-notte/SKILL.md
+++ b/skills/orthogonal-notte/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: notte
+description: Browser automation - control browser sessions, scrape pages, and run AI agents
+---
+
+# Notte - Browser Automation API
+
+Control browser sessions, scrape web pages, and run autonomous AI agents.
+
+## Capabilities
+
+- **Take Screenshot**: Take a screenshot of the current page ($0.001)
+- **Get Session**: Get session status and details (free)
+- **Stop Session**: Stop and clean up a browser session (free)
+- **Get Session Cookies**: Get all cookies from the browser session (free)
+- **Get Network Logs**: Get network request/response logs from the session (free)
+- **Get Agent Status**: Get agent execution status and results (free)
+- **Observe Page**: Observe the current page state and get available actions ($0.005)
+- **Stop Agent**: Stop a running agent (free)
+- **Scrape Webpage**: Scrape content from a URL without managing sessions ($0.01)
+- **Execute Page Action**: Execute an action on the page (click, type, navigate, etc ($0.002)
+- **Set Session Cookies**: Set cookies in the browser session ($0.001)
+- **Start Session**: Start a new browser session ($0.015)
+- **Scrape from HTML**: Extract structured content from raw HTML without using a browser ($0.002)
+- **Start Agent**: Start an AI agent to autonomously complete a browser task ($0.07)
+- **Scrape Page**: Scrape content from the current page in the session ($0.003)
+
+## Usage
+
+### Take Screenshot ($0.001)
+Take a screenshot of the current page.
+
+Parameters:
+- full_page (boolean) - Capture full page
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}/page/screenshot --body '{}'
+```
+
+### Get Session (free)
+Get session status and details.
+
+Parameters:
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}
+```
+
+### Stop Session (free)
+Stop and clean up a browser session.
+
+Parameters:
+- session_id* (string) - Session ID
+
+```bash
+orth api run notte /sessions/{session_id}/stop
+```
+
+### Get Session Cookies (free)
+Get all cookies from the browser session.
+
+Parameters:
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}/cookies
+```
+
+### Get Network Logs (free)
+Get network request/response logs from the session.
+
+Parameters:
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}/network/logs --query session_id=example
+```
+
+### Get Agent Status (free)
+Get agent execution status and results.
+
+Parameters:
+- agent_id* (string)
+
+```bash
+orth api run notte /agents/{agent_id}
+```
+
+### Observe Page ($0.005)
+Observe the current page state and get available actions.
+
+Parameters:
+- max_nb_actions (number) - Maximum actions to return (default: 100)
+- min_nb_actions (number) - Minimum actions to return
+- instruction (string) - Optional instruction to filter actions
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}/page/observe --body '{"instruction": "Find the search box"}'
+```
+
+### Stop Agent (free)
+Stop a running agent.
+
+Parameters:
+- session_id* (string) - Session ID the agent is running on
+
+```bash
+orth api run notte /agents/{agent_id}/stop
+```
+
+### Scrape Webpage ($0.01)
+Scrape content from a URL without managing sessions.
+
+Parameters:
+- url* (string) - URL to scrape
+- schema (object) - Structured extraction schema
+
+```bash
+orth api run notte /scrape --body '{"url": "https://example.com"}'
+```
+
+### Execute Page Action ($0.002)
+Execute an action on the page (click, type, navigate, etc.).
+
+Parameters:
+- type* (string) - Action type: goto, click, type, scroll, select, hover, wait, screenshot
+- url (string) - URL for goto action
+- ref (string) - Element reference for click/type/select actions
+- text (string) - Text for type action
+- value (string) - Value for select action
+- direction (string) - Scroll direction: up/down
+- amount (number) - Scroll amount in pixels
+- timeout (number) - Wait timeout in ms
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}/page/execute --body '{"instruction": "Click the search button"}'
+```
+
+### Set Session Cookies ($0.001)
+Set cookies in the browser session.
+
+Parameters:
+- cookies* (array) - Array of cookie objects
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}/cookies
+```
+
+### Start Session ($0.015)
+Start a new browser session. Configure browser type, proxies, viewport, and session timeout.
+
+Parameters:
+- headless (boolean) - Run in headless mode (default: true)
+- browser_type (string) - Browser type: chromium, chrome, firefox
+- proxies (boolean) - Enable proxy rotation
+- solve_captchas (boolean) - Auto-solve CAPTCHAs
+- idle_timeout_minutes (integer) - Idle timeout (default: 3)
+- max_duration_minutes (integer) - Max duration (default: 15)
+- viewport_width (integer)
+- viewport_height (integer)
+- user_agent (string)
+
+```bash
+orth api run notte /sessions/start --body '{
+  "url": "https://example.com",
+  "timeout_minutes": 5
+}'
+```
+
+### Scrape from HTML ($0.002)
+Extract structured content from raw HTML without using a browser
+
+Parameters:
+- frames* (array) - Array of HTML frames to parse
+
+```bash
+orth api run notte /scrape_from_html --body '{"html": "<html><body>Hello</body></html>"}'
+```
+
+### Start Agent ($0.07)
+Start an AI agent to autonomously complete a browser task.
+
+Parameters:
+- task* (string) - Task for the AI agent to perform
+- session_id* (string) - Session ID to run the agent on
+- url (string) - Starting URL
+- max_steps (number) - Max steps (1-50, default: 20)
+- use_vision (boolean) - Use vision model (default: true)
+
+```bash
+orth api run notte /agents/start --body '{
+  "task": "Search for AI news on Google and summarize the top results",
+  "url": "https://google.com"
+}'
+```
+
+### Scrape Page ($0.003)
+Scrape content from the current page in the session.
+
+Parameters:
+- selector (string) - Playwright selector to scope the scrape
+- scrape_links (boolean) - Scrape links (default: true)
+- scrape_images (boolean) - Scrape images (default: false)
+- only_main_content (boolean) - Only main content, exclude nav/footer (default: true)
+- response_format (object) - Pydantic model or JSON Schema for structured extraction
+- instructions (string) - Additional extraction instructions
+- session_id* (string)
+
+```bash
+orth api run notte /sessions/{session_id}/page/scrape --body '{}'
+```
+
+## Use Cases
+
+1. **Web Scraping**: Extract structured data from any webpage
+2. **Browser Automation**: Automate complex browser workflows
+3. **Testing**: Run automated browser tests
+4. **AI Agents**: Deploy autonomous agents for web tasks
+5. **Monitoring**: Track website changes and content

--- a/skills/orthogonal-nyne/SKILL.md
+++ b/skills/orthogonal-nyne/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: nyne
+description: Intelligence and enrichment - person and company data, social profiles, events, and funding
+---
+
+# Nyne - Intelligence & Enrichment API
+
+Enrich person and company data with social profiles, events, interests, funding, and more.
+
+## Capabilities
+
+- **Person Search**: Search people by company, role, geography, and name ($0.075)
+- **Person Enrichment**: Enrich person data from email, phone, or social URL ($0.075)
+- **Person Events**: Find life events and career milestones ($0.219)
+- **Person Social Profiles**: Get all social media profiles for a person ($0.363)
+- **Person Single Social Lookup**: Look up a specific social media profile ($0.148)
+- **Person Interactions**: Get social media interactions ($0.219)
+- **Person Interests**: Get interests, skills, and topics a person engages with ($0.363)
+- **Person Newsfeed**: Get social media newsfeed data ($0.435)
+- **Company Search**: Search companies by industry and keywords ($0.363)
+- **Company Enrichment**: Enrich company data from email, phone, or social URL ($0.076)
+- **Company Check Seller**: Check if a company sells a specific product/service ($0.148)
+- **Company Needs**: Analyze company needs from SEC filings and content ($0.219)
+- **Company Funding**: Get company funding history and investment details ($0.578)
+- **Company Funders**: Get investors and funders associated with a company ($1.44)
+
+## Usage
+
+### Person Search ($0.075)
+Search people by company name, role, geography, and person name. Returns requestId for polling.
+
+Parameters:
+- query* (string) - Natural language search query (max 1000 chars)
+- limit (integer) - Max results per request (default: 10, max: 100)
+- offset (integer) - Starting position in results (default: 0, max: 999)
+- cursor (string) - Pagination token from previous response
+- request_id (string) - Request ID to continue fetching from same search
+- force_new (boolean) - Force fresh search even if cached (default: false)
+- type (string) - Search tier: light (fastest), medium, premium (best quality). Default: premium
+- show_emails (boolean) - Include email addresses in results (default: false)
+- show_phone_numbers (boolean) - Include phone numbers in results (default: false)
+- require_emails (boolean) - Only return profiles with emails (default: false)
+- require_phone_numbers (boolean) - Only return profiles with phones (default: false)
+- require_phones_or_emails (boolean) - Only return profiles with phone OR email (default: false)
+- insights (boolean) - Include AI-generated relevance insights (default: false, not available for light)
+- high_freshness (boolean) - Prioritize recently updated profiles (default: false, not available for light)
+- profile_scoring (boolean) - Include AI relevance scoring (default: false)
+- callback_url (string) - URL to receive results via webhook
+- custom_filters (object) - Structured filters (locations, industries, titles, etc.)
+
+```bash
+orth api run nyne /person/search --body '{"query": "Software engineers at OpenAI"}'
+```
+
+### Person Enrichment ($0.075)
+Enrich a person's profile from email, phone, or social media URL. Returns comprehensive data including work history, education, and social profiles.
+
+Parameters:
+- email (string) - Email address to enrich
+- phone (string) - Phone number to enrich
+- social_media_url (string) - Social media profile URL (LinkedIn, Twitter, etc.)
+- name (string) - Person name to search (used with company)
+- company (string) - Company name to narrow name-based search
+- callback_url (string) - URL to receive results via webhook
+- newsfeed (array) - Social media sources for newsfeed: linkedin, twitter, instagram, github, facebook, or all
+- ai_enhanced_search (boolean) - Enable AI-powered deep search for more social profiles (slower)
+- strict_email_check (boolean) - Enable strict email validation
+- lite_enrich (boolean) - Lightweight enrichment mode (3 credits vs 6, returns only basic fields)
+- probability_score (boolean) - Include confidence score in results
+
+```bash
+orth api run nyne /person/enrichment --body '{"email": "john@openai.com"}'
+```
+
+### Person Events ($0.219)
+Find life events and career milestones for people at specific events.
+
+Parameters:
+- event* (string) - Event name (e.g., YC Demo Day, TechCrunch Disrupt)
+- company_name (string) - Filter by company to find employees who attended
+- role (string) - Filter by job title (e.g., Founder, CTO)
+- industry (string) - Filter by industry sector
+- location (string) - Geographic filter for attendees
+- callback_url (string) - HTTPS endpoint for automatic delivery
+
+```bash
+orth api run nyne /person/events --body '{"event": "YC Demo Day"}'
+```
+
+### Person Social Profiles ($0.363)
+Get all social media profiles associated with a person.
+
+Parameters:
+- email (string) - Email address to look up
+- phone (string) - Phone number to look up
+- social_media_url (string) - Social media profile URL to find other profiles from
+- callback_url (string) - URL to receive results via webhook
+
+```bash
+orth api run nyne /person/social-profiles --body '{"email": "john@openai.com"}'
+```
+
+### Person Single Social Lookup ($0.148)
+Look up a single social media profile for a person on a specific platform.
+
+Parameters:
+- social_media_url (string) - Social media profile URL to look up from
+- email (string) - Email address to look up from
+- site* (string) - Target social media site: twitter, linkedin, instagram, facebook, tiktok, pinterest, github
+- callback_url (string) - URL to receive results via webhook
+
+```bash
+orth api run nyne /person/single-social-lookup --body '{"email": "john@openai.com", "site": "linkedin"}'
+```
+
+### Person Interactions ($0.219)
+Get social media interactions (replies, followers, following) from a profile.
+
+Parameters:
+- type* (string) - Interaction type: replies, followers, following, or followers,following
+- social_media_url* (string) - Twitter/X or Instagram profile or post URL
+- max_results (integer) - Maximum results to return (default: 100, max: 1000)
+- callback_url (string) - URL to receive results via webhook
+
+```bash
+orth api run nyne /person/interactions --body '{"type": "followers", "social_media_url": "https://twitter.com/openai"}'
+```
+
+### Person Interests ($0.363)
+Get interests, skills, and topics a person engages with.
+
+Parameters:
+- email (string) - Email address to look up
+- phone (string) - Phone number to look up
+- social_media_url (string) - Social media profile URL
+- callback_url (string) - URL to receive results via webhook
+
+```bash
+orth api run nyne /person/interests --body '{"email": "john@openai.com"}'
+```
+
+### Person Newsfeed ($0.435)
+Get social media newsfeed data from LinkedIn, Twitter, Instagram, GitHub, or Facebook profiles.
+
+Parameters:
+- social_media_url* (string) - Social media profile URL (LinkedIn, Twitter, Instagram, GitHub, Facebook)
+- callback_url (string) - URL to receive results via webhook
+
+```bash
+orth api run nyne /person/newsfeed --body '{"social_media_url": "https://linkedin.com/in/johndoe"}'
+```
+
+### Company Search ($0.363)
+Search for companies by industry focus and website keywords.
+
+Parameters:
+- industry (string) - Industry focus (e.g., Healthcare SaaS). Required if website_keyword not provided
+- website_keyword (string) - Keyword that should appear on company sites (e.g., SOC 2). Required if industry not provided
+- location (string) - Geographic filter (city, region, or country)
+- max_results (integer) - Maximum results (1-50, default: 25)
+- validate_keyword (boolean) - Validate keyword exists on company website HTML
+- callback_url (string) - HTTPS endpoint for automatic delivery
+
+```bash
+orth api run nyne /company/search --body '{"industry": "AI", "location": "San Francisco"}'
+```
+
+### Company Enrichment ($0.076)
+Enrich company data from email, phone, or LinkedIn company URL.
+
+Parameters:
+- email (string) - Company email address to enrich
+- phone (string) - Company phone number to enrich
+- social_media_url (string) - LinkedIn company profile URL
+- callback_url (string) - HTTPS endpoint for automatic delivery
+
+```bash
+orth api run nyne /company/enrichment --body '{"social_media_url": "https://linkedin.com/company/openai"}'
+```
+
+### Company Check Seller ($0.148)
+Check if a company sells a specific product or service.
+
+Parameters:
+- company_name* (string) - Company name to check
+- product_service* (string) - Product or service to verify (e.g., SOC 2 automation)
+- callback_url (string) - HTTPS endpoint for automatic delivery
+
+```bash
+orth api run nyne /company/checkseller --body '{"company_name": "Vanta", "product_service": "SOC 2 automation"}'
+```
+
+### Company Needs ($0.219)
+Analyze company needs based on SEC filings and provided content.
+
+Parameters:
+- company_name* (string) - Company to analyze (e.g., Uber Technologies, Inc.)
+- content* (string) - Topic to surface (e.g., Regulatory challenges, Supply chain issues)
+- filing (string) - Restrict to filing type (e.g., Form 10-K, Form 8-K)
+- callback_url (string) - HTTPS endpoint for automatic delivery
+
+```bash
+orth api run nyne /company/needs --body '{"company_name": "Uber Technologies", "content": "Regulatory challenges"}'
+```
+
+### Company Funding ($0.578)
+Get company funding history and investment details.
+
+Parameters:
+- company_name (string) - Company name to search (e.g., Stripe, OpenAI)
+- company_domain (string) - Company domain to search (e.g., stripe.com, openai.com)
+- callback_url (string) - HTTPS endpoint for automatic delivery
+
+```bash
+orth api run nyne /company/funding --body '{"company_name": "OpenAI"}'
+```
+
+### Company Funders ($1.44)
+Get investors and funders associated with a company.
+
+Parameters:
+- company_name (string) - Investor name (e.g., Y Combinator, Sequoia Capital, Andreessen Horowitz)
+- company_domain (string) - Investor domain (e.g., ycombinator.com, sequoiacap.com, a16z.com)
+- callback_url (string) - HTTPS endpoint for automatic delivery
+
+```bash
+orth api run nyne /company/funders --body '{"company_name": "OpenAI"}'
+```
+
+## Use Cases
+
+1. **Sales Intelligence**: Enrich leads with comprehensive data
+2. **Recruiting**: Find candidates and their social profiles
+3. **Investment Research**: Research company funding and investors
+4. **Market Research**: Track company signals and news
+5. **Lead Scoring**: Score leads based on interests and events

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -19,7 +19,7 @@ Powerful web scraping, crawling, and AI-powered content extraction.
 
 ### Scrape a Page ($0.01)
 ```bash
-orth api run olostep /v1/scrapes --body '{"url": "https://example.com/page"}'
+orth api run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
 ```
 
 ### Check Scrape Status
@@ -30,7 +30,7 @@ orth api run olostep /v1/scrapes/{scrape_id}
 ### Start a Crawl ($0.05)
 ```bash
 orth api run olostep /v1/crawls --body '{
-  "url": "https://example.com",
+  "start_url": "https://example.com",
   "max_pages": 100
 }'
 ```
@@ -38,16 +38,16 @@ orth api run olostep /v1/crawls --body '{
 ### Batch Scrape ($0.01)
 ```bash
 orth api run olostep /v1/batches --body '{
-  "urls": [
-    "https://example.com/page1",
-    "https://example.com/page2"
+  "items": [
+    {"url_to_scrape": "https://example.com/page1"},
+    {"url_to_scrape": "https://example.com/page2"}
   ]
 }'
 ```
 
 ### AI Answer ($0.05)
 ```bash
-orth api run olostep /v1/answers --body '{"question": "What are the latest AI developments?"}'
+orth api run olostep /v1/answers --body '{"task": "What are the latest AI developments?"}'
 ```
 
 ### Get Site Map ($0.01)

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -9,25 +9,87 @@ Powerful web scraping, crawling, and AI-powered content extraction.
 
 ## Capabilities
 
-- **Scrape Pages**: Extract content from individual URLs ($0.01)
-- **Batch Processing**: Process multiple URLs in parallel ($0.01)
-- **Web Crawling**: Crawl entire websites ($0.05)
-- **AI Answers**: Get AI-powered answers from web research ($0.05)
-- **Site Maps**: Extract all URLs from a website ($0.01)
+- **Create Scrape**: Initiate a web page scrape ($0.01)
+- **Create Answer**: The AI will perform actions like searching and browsing web pages to find the answer to the provided task ($0.05)
+- **Maps**: This endpoint allows users to get all the urls on a certain website ($0.01)
+- **Start Crawl**: Starts a new crawl ($0.05)
+- **Start Batch**: Starts a new batch ($0.01)
+- **Batch Items**: Retrieves the list of items processed for a batch ($0.01)
+- **Crawl Info**: Fetches information about a specific crawl ($0.01)
+- **Crawl Pages**: Fetches the list of pages for a specific crawl ($0.01)
+- **Get Answer**: This endpoint retrieves a previously completed answer by its ID ($0.01)
+- **Get Scrape**: Can be used to retrieve response for a scrape ($0.01)
+- **Batch Info**: Retrieves the status and progress information about a batch ($0.01)
+- **Retrieve Content**: Retrieve page content of processed batches and crawls urls ($0.01)
 
 ## Usage
 
-### Scrape a Page ($0.01)
+### Create Scrape ($0.01)
+Initiate a web page scrape
+
+Parameters:
+- url_to_scrape* (string) - The URL to start scraping from.
+- wait_before_scraping (integer) - Time to wait in milliseconds before starting the scraping.
+- formats (string[]) - Formats in which you want the content.
+- remove_css_selectors (string) - Option to remove certain CSS selectors from the content. Optionally, you can also pass a JSON stringified array of specific selectors you want to remove. The CSS selectors removed when this option is set to default are ['nav','footer','script','style','noscript','svg',[role=alert],[role=banner],[role=dialog],[role=alertdialog],[role=region][aria-label*=skip i],[aria-modal=true]] Available options: `default`, `none`, `array`
+- actions (object[]) - Actions to perform on the page before getting the content.
+- country (string) - Residential country to load the request from. Supported values are: * US (United States) * CA (Canada) * IT (Italy) * IN (India) * GB (England) * JP (Japan) * MX (Mexico) * AU (Australia) * ID (Indonesia) * UA (UAE) * RU (Russia) * RANDOM Some operations, like scraping Google Search and Google News, support all countries.
+- transformer (string) - Specify the HTML transformer to use, if any. Postlight's Mercury Parser library is used to remove ads and other unwanted content from the scraped content. Available options: `postlight`, `none`
+- remove_images (boolean) - Option to remove images from the scraped content. Defaults to false.
+- remove_class_names (string[]) - List of class names to remove from the content.
+- parser (object) - When defining json as a format, you can use this parameter to specify the parser to use. Parsers are useful to extract structured content from web pages. Olostep has a few parsers built in for most common web pages, and you can also create your own parsers.
+- llm_extract (object)
+- links_on_page (object) - With this option, you can get all the links present on the page you scrape.
+- screen_size (object) - Configuration for screen size. Preset dimensions are available through screen_type: desktop (1920x1080), mobile (414x896), or default (768x1024).
+- metadata (object) - User-defined metadata. Not supported yet
+
 ```bash
 orth api run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
 ```
 
-### Check Scrape Status
+### Create Answer ($0.05)
+The AI will perform actions like searching and browsing web pages to find the answer to the provided task. Execution time is 3-30s depending upon complexity. For longer tasks, use the agent endpoint instead.
+
+Parameters:
+- task* (string) - The task to be performed.
+- json_format (object) - The desired output JSON object with empty values as a schema, or simply describe the data you want as a string.
+
 ```bash
-orth api run olostep /v1/scrapes/{scrape_id}
+orth api run olostep /v1/answers --body '{"task": "What are the latest AI developments?"}'
 ```
 
-### Start a Crawl ($0.05)
+### Maps ($0.01)
+This endpoint allows users to get all the urls on a certain website. It can take up to 120 seconds for complex websites. For large websites, results are paginated using cursor-based pagination
+
+Parameters:
+- url* (string) - The URL of the website for which you want the links
+- search_query (string) - An optional search query to sort the links by search relevance.
+- top_n (number) - An optional number to limit to only top n links for a search query.
+- include_subdomain (boolean) - Include subdomains of the given URL. `true` by default.
+- include_urls (string[]) - URL path patterns to include using glob syntax. For example: `/blog/**` to only include blog URLs. Only URLs matching these patterns will be returned.
+- exclude_urls (string[]) - URL path patterns to exclude using glob syntax. For example: `/careers/**`. Excluded URLs will supersede included URLs.
+- cursor (string) - OPTIONAL: Pagination cursor from a previous response. When provided, returns the next set of URLs from where the previous request left off due to response size limit.
+
+```bash
+orth api run olostep /v1/maps --body '{"url": "https://example.com"}'
+```
+
+### Start Crawl ($0.05)
+Starts a new crawl. You receive a `id` to track the progress. The operation may take 1-10 mins depending upon the site and depth and pages parameters.
+
+Parameters:
+- start_url* (string) - The starting point of the crawl.
+- max_pages* (number) - Maximum number of pages to crawl. Recommended for most use cases like crawling an entire website.
+- include_urls (string[]) - URL path patterns to include in the crawl using glob syntax. Defaults to `/**` which includes all URLs. Use patterns like `/blog/**` to crawl specific sections (e.g., only blog pages), `/products/*.html` for product pages, or multiple patterns for different sections. Supports standard glob features like * (any characters) and ** (recursive matching).
+- exclude_urls (string[]) - URL path names in glob pattern to exclude. For example: `/careers/**`. Excluded URLs will supersede included URLs.
+- max_depth (number) - Maximum depth of the crawl. Useful to extract only up to n-degree of links.
+- include_external (boolean) - Crawl first-degree external links.
+- include_subdomain (boolean) - Include subdomains of the website. `false` by default.
+- search_query (string) - An optional search query to find specific links and also sort the results by relevance.
+- top_n (number) - An optional number to only crawl the top N most relevant links on every page as per search query.
+- webhook_url (string) - An optional POST request endpoint called when this crawl is completed. The body of the request will be same as the response of this [`v1/crawls/{crawl_id}`](./info#response-created) endpoint.
+- timeout (number) - End the crawl after n seconds with the pages completed until then. May take ~10s extra from provided timeout.
+
 ```bash
 orth api run olostep /v1/crawls --body '{
   "start_url": "https://example.com",
@@ -35,7 +97,15 @@ orth api run olostep /v1/crawls --body '{
 }'
 ```
 
-### Batch Scrape ($0.01)
+### Start Batch ($0.01)
+Starts a new batch. You receive an `id` that you can use to track the progress of the batch as shown [here](/api-reference/batches/info). Note: Processing time is constant regardless of batch size
+
+Parameters:
+- items* (object[]) - Array of items to be processed in the batch.
+- country (string) - Country for the batch execution. Provide in ISO 3166-1 alpha-2 codes like US(USA), IN(India), etc
+- parser (object) - You can use this parameter to specify the parser to use. Parsers are useful to extract structured content from web pages. Olostep has a few parsers built in for most common web pages, and you can also create your own parsers.
+- links_on_page (object) - Get all the links present on each page in the batch.
+
 ```bash
 orth api run olostep /v1/batches --body '{
   "items": [
@@ -45,14 +115,57 @@ orth api run olostep /v1/batches --body '{
 }'
 ```
 
-### AI Answer ($0.05)
+### Batch Items ($0.01)
+Retrieves the list of items processed for a batch. You can then use the `retrieve_id` to get the content with the Retrieve Endpoint
+
 ```bash
-orth api run olostep /v1/answers --body '{"task": "What are the latest AI developments?"}'
+orth api run olostep /v1/batches/{batch_id}/items
 ```
 
-### Get Site Map ($0.01)
+### Crawl Info ($0.01)
+Fetches information about a specific crawl.
+
 ```bash
-orth api run olostep /v1/maps --body '{"url": "https://example.com"}'
+orth api run olostep /v1/crawls/{crawl_id}
+```
+
+### Crawl Pages ($0.01)
+Fetches the list of pages for a specific crawl.
+
+```bash
+orth api run olostep /v1/crawls/{crawl_id}/pages
+```
+
+### Get Answer ($0.01)
+This endpoint retrieves a previously completed answer by its ID.
+
+```bash
+orth api run olostep /v1/answers/{answer_id}
+```
+
+### Get Scrape ($0.01)
+Can be used to retrieve response for a scrape.
+
+```bash
+orth api run olostep /v1/scrapes/{scrape_id}
+```
+
+### Batch Info ($0.01)
+Retrieves the status and progress information about a batch. To retrieve the content for a batch, see here
+
+```bash
+orth api run olostep /v1/batches/{batch_id}
+```
+
+### Retrieve Content ($0.01)
+Retrieve page content of processed batches and crawls urls.
+
+Parameters:
+- retrieve_id* (string) - The ID of the page content to retrieve. Available in the response of `/v1/crawls/{crawl_id}/pages`, `/v1/scrapes/{scrape_id}` or `/v1/batches/{batch_id}/items` endpoints
+- formats (string[]) - Optional array to retrieve only specific formats in production. If not provided, all formats will be returned.
+
+```bash
+orth api run olostep /v1/retrieve --body '{"retrieve_id": "abc123"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -19,69 +19,40 @@ Powerful web scraping, crawling, and AI-powered content extraction.
 
 ### Scrape a Page ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/scrapes" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/page"}'
+orth api run olostep /v1/scrapes --body '{"url": "https://example.com/page"}'
 ```
 
 ### Check Scrape Status
 ```bash
-curl "https://api.orth.sh/v1/run/olostep/v1/scrapes/{scrape_id}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run olostep /v1/scrapes/{scrape_id}
 ```
 
 ### Start a Crawl ($0.05)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/crawls" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://example.com",
-    "max_pages": 100
-  }'
+orth api run olostep /v1/crawls --body '{
+  "url": "https://example.com",
+  "max_pages": 100
+}'
 ```
 
 ### Batch Scrape ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/batches" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "urls": [
-      "https://example.com/page1",
-      "https://example.com/page2"
-    ]
-  }'
+orth api run olostep /v1/batches --body '{
+  "urls": [
+    "https://example.com/page1",
+    "https://example.com/page2"
+  ]
+}'
 ```
 
 ### AI Answer ($0.05)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"question": "What are the latest AI developments?"}'
+orth api run olostep /v1/answers --body '{"question": "What are the latest AI developments?"}'
 ```
 
 ### Get Site Map ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/maps" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
-```
-
-## CLI Usage
-
-```bash
-# Scrape a single page
-orth api run olostep /v1/scrapes --body '{"url": "https://news.ycombinator.com"}'
-
-# Start a crawl
-orth api run olostep /v1/crawls --body '{"url": "https://docs.example.com", "max_pages": 50}'
-
-# Get AI answer from web
-orth api run olostep /v1/answers --body '{"question": "Who founded OpenAI?"}'
+orth api run olostep /v1/maps --body '{"url": "https://example.com"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -17,48 +17,28 @@ Web research API that returns OpenAI ChatCompletions-compatible responses.
 
 ### Chat Completions ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/parallel/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "parallel",
-    "messages": [
-      {"role": "user", "content": "What are the latest developments in quantum computing?"}
-    ]
-  }'
+orth api run parallel /chat/completions --body '{
+  "model": "parallel",
+  "messages": [
+    {"role": "user", "content": "What are the latest developments in quantum computing?"}
+  ]
+}'
 ```
 
 ### Start Task Run ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/parallel/v1/tasks/runs" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "task": "Research the competitive landscape of AI coding assistants",
-    "depth": "comprehensive"
-  }'
+orth api run parallel /v1/tasks/runs --body '{
+  "task": "Research the competitive landscape of AI coding assistants",
+  "depth": "comprehensive"
+}'
 ```
 
 ### Beta Search ($0.01)
-```bash
-curl -X POST "https://api.orth.sh/v1/run/parallel/v1beta/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -H "parallel-beta: true" \
-  -d '{"query": "AI agent frameworks comparison 2024"}'
-```
 
-## CLI Usage
+> Note: The beta search endpoint requires a custom header (`parallel-beta: true`). If `orth api run` does not support `--header`, use the SDK or direct HTTP request instead.
 
 ```bash
-# Research via chat completion
-orth api run parallel /chat/completions --body '{
-  "model": "parallel",
-  "messages": [{"role": "user", "content": "Compare GPT-4 vs Claude 3"}]
-}'
-
-# Start async research task
-orth api run parallel /v1/tasks/runs --body '{"task": "Find all YC W24 AI startups"}'
+orth api run parallel /v1beta/search --body '{"query": "AI agent frameworks comparison 2024"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -28,8 +28,8 @@ orth api run parallel /chat/completions --body '{
 ### Start Task Run ($0.01)
 ```bash
 orth api run parallel /v1/tasks/runs --body '{
-  "task": "Research the competitive landscape of AI coding assistants",
-  "depth": "comprehensive"
+  "processor": "base",
+  "input": "Research the competitive landscape of AI coding assistants"
 }'
 ```
 
@@ -38,7 +38,7 @@ orth api run parallel /v1/tasks/runs --body '{
 > Note: The beta search endpoint requires a custom header (`parallel-beta: true`). If `orth api run` does not support `--header`, use the SDK or direct HTTP request instead.
 
 ```bash
-orth api run parallel /v1beta/search --body '{"query": "AI agent frameworks comparison 2024"}'
+orth api run parallel /v1beta/search --body '{"objective": "AI agent frameworks comparison 2024"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -9,13 +9,122 @@ Web research API that returns OpenAI ChatCompletions-compatible responses.
 
 ## Capabilities
 
-- **Chat Completions**: Web research with OpenAI-compatible format ($0.01)
-- **Task Runs**: Async research tasks ($0.01)
-- **Beta Search**: Advanced web search ($0.01)
+- **Retrieve FindAll Run Status**: Retrieve a FindAll run (free)
+- **FindAll Run Result**: Retrieve the FindAll run result at the time of the request (free)
+- **Cancel FindAll Run**: Cancel a FindAll run (free)
+- **Retrieve Task Run Input**: Retrieves the input of a run by run_id (free)
+- **Retrieve Task Run**: Retrieves run status by run_id (free)
+- **Ingest FindAll Run**: Transforms a natural language search objective into a structured FindAll spec ($0.01)
+- **Retrieve Task Run Result**: Retrieves a run result by run_id, blocking until the run is completed (free)
+- **Create FindAll Run**: Starts a FindAll run ($0.01)
+- **Search**: Searches the web ($0.01)
+- **Chat API**: Parallel Chat is a web research API that returns OpenAI ChatCompletions compatible streaming text and JSON ($0.01)
+- **Extract**: Extracts relevant content from specific web URLs ($0.01)
+- **Create Task Run**: Initiates a task run ($0.01)
 
 ## Usage
 
-### Chat Completions ($0.01)
+### Retrieve FindAll Run Status (free)
+Retrieve a FindAll run.
+
+```bash
+orth api run parallel /v1beta/findall/runs/{findall_id}
+```
+
+### FindAll Run Result (free)
+Retrieve the FindAll run result at the time of the request.
+
+```bash
+orth api run parallel /v1beta/findall/runs/{findall_id}/result
+```
+
+### Cancel FindAll Run (free)
+Cancel a FindAll run.
+
+```bash
+orth api run parallel /v1beta/findall/runs/{findall_id}/cancel
+```
+
+### Retrieve Task Run Input (free)
+Retrieves the input of a run by run_id.
+
+```bash
+orth api run parallel /v1/tasks/runs/{run_id}/input
+```
+
+### Retrieve Task Run (free)
+Retrieves run status by run_id.The run result is available from the /result endpoint.
+
+```bash
+orth api run parallel /v1/tasks/runs/{run_id}
+```
+
+### Ingest FindAll Run ($0.01)
+Transforms a natural language search objective into a structured FindAll spec.Note: Access to this endpoint requires the parallel-beta header.The generated specification serves as a suggested starting point and can be furthercustomized by the user.
+
+Parameters:
+- objective* (string) - Input model for FindAll ingest.
+
+```bash
+orth api run parallel /v1beta/findall/ingest --body '{"objective": "Find all AI startups in San Francisco"}'
+```
+
+### Retrieve Task Run Result (free)
+Retrieves a run result by run_id, blocking until the run is completed.
+
+Parameters:
+- timeout (integer)
+
+```bash
+orth api run parallel /v1/tasks/runs/{run_id}/result
+```
+
+### Create FindAll Run ($0.01)
+Starts a FindAll run.This endpoint immediately returns a FindAll run object with status set to ‘queued’.You can get the run result snapshot using the GET /v1beta/findall/runs//result endpoint.You can track the progress of the run by:Polling the status using the GET /v1beta/findall/runs/ endpoint,Subscribing to real-time updates via the /v1beta/findall/runs//eventsendpoint,Or specifying a webhook with relevant event types during run creation to receivenotifications.
+
+Parameters:
+- objective* (string) - Input model for FindAll run.
+- entity_type* (string) - Type of the entity for the FindAll run.
+- match_conditions* (MatchCondition · object[]) - List of match conditions for the FindAll run.
+- generator* (enum<string>) - Generator for the FindAll run. One of base, core, pro, preview.
+- match_limit* (integer) - Maximum number of matches to find for this FindAll run. Must be between 5 and 1000 (inclusive).
+- exclude_list (ExcludeCandidate · object[] | null) - List of entity names/IDs to exclude from results.
+- metadata (Metadata · object) - Metadata for the FindAll run.
+- webhook (Webhook · object) - Webhook for the FindAll run.
+
+```bash
+orth api run parallel /v1beta/findall/runs --body '{
+  "goal": "Find all AI startups in San Francisco"
+}'
+```
+
+### Search ($0.01)
+Searches the web.To access this endpoint, pass the parallel-beta header with the valuesearch-extract-2025-10-10.
+
+Parameters:
+- mode (enum<string> | null) - Request to Search API.
+- objective (string | null) - Natural-language description of what the web search is trying to find. May include guidance about preferred sources or freshness. At least one of objective or search_queries must be provided.
+- search_queries (string[] | null) - Optional list of traditional keyword search queries to guide the search. May contain search operators. At least one of objective or search_queries must be provided.
+- processor (enum<string> | null) - DEPRECATED: use mode instead.
+- max_results (integer | null) - Upper bound on the number of results to return. May be limited by the processor. Defaults to 10 if not provided.
+- max_chars_per_result (integer | null) - DEPRECATED: Use excerpts.max_chars_per_result instead.
+- excerpts (object) - Optional settings to configure excerpt generation.
+- source_policy (object) - Optional source policy governing domain and date preferences in search results.
+- fetch_policy (object) - Fetch policy: determines when to return cached content from the index (faster) vs fetching live content (fresher). Default is to disable live fetch and return cached content from the index.
+
+```bash
+orth api run parallel /v1beta/search --body '{"objective": "AI agent frameworks comparison 2024"}'
+```
+
+### Chat API ($0.01)
+Parallel Chat is a web research API that returns OpenAI ChatCompletions compatible streaming text and JSON.
+
+Parameters:
+- model (string)
+- messages (array)
+- stream (boolean)
+- response_format (object)
+
 ```bash
 orth api run parallel /chat/completions --body '{
   "model": "parallel",
@@ -25,20 +134,39 @@ orth api run parallel /chat/completions --body '{
 }'
 ```
 
-### Start Task Run ($0.01)
+### Extract ($0.01)
+Extracts relevant content from specific web URLs.To access this endpoint, pass the parallel-beta header with the valuesearch-extract-2025-10-10.
+
+Parameters:
+- urls* (string[]) - Extract request.
+- objective (string) - If provided, focuses extracted content on the specified search objective.
+- search_queries (string[]) - If provided, focuses extracted content on the specified keyword search queries.
+- fetch_policy (object) - Fetch policy: determines when to return cached content from the index (faster) vs fetching live content (fresher). Default is to use a dynamic policy based on the search objective and url.
+- excerpts (boolean) - Include excerpts from each URL relevant to the search objective and queries. Note that if neither objective nor search_queries is provided, excerpts are redundant with full content. default:true
+- full_content (boolean) - Include full content from each URL. Note that if neither objective nor search_queries is provided, excerpts are redundant with full content. default:false
+
+```bash
+orth api run parallel /v1beta/extract --body '{"urls": ["https://example.com/article"]}'
+```
+
+### Create Task Run ($0.01)
+Initiates a task run.Returns immediately with a run object in status ‘queued’.Beta features can be enabled by setting the ‘parallel-beta’ header.
+
+Parameters:
+- processor* (string) - Task run input with additional beta fields.
+- input* (string) - Input to the task, either text or a JSON object.
+- metadata (object) - User-provided metadata stored with the run. Keys and values must be strings with a maximum length of 16 and 512 characters respectively.
+- source_policy (object) - Optional source policy governing preferred and disallowed domains in web search results.
+- task_spec (object) - Task specification. If unspecified, defaults to auto output schema.
+- mcp_servers (object[]) - Optional list of MCP servers to use for the run.To enable this feature in your requests, specify mcp-server-2025-07-17 as one of the values in parallel-beta header (for API calls) or betas param (for the SDKs).
+- enable_events (boolean) - Controls tracking of task run execution progress. When set to true, progress events are recorded and can be accessed via the Task Run events endpoint. When false, no progress events are tracked. Note that progress tracking cannot be enabled after a run has been created. The flag is set to true by default for premium processors (pro and above).To enable this feature in your requests, specify events-sse-2025-07-24 as one of the values in parallel-beta header (for API calls) or betas param (for the SDKs).
+- webhook (object) - Callback URL (webhook endpoint) that will receive an HTTP POST when the run completes.This feature is not available via the Python SDK. To enable this feature in your API requests, specify the parallel-beta header with webhook-2025-08-12 value.
+
 ```bash
 orth api run parallel /v1/tasks/runs --body '{
   "processor": "base",
   "input": "Research the competitive landscape of AI coding assistants"
 }'
-```
-
-### Beta Search ($0.01)
-
-> Note: The beta search endpoint requires a custom header (`parallel-beta: true`). If `orth api run` does not support `--header`, use the SDK or direct HTTP request instead.
-
-```bash
-orth api run parallel /v1beta/search --body '{"objective": "AI agent frameworks comparison 2024"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-pdf-processor/SKILL.md
+++ b/skills/orthogonal-pdf-processor/SKILL.md
@@ -31,13 +31,11 @@ Get structured table data:
 
 ```bash
 orth api run riveter /v1/run --body '{
-  "url": "https://example.com/report.pdf",
-  "schema": {
-    "tables": [{
-      "title": "string",
-      "headers": ["string"],
-      "rows": [["string"]]
-    }]
+  "input": {
+    "urls": ["https://example.com/report.pdf"]
+  },
+  "output": {
+    "tables": {"prompt": "Extract all tables with titles, headers, and rows", "contexts": ["urls"]}
   }
 }'
 ```
@@ -54,7 +52,7 @@ Use AI to answer questions:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "What is the total revenue mentioned in this SEC filing? [url: https://example.com/10k.pdf]"
+  "task": "What is the total revenue mentioned in this SEC filing? [url: https://example.com/10k.pdf]"
 }'
 ```
 
@@ -75,8 +73,12 @@ orth api run perplexity /chat/completions --body '{
 
 # Extract invoice data
 orth api run riveter /v1/run --body '{
-  "url": "https://example.com/invoice.pdf",
-  "schema": {"vendor": "string", "amount": "number", "date": "string", "items": [{"description": "string", "price": "number"}]}
+  "input": {"urls": ["https://example.com/invoice.pdf"]},
+  "output": {
+    "vendor": {"prompt": "Vendor name", "contexts": ["urls"]},
+    "amount": {"prompt": "Total amount", "contexts": ["urls"]},
+    "date": {"prompt": "Invoice date", "contexts": ["urls"]}
+  }
 }'
 ```
 

--- a/skills/orthogonal-pdf-processor/SKILL.md
+++ b/skills/orthogonal-pdf-processor/SKILL.md
@@ -13,64 +13,49 @@ Extract text, tables, and structured data from PDF documents.
 Use Linkup to fetch PDF URLs:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/document.pdf"}'
+orth api run linkup /fetch --body '{"url": "https://example.com/document.pdf"}'
 ```
 
 ### Step 2: Extract with AI
 Use ScrapeGraph to extract specific content:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://example.com/report.pdf",
-    "user_prompt": "Extract all financial figures, tables, and key metrics from this document"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://example.com/report.pdf",
+  "user_prompt": "Extract all financial figures, tables, and key metrics from this document"
+}'
 ```
 
 ### Step 3: Extract Tables
 Get structured table data:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/riveter/v1/run" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://example.com/report.pdf",
-    "schema": {
-      "tables": [{
-        "title": "string",
-        "headers": ["string"],
-        "rows": [["string"]]
-      }]
-    }
-  }'
+orth api run riveter /v1/run --body '{
+  "url": "https://example.com/report.pdf",
+  "schema": {
+    "tables": [{
+      "title": "string",
+      "headers": ["string"],
+      "rows": [["string"]]
+    }]
+  }
+}'
 ```
 
 ### Step 4: Convert to Markdown
 Get readable markdown output:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/markdownify" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"website_url": "https://example.com/document.pdf"}'
+orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/document.pdf"}'
 ```
 
 ### Step 5: Ask Questions About PDF
 Use AI to answer questions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "What is the total revenue mentioned in this SEC filing? [url: https://example.com/10k.pdf]"
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "What is the total revenue mentioned in this SEC filing? [url: https://example.com/10k.pdf]"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-perplexity/SKILL.md
+++ b/skills/orthogonal-perplexity/SKILL.md
@@ -17,61 +17,37 @@ AI-powered search and chat completions with real-time web data.
 
 ### Search ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "latest AI developments February 2024"}'
+orth api run perplexity /search --body '{"query": "latest AI developments February 2024"}'
 ```
 
 ### Chat Completion ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [
-      {"role": "user", "content": "What are the latest developments in AI agents?"}
-    ]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [
+    {"role": "user", "content": "What are the latest developments in AI agents?"}
+  ]
+}'
 ```
 
 ### Async Chat Completion ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/async/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [
-      {"role": "user", "content": "Write a comprehensive analysis of vector databases"}
-    ]
-  }'
+orth api run perplexity /async/chat/completions --body '{
+  "model": "sonar",
+  "messages": [
+    {"role": "user", "content": "Write a comprehensive analysis of vector databases"}
+  ]
+}'
 ```
 
 ### Check Async Status ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/perplexity/async/chat/completions/{request_id}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run perplexity /async/chat/completions/{request_id}
 ```
 
 ### List Async Jobs ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/perplexity/async/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Quick search
-orth api run perplexity /search --body '{"query": "best practices for RAG"}'
-
-# Chat with web grounding
-orth api run perplexity /chat/completions --body '{
-  "model": "sonar",
-  "messages": [{"role": "user", "content": "Explain quantum computing recent breakthroughs"}]
-}'
+orth api run perplexity /async/chat/completions
 ```
 
 ## Use Cases

--- a/skills/orthogonal-perplexity/SKILL.md
+++ b/skills/orthogonal-perplexity/SKILL.md
@@ -9,18 +9,44 @@ AI-powered search and chat completions with real-time web data.
 
 ## Capabilities
 
-- **Search**: Ranked search with real-time index ($0.01)
-- **Chat Completions**: AI responses with web grounding ($0.01)
-- **Async Chat**: Background chat completion jobs ($0.01)
+- **Chat Completions**: Generates a model’s response for the given chat conversation ($0.01)
+- **Search**: Get ranked search results from Perplexity’s continuously refreshed index with advanced filtering and customization options ($0.01)
+- **Sonar Chat Completions API**: Creates an asynchronous chat completion job ($0.01)
+- **Get Async Chat Completion Response**: Retrieves the status and result of a specific asynchronous chat completion job ($0.01)
+- **List Async Chat Completions**: Lists all asynchronous chat completion requests for the authenticated user ($0.01)
 
 ## Usage
 
-### Search ($0.01)
-```bash
-orth api run perplexity /search --body '{"query": "latest AI developments February 2024"}'
-```
+### Chat Completions ($0.01)
+Generates a model’s response for the given chat conversation.
 
-### Chat Completion ($0.01)
+Parameters:
+- model* (enum<string>) - The name of the model that will complete your prompt. Choose from our available Sonar models: sonar (lightweight search), sonar-pro (advanced search), sonar-deep-research (exhaustive research), or sonar-reasoning-pro (premier reasoning).
+- messages* (object[]) - A list of messages comprising the conversation so far.
+- search_mode (string) - Controls search mode: 'academic' prioritizes scholarly sources, 'sec' prioritizes SEC filings, 'web' uses general web search. See academic guide and SEC guide.
+- reasoning_effort (string) - Perplexity-Specific: Controls how much computational effort the AI dedicates to each query for deep research models. 'low' provides faster, simpler answers with reduced token usage, 'medium' offers a balanced approach, and 'high' delivers deeper, more thorough responses with increased token usage. This parameter directly impacts the amount of reasoning tokens consumed. WARNING: This parameter is ONLY applicable for sonar-deep-research. Defaults to 'medium' when used with sonar-deep-research.
+- max_tokens (integer) - OpenAI Compatible: The maximum number of completion tokens returned by the API. Controls the length of the model's response. If the response would exceed this limit, it will be truncated. Higher values allow for longer responses but may increase processing time and costs.
+- temperature (number) - The amount of randomness in the response, valued between 0 and 2. Lower values (e.g., 0.1) make the output more focused, deterministic, and less creative. Higher values (e.g., 1.5) make the output more random and creative. Use lower values for factual/information retrieval tasks and higher values for creative applications.
+- top_p (number) - OpenAI Compatible: The nucleus sampling threshold, valued between 0 and 1. Controls the diversity of generated text by considering only the tokens whose cumulative probability exceeds the top_p value. Lower values (e.g., 0.5) make the output more focused and deterministic, while higher values (e.g., 0.95) allow for more diverse outputs. Often used as an alternative to temperature.
+- language_preference (string) - Perplexity-Specific: Specifies the preferred language for the chat completion response (i.e., English, Korean, Spanish, etc.) of the response content. This parameter is supported only by the sonar and sonar-pro models. Using it with other models is on a best-effort basis and may not produce consistent results.
+- search_domain_filter (array) - A list of domains to limit search results to. Currently limited to 20 domains for Allowlisting and Denylisting. For Denylisting, add a - at the beginning of the domain string. More information about this here.
+- return_images (boolean) - Perplexity-Specific: Determines whether search results should include images.
+- return_related_questions (boolean) - Perplexity-Specific: Determines whether related questions should be returned.
+- search_recency_filter (string) - Perplexity-Specific: Filters search results based on time (e.g., 'week', 'day').
+- search_after_date_filter (string) - Perplexity-Specific: Filters search results to only include content published after this date. Format should be %m/%d/%Y (e.g. 3/1/2025)
+- search_before_date_filter (string) - Perplexity-Specific: Filters search results to only include content published before this date. Format should be %m/%d/%Y (e.g. 3/1/2025)
+- last_updated_after_filter (string) - Perplexity-Specific: Filters search results to only include content last updated after this date. Format should be %m/%d/%Y (e.g. 3/1/2025)
+- last_updated_before_filter (string) - Perplexity-Specific: Filters search results to only include content last updated before this date. Format should be %m/%d/%Y (e.g. 3/1/2025)
+- top_k (number) - OpenAI Compatible: The number of tokens to keep for top-k filtering. Limits the model to consider only the k most likely next tokens at each step. Lower values (e.g., 20) make the output more focused and deterministic, while higher values allow for more diverse outputs. A value of 0 disables this filter. Often used in conjunction with top_p to control output randomness.
+- stream (boolean) - OpenAI Compatible: Determines whether to stream the response incrementally.
+- presence_penalty (number) - OpenAI Compatible: Positive values increase the likelihood of discussing new topics. Applies a penalty to tokens that have already appeared in the text, encouraging the model to talk about new concepts. Values typically range from 0 (no penalty) to 2.0 (strong penalty). Higher values reduce repetition but may lead to more off-topic text.
+- frequency_penalty (number) - OpenAI Compatible: Decreases likelihood of repetition based on prior frequency. Applies a penalty to tokens based on how frequently they've appeared in the text so far. Values typically range from 0 (no penalty) to 2.0 (strong penalty). Higher values (e.g., 1.5) reduce repetition of the same words and phrases. Useful for preventing the model from getting stuck in loops.
+- response_format (object) - Enables structured JSON output formatting.
+- disable_search (boolean) - Perplexity-Specific: When set to true, disables web search completely and the model will only use its training data to respond. This is useful when you want deterministic responses without external information. More information about this here.
+- enable_search_classifier (boolean) - Perplexity-Specific: Enables a classifier that decides if web search is needed based on your query. See more here.
+- web_search_options (object) - Perplexity-Specific: Configuration for using web search in model responses.
+- media_response (object) - Perplexity-Specific: Configuration for controlling media content in responses, such as videos and images. Use the overrides property to enable specific media types.
+
 ```bash
 orth api run perplexity /chat/completions --body '{
   "model": "sonar",
@@ -30,7 +56,33 @@ orth api run perplexity /chat/completions --body '{
 }'
 ```
 
-### Async Chat Completion ($0.01)
+### Search ($0.01)
+Get ranked search results from Perplexity’s continuously refreshed index with advanced filtering and customization options.
+
+Parameters:
+- query* (string) - A search query. Can be a single query or a list of queries for multi-query search.
+- max_results (integer) - The maximum number of search results to return.
+- max_tokens (integer) - The maximum total number of tokens of webpage content returned across all search results. This sets the overall content budget for the search operation. Higher values return more content in the snippet fields. Use in combination with max_tokens_per_page to control content distribution.
+- search_domain_filter (string[]) - A list of domains/URLs to limit search results to. Maximum 20 domains.
+- max_tokens_per_page (integer) - Controls the maximum number of tokens retrieved from each webpage during search processing. Higher values provide more comprehensive content extraction but may increase processing time.
+- country (string) - Country code to filter search results by geographic location (e.g., 'US', 'GB', 'DE').
+- search_recency_filter (string) - Filters search results based on recency. Specify 'day' for results from the past 24 hours, 'week' for the past 7 days, 'month' for the past 30 days, or 'year' for the past 365 days.
+- search_after_date (string) - Filters search results to only include content published after this date. Format should be %m/%d/%Y (e.g., '10/15/2025').
+- search_before_date (string) - Filters search results to only include content published before this date. Format should be %m/%d/%Y (e.g., '10/16/2025').
+- last_updated_after_filter (string) - Perplexity-Specific: Filters search results to only include content last updated after this date. Format should be %m/%d/%Y (e.g., '07/01/2025').
+- last_updated_before_filter (string) - Perplexity-Specific: Filters search results to only include content last updated before this date. Format should be %m/%d/%Y (e.g., '12/30/2025').
+- search_language_filter (string[]) - Perplexity-Specific: Filters search results to only include content in the specified languages. Accepts an array of ISO 639-1 language codes (2 lowercase letters). Maximum 10 language codes per request.
+
+```bash
+orth api run perplexity /search --body '{"query": "latest AI developments February 2024"}'
+```
+
+### Sonar Chat Completions API ($0.01)
+Creates an asynchronous chat completion job.
+
+Parameters:
+- request (object) - required Show child attributes
+
 ```bash
 orth api run perplexity /async/chat/completions --body '{
   "model": "sonar",
@@ -40,12 +92,20 @@ orth api run perplexity /async/chat/completions --body '{
 }'
 ```
 
-### Check Async Status ($0.01)
+### Get Async Chat Completion Response ($0.01)
+Retrieves the status and result of a specific asynchronous chat completion job.
+
 ```bash
 orth api run perplexity /async/chat/completions/{request_id}
 ```
 
-### List Async Jobs ($0.01)
+### List Async Chat Completions ($0.01)
+Lists all asynchronous chat completion requests for the authenticated user.
+
+Parameters:
+- limit (integer) - Maximum number of requests to return.
+- next_token (string) - Token for fetching the next page of results. Ensure this token is URL-encoded when passed as a query parameter.
+
 ```bash
 orth api run perplexity /async/chat/completions
 ```

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -9,54 +9,276 @@ Access hyperlocal weather data including precipitation, temperature, wind, soil 
 
 ## Capabilities
 
-- **Precipitation**: Hourly and daily rainfall data ($0.01)
-- **Temperature**: Air and soil temperature readings ($0.01)
-- **Wind**: Speed, direction, and gusts ($0.01)
-- **Humidity**: Relative and specific humidity ($0.01)
-- **Soil**: Moisture and temperature at depth ($0.01)
-- **Solar**: Radiation flux data ($0.01)
-- **Embeds**: Full weather widget for any location ($0.10)
+- **Last 48 Hours Precipitation Data**: Total precipitation in the last 48 hours for the given location(s) ($0.01)
+- **Air Temperature**: Hourly near-surface air temperature in Celsius (°C) ($0.01)
+- **Hourly Soil Moisture**: Hourly soil moisture percentage relative to holding capacity at 0-10cm depth ($0.01)
+- **Wind Direction**: Hourly wind direction in compass degrees (0-360) ($0.01)
+- **Daily Precipitation Data**: Returns comprehensive daily precipitation data for the given time range and location(s) ($0.01)
+- **Wind Gusts**: Hourly wind gust speed in meters per second (m/s) ($0.01)
+- **Recent Rain Event**: Returns detailed information about the most recent precipitation event for the given location(s), including total amounts, precipitation type (rain/snow), timing, and how long ago it occurred ($0.01)
+- **Map Layer Tiles**: Map tiles compatible with most web mapping or GIS tools ($0.01)
+- **Wind Speed**: Hourly near-surface wind speed in meters per second (m/s) ($0.01)
+- **Cloud Cover**: Hourly cloud cover fraction (0-1, where 0 is clear and 1 is overcast) ($0.01)
+- **Soil Temperature**: Hourly soil temperature data at 0-10cm depth in Celsius (°C) ($0.01)
+- **Specific Humidity**: Hourly specific humidity (kg/kg) ($0.01)
+- **Hourly Precipitation Data**: Returns comprehensive hourly precipitation data for the given time range and location(s) ($0.01)
+- **Daily Soil Moisture**: Daily soil moisture percentage relative to holding capacity at 0-10cm depth ($0.01)
+- **Embeddable HTML UI**: Returns a complete, HTML page displaying comprehensive weather data for a specific location ($0.10)
+- **Solar Radiation**: Hourly downward short-wave radiation flux in watts per square meter (W/m²) ($0.01)
+- **Relative Humidity**: Hourly relative humidity as a percentage (0-100%) ($0.01)
 
 ## Usage
 
-### Hourly Precipitation ($0.01)
-```bash
-orth api run precip /api/v1/hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-07
-```
+### Last 48 Hours Precipitation Data ($0.01)
+Total precipitation in the last 48 hours for the given location(s).
 
-### Daily Precipitation ($0.01)
-```bash
-orth api run precip /api/v1/daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
-```
+Parameters:
+- longitude* (string)
+- latitude* (string)
+- timeZoneId (string)
+- format (string)
 
-### Last 48 Hours ($0.01)
 ```bash
 orth api run precip /api/v1/last-48 --query latitude=37.7749 longitude=-122.4194
 ```
 
-### Temperature Hourly ($0.01)
+### Air Temperature ($0.01)
+Hourly near-surface air temperature in Celsius (°C)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
 ```bash
 orth api run precip /api/v1/temperature-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Wind Speed ($0.01)
-```bash
-orth api run precip /api/v1/wind-speed-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
-```
+### Hourly Soil Moisture ($0.01)
+Hourly soil moisture percentage relative to holding capacity at 0-10cm depth
 
-### Soil Moisture ($0.01)
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string)
+- latitude* (string)
+- timeZoneId (string)
+- format (string)
+
 ```bash
 orth api run precip /api/v1/soil-moisture-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
+### Wind Direction ($0.01)
+Hourly wind direction in compass degrees (0-360)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
+```bash
+orth api run precip /api/v1/wind-direction-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+```
+
+### Daily Precipitation Data ($0.01)
+Returns comprehensive daily precipitation data for the given time range and location(s). Each day includes precipitation amount, type (rain/snow/mixed), probability (for forecasts), and data source. Seamlessly combines historical observations with forecast data depending on the requested time range.
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string)
+- latitude* (string)
+- timeZoneId (string)
+- format (string)
+
+```bash
+orth api run precip /api/v1/daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
+```
+
+### Wind Gusts ($0.01)
+Hourly wind gust speed in meters per second (m/s)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
+```bash
+orth api run precip /api/v1/wind-speed-gust-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+```
+
 ### Recent Rain Event ($0.01)
+Returns detailed information about the most recent precipitation event for the given location(s), including total amounts, precipitation type (rain/snow), timing, and how long ago it occurred.
+
+Parameters:
+- longitude* (string)
+- latitude* (string)
+- timeZoneId (string)
+- format (string)
+
 ```bash
 orth api run precip /api/v1/recent-rain --query latitude=37.7749 longitude=-122.4194
 ```
 
-### Weather Embed ($0.10)
+### Map Layer Tiles ($0.01)
+Map tiles compatible with most web mapping or GIS tools. Software such as Mapbox, Google Maps, ArcGIS, Leaflet, OpenLayers or QGIS will require an `x/y/z` url eg `https://api.precip.ai/api/v1/map/last-48/ImageServer/tile/{z}/{y}/{x}`. See the examples for more details.
+
+Parameters:
+- time (string)
+
+```bash
+orth api run precip /api/v1/map/precipitation/ImageServer/tile/5/12/10
+```
+
+### Wind Speed ($0.01)
+Hourly near-surface wind speed in meters per second (m/s)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
+```bash
+orth api run precip /api/v1/wind-speed-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+```
+
+### Cloud Cover ($0.01)
+Hourly cloud cover fraction (0-1, where 0 is clear and 1 is overcast)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
+```bash
+orth api run precip /api/v1/cloud-cover-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+```
+
+### Soil Temperature ($0.01)
+Hourly soil temperature data at 0-10cm depth in Celsius (°C)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
+```bash
+orth api run precip /api/v1/temp-0-10cm-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+```
+
+### Specific Humidity ($0.01)
+Hourly specific humidity (kg/kg)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string)
+
+```bash
+orth api run precip /api/v1/specific-humidity-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+```
+
+### Hourly Precipitation Data ($0.01)
+Returns comprehensive hourly precipitation data for the given time range and location(s). Each hour includes precipitation amount, type (rain/snow/mixed), probability (for forecasts), and data source.
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string)
+- latitude* (string)
+- timeZoneId (string)
+- format (string)
+
+```bash
+orth api run precip /api/v1/hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-07
+```
+
+### Daily Soil Moisture ($0.01)
+Daily soil moisture percentage relative to holding capacity at 0-10cm depth
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string)
+- latitude* (string)
+- timeZoneId (string)
+- format (string)
+
+```bash
+orth api run precip /api/v1/soil-moisture-daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
+```
+
+### Embeddable HTML UI ($0.10)
+Returns a complete, HTML page displaying comprehensive weather data for a specific location. See the examples page for more details. 
+
+ Authorization headers set automatically from query parameters on this endpoint.
+
+Parameters:
+- lat* (number) - Latitude coordinate (-90 to 90) for the location center of the precipitation widget
+- lon* (number) - Longitude coordinate (-180 to 180) for the location center of the precipitation widget
+- apiKey* (string) - Your API key for authentication. Gets automatically applied as header.
+- units (string) - Unit system for displaying precipitation amounts and temperatures. 'metric' shows mm and °C, 'imperial' shows inches and °F.
+- widgets (string) - Comma-separated list of widget keys to display.
+
+Available options:
+`current`, `event`, `calendar`, `cumulative`, `total`, `precip`, `table`, `wind`, `temp`, `soiltemp`, `soilmoisture`, `snow`
+
+When not provided, shows all widgets.
+
 ```bash
 orth api run precip /embed/location --query lat=37.7749 lon=-122.4194
+```
+
+### Solar Radiation ($0.01)
+Hourly downward short-wave radiation flux in watts per square meter (W/m²)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
+```bash
+orth api run precip /api/v1/solar-radiation-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+```
+
+### Relative Humidity ($0.01)
+Hourly relative humidity as a percentage (0-100%)
+
+Parameters:
+- start* (string)
+- end* (string)
+- longitude* (string) - Comma-separated list of longitude coordinates (WGS84)
+- latitude* (string) - Comma-separated list of latitude coordinates (WGS84)
+- timeZoneId (string) - IANA timezone identifier for localizing timestamps
+- format (string) - Output format: `geojson`, `json` or `csv`
+
+```bash
+orth api run precip /api/v1/relative-humidity-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ## Use Cases

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -21,63 +21,42 @@ Access hyperlocal weather data including precipitation, temperature, wind, soil 
 
 ### Hourly Precipitation ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/hourly?lat=37.7749&lon=-122.4194&start=2024-01-01&end=2024-01-07" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-07
 ```
 
 ### Daily Precipitation ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/daily?lat=37.7749&lon=-122.4194&start=2024-01-01&end=2024-01-31" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/daily --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-31
 ```
 
 ### Last 48 Hours ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/last-48?lat=37.7749&lon=-122.4194" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/last-48 --query lat=37.7749 lon=-122.4194
 ```
 
 ### Temperature Hourly ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/temperature-hourly?lat=37.7749&lon=-122.4194&start=2024-01-01&end=2024-01-02" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/temperature-hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Wind Speed ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/wind-speed-hourly?lat=37.7749&lon=-122.4194&start=2024-01-01&end=2024-01-02" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/wind-speed-hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Soil Moisture ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/soil-moisture-hourly?lat=37.7749&lon=-122.4194&start=2024-01-01&end=2024-01-02" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/soil-moisture-hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Recent Rain Event ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/recent-rain?lat=37.7749&lon=-122.4194" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/recent-rain --query lat=37.7749 lon=-122.4194
 ```
 
 ### Weather Embed ($0.10)
 ```bash
-curl "https://api.orth.sh/v1/run/precip/embed/location?lat=37.7749&lon=-122.4194" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Get hourly precipitation data
-orth api run precip /api/v1/hourly --query 'lat=40.7128&lon=-74.0060&start=2024-01-01&end=2024-01-07'
-
-# Check last 48 hours of rain
-orth api run precip /api/v1/last-48 --query 'lat=34.0522&lon=-118.2437'
-
-# Get soil moisture for agriculture
-orth api run precip /api/v1/soil-moisture-daily --query 'lat=38.5816&lon=-121.4944&start=2024-01-01&end=2024-01-31'
+orth api run precip /embed/location --query lat=37.7749 lon=-122.4194
 ```
 
 ## Use Cases

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -21,37 +21,37 @@ Access hyperlocal weather data including precipitation, temperature, wind, soil 
 
 ### Hourly Precipitation ($0.01)
 ```bash
-orth api run precip /api/v1/hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-07
+orth api run precip /api/v1/hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-07
 ```
 
 ### Daily Precipitation ($0.01)
 ```bash
-orth api run precip /api/v1/daily --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-31
+orth api run precip /api/v1/daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
 ```
 
 ### Last 48 Hours ($0.01)
 ```bash
-orth api run precip /api/v1/last-48 --query lat=37.7749 lon=-122.4194
+orth api run precip /api/v1/last-48 --query latitude=37.7749 longitude=-122.4194
 ```
 
 ### Temperature Hourly ($0.01)
 ```bash
-orth api run precip /api/v1/temperature-hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-02
+orth api run precip /api/v1/temperature-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Wind Speed ($0.01)
 ```bash
-orth api run precip /api/v1/wind-speed-hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-02
+orth api run precip /api/v1/wind-speed-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Soil Moisture ($0.01)
 ```bash
-orth api run precip /api/v1/soil-moisture-hourly --query lat=37.7749 lon=-122.4194 start=2024-01-01 end=2024-01-02
+orth api run precip /api/v1/soil-moisture-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Recent Rain Event ($0.01)
 ```bash
-orth api run precip /api/v1/recent-rain --query lat=37.7749 lon=-122.4194
+orth api run precip /api/v1/recent-rain --query latitude=37.7749 longitude=-122.4194
 ```
 
 ### Weather Embed ($0.10)

--- a/skills/orthogonal-recipe-finder/SKILL.md
+++ b/skills/orthogonal-recipe-finder/SKILL.md
@@ -60,7 +60,7 @@ orth api run perplexity /chat/completions --body '{
 
 # Find cuisine-specific dishes
 orth api run olostep /v1/answers --body '{
-  "question": "Best authentic Thai curry recipes for beginners"
+  "task": "Best authentic Thai curry recipes for beginners"
 }'
 ```
 

--- a/skills/orthogonal-recipe-finder/SKILL.md
+++ b/skills/orthogonal-recipe-finder/SKILL.md
@@ -13,43 +13,34 @@ Find recipes based on available ingredients, dietary needs, or cuisine preferenc
 Use Tavily to find recipes matching your criteria:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "easy chicken recipes with rice and vegetables under 30 minutes",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "easy chicken recipes with rice and vegetables under 30 minutes",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Get Recipe Suggestions
 Use Perplexity for personalized recipe ideas:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "I have chicken breast, garlic, lemon, and olive oil. What are 5 recipes I can make? Include cooking times."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "I have chicken breast, garlic, lemon, and olive oil. What are 5 recipes I can make? Include cooking times."
+  }]
+}'
 ```
 
 ### Step 3: Extract Full Recipe
 Use ScrapeGraph to get complete recipe details:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://www.allrecipes.com/recipe/example",
-    "user_prompt": "Extract the full recipe including ingredients list, step-by-step instructions, cooking time, and servings"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.allrecipes.com/recipe/example",
+  "user_prompt": "Extract the full recipe including ingredients list, step-by-step instructions, cooking time, and servings"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -9,19 +9,34 @@ Scrape web pages and extract data into your defined structure.
 
 ## Capabilities
 
-- **Scrape**: Extract text content from web pages ($0.01)
-- **Structured Run**: Define output schema and extract structured data ($0.01)
-- **Status Tracking**: Monitor long-running extraction jobs (free)
-- **Stop Jobs**: Cancel running extraction jobs (free)
+- **Scrape**: Scrape a webpage and return the text content ($0.01)
+- **Run**: Copy link Define the structure of your output directly in the API request ($0.01)
+- **Run data**: Retrieve the processed data from a completed project run (free)
+- **Run status**: Check the current status of a project run (free)
+- **Stop run**: Stop a currently running project (free)
 
 ## Usage
 
-### Simple Scrape ($0.01)
+### Scrape ($0.01)
+Scrape a webpage and return the text content. This endpoint allows you to extract text content from any public webpage.
+
+Parameters:
+- url* (string) - Example: "https://example.com"
+- proxy_country_code (string) - Optional two-character country code for proxy (e.g., 'us', 'gb', 'de')
+- skip_cache (boolean) - Default: false. Set to true to bypass cache and always fetch fresh content
+
 ```bash
 orth api run riveter /v1/scrape --body '{"url": "https://example.com/article"}'
 ```
 
-### Structured Extraction ($0.01)
+### Run ($0.01)
+Copy link Define the structure of your output directly in the API request. This endpoint allows you to define both your input data and output configuration in a single request.
+
+Parameters:
+- input* (object) - The input object contains your source data:  Keys are column/attribute names Values are arrays of strings (all arrays must be the same length) Maximum 1000 rows per request
+- output* (object) - The output object defines what data you want to extract:  Keys are the names of attributes you want to extract Each attribute requires: prompt: Instructions for finding/extracting this data contexts: Array of input or other output attribute names this depends on. Optional Output Configuration Each output attribute can optionally include:  format: Data type ('number', 'json', 'url', 'text', 'email', 'tag', 'date', 'boolean') format_details: Format-specific configuration (varies by format type). For json format, you can provide either a description (string) or a schema (JSON Schema object) or both. tools: Array of tools to use (['web_search', 'web_scrape', 'query_pdf', 'query_image']) max_tool_calls: Number of tool calls allowed (0-10) run_when: When to run this extraction ('always', 'any_filled', 'all_filled')
+- run_key (string) - Custom identifier for this run (optional, will be generated if not provided)
+
 ```bash
 orth api run riveter /v1/run --body '{
   "input": {
@@ -29,23 +44,37 @@ orth api run riveter /v1/run --body '{
   },
   "output": {
     "name": {"prompt": "Product name", "contexts": ["urls"]},
-    "price": {"prompt": "Product price", "contexts": ["urls"], "format": "number"},
-    "description": {"prompt": "Product description", "contexts": ["urls"]}
+    "price": {"prompt": "Product price", "contexts": ["urls"], "format": "number"}
   }
 }'
 ```
 
-### Check Run Status (free)
-```bash
-orth api run riveter /v1/run_status --query 'run_key=abc123'
-```
+### Run data (free)
+Retrieve the processed data from a completed project run
 
-### Get Run Data (free)
+Parameters:
+- run_key* (string) - The run key (UUID) of the project run to retrieve data for
+
 ```bash
 orth api run riveter /v1/run_data --query 'run_key=abc123'
 ```
 
-### Stop a Run (free)
+### Run status (free)
+Check the current status of a project run
+
+Parameters:
+- run_key* (string) - The run key (UUID) of the project run to check
+
+```bash
+orth api run riveter /v1/run_status --query 'run_key=abc123'
+```
+
+### Stop run (free)
+Stop a currently running project. This will halt all processing and mark the run as stopped. Behavior:  If the run is already stopped or success, returns success with current status. If the run is in progress, stops all pending cells and marks the run as stopped.  Stopped runs cannot be resumed
+
+Parameters:
+- run_key* (string) - The run key (UUID) of the project run to stop
+
 ```bash
 orth api run riveter /v1/stop_run --query 'run_key=abc123'
 ```

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -18,60 +18,36 @@ Scrape web pages and extract data into your defined structure.
 
 ### Simple Scrape ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/riveter/v1/scrape" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/article"}'
+orth api run riveter /v1/scrape --body '{"url": "https://example.com/article"}'
 ```
 
 ### Structured Extraction ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/riveter/v1/run" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://example.com/products",
-    "schema": {
-      "products": [{
-        "name": "string",
-        "price": "number",
-        "description": "string"
-      }]
-    }
-  }'
+orth api run riveter /v1/run --body '{
+  "url": "https://example.com/products",
+  "schema": {
+    "products": [{
+      "name": "string",
+      "price": "number",
+      "description": "string"
+    }]
+  }
+}'
 ```
 
 ### Check Run Status (free)
 ```bash
-curl "https://api.orth.sh/v1/run/riveter/v1/run_status?run_id=abc123" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run riveter /v1/run_status --query 'run_id=abc123'
 ```
 
 ### Get Run Data (free)
 ```bash
-curl "https://api.orth.sh/v1/run/riveter/v1/run_data?run_id=abc123" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run riveter /v1/run_data --query 'run_id=abc123'
 ```
 
 ### Stop a Run (free)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/riveter/v1/stop_run" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"run_id": "abc123"}'
-```
-
-## CLI Usage
-
-```bash
-# Simple text extraction
-orth api run riveter /v1/scrape --body '{"url": "https://news.ycombinator.com"}'
-
-# Extract products with schema
-orth api run riveter /v1/run --body '{
-  "url": "https://store.example.com",
-  "schema": {"items": [{"name": "string", "price": "number"}]}
-}'
+orth api run riveter /v1/stop_run --body '{"run_id": "abc123"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -24,30 +24,30 @@ orth api run riveter /v1/scrape --body '{"url": "https://example.com/article"}'
 ### Structured Extraction ($0.01)
 ```bash
 orth api run riveter /v1/run --body '{
-  "url": "https://example.com/products",
-  "schema": {
-    "products": [{
-      "name": "string",
-      "price": "number",
-      "description": "string"
-    }]
+  "input": {
+    "urls": ["https://example.com/products"]
+  },
+  "output": {
+    "name": {"prompt": "Product name", "contexts": ["urls"]},
+    "price": {"prompt": "Product price", "contexts": ["urls"], "format": "number"},
+    "description": {"prompt": "Product description", "contexts": ["urls"]}
   }
 }'
 ```
 
 ### Check Run Status (free)
 ```bash
-orth api run riveter /v1/run_status --query 'run_id=abc123'
+orth api run riveter /v1/run_status --query 'run_key=abc123'
 ```
 
 ### Get Run Data (free)
 ```bash
-orth api run riveter /v1/run_data --query 'run_id=abc123'
+orth api run riveter /v1/run_data --query 'run_key=abc123'
 ```
 
 ### Stop a Run (free)
 ```bash
-orth api run riveter /v1/stop_run --body '{"run_id": "abc123"}'
+orth api run riveter /v1/stop_run --query 'run_key=abc123'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-sales-prospecting/SKILL.md
+++ b/skills/orthogonal-sales-prospecting/SKILL.md
@@ -13,66 +13,52 @@ Build targeted prospect lists with verified emails and contact information.
 Search for companies matching your ICP:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/natural-language-search/companies" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "B2B SaaS startups in San Francisco with 50-200 employees Series A or B funded"
-  }'
+orth api run fiber /v1/natural-language-search/companies --body '{
+  "query": "B2B SaaS startups in San Francisco with 50-200 employees Series A or B funded"
+}'
 ```
 
 ### Step 2: Find Decision Makers
 Search for people at target companies:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/people-search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "job_titles": ["CTO", "VP Engineering", "Head of Engineering"],
-    "company_names": ["Stripe", "Figma", "Notion"],
-    "locations": ["San Francisco"]
-  }'
+orth api run fiber /v1/people-search --body '{
+  "job_titles": ["CTO", "VP Engineering", "Head of Engineering"],
+  "company_names": ["Stripe", "Figma", "Notion"],
+  "locations": ["San Francisco"]
+}'
 ```
 
 ### Step 3: Get All Emails for Company
 Find all contacts at a domain:
 
 ```bash
-curl "https://api.orth.sh/v1/run/hunter/v2/domain-search?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run hunter /v2/domain-search --query 'domain=stripe.com'
 ```
 
 ### Step 4: Find Specific Contact's Email
 Find email for a specific person:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/find-email" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "Sarah",
-    "last_name": "Chen",
-    "domain": "stripe.com"
-  }'
+orth api run sixtyfour /find-email --body '{
+  "first_name": "Sarah",
+  "last_name": "Chen",
+  "domain": "stripe.com"
+}'
 ```
 
 ### Step 5: Verify Emails
 Check deliverability before outreach:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/fiber/v1/validate-email/single" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"email": "sarah@stripe.com"}'
+orth api run fiber /v1/validate-email/single --body '{"email": "sarah@stripe.com"}'
 ```
 
 ### Step 6: Enrich with Company Data
 Get company context for personalization:
 
 ```bash
-curl "https://api.orth.sh/v1/run/brand-dev/v1/brand/retrieve?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ## Prospecting Pipeline

--- a/skills/orthogonal-sales-prospecting/SKILL.md
+++ b/skills/orthogonal-sales-prospecting/SKILL.md
@@ -23,9 +23,11 @@ Search for people at target companies:
 
 ```bash
 orth api run fiber /v1/people-search --body '{
-  "job_titles": ["CTO", "VP Engineering", "Head of Engineering"],
-  "company_names": ["Stripe", "Figma", "Notion"],
-  "locations": ["San Francisco"]
+  "searchParams": {
+    "job_titles": ["CTO", "VP Engineering", "Head of Engineering"],
+    "company_names": ["Stripe", "Figma", "Notion"],
+    "locations": ["San Francisco"]
+  }
 }'
 ```
 
@@ -41,9 +43,11 @@ Find email for a specific person:
 
 ```bash
 orth api run sixtyfour /find-email --body '{
-  "first_name": "Sarah",
-  "last_name": "Chen",
-  "domain": "stripe.com"
+  "lead": {
+    "first_name": "Sarah",
+    "last_name": "Chen",
+    "domain": "stripe.com"
+  }
 }'
 ```
 
@@ -66,16 +70,20 @@ orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```bash
 # 1. Find companies (Fiber)
 orth api run fiber /v1/company-search --body '{
-  "industries": ["Software", "SaaS"],
-  "employee_count_min": 50,
-  "employee_count_max": 500,
-  "locations": ["San Francisco", "New York"]
+  "searchParams": {
+    "industries": ["Software", "SaaS"],
+    "employee_count_min": 50,
+    "employee_count_max": 500,
+    "locations": ["San Francisco", "New York"]
+  }
 }'
 
 # 2. Find decision makers (Fiber)
 orth api run fiber /v1/people-search --body '{
-  "job_titles": ["VP Sales", "Head of Sales", "CRO"],
-  "company_domains": ["company1.com", "company2.com"]
+  "searchParams": {
+    "job_titles": ["VP Sales", "Head of Sales", "CRO"],
+    "company_domains": ["company1.com", "company2.com"]
+  }
 }'
 
 # 3. Get emails (Hunter)

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -9,16 +9,38 @@ Extract web content using AI with natural language prompts.
 
 ## Capabilities
 
-- **SmartScraper**: AI extraction with natural language ($0.04)
-- **SearchScraper**: AI-powered web search ($0.12)
-- **Crawl**: Crawl websites with AI extraction ($0.04)
-- **Markdownify**: Convert pages to markdown ($0.03)
-- **Sitemap**: Extract all URLs from a site ($0.01)
-- **Raw Scrape**: Get raw HTML content ($0.03)
+- **Start SmartScraper**: Extract content from a webpage using AI by providing a natural language prompt and a URL ($0.04)
+- **Start SearchScraper**: Start a new AI-powered web search request ($0.12)
+- **Scrape**: Extract raw HTML content from web pages with JavaScript rendering support ($0.03)
+- **Start SmartCrawler**: Start a new web crawl request with AI extraction or markdown conversion ($0.04)
+- **Start Sitemap**: Extract all URLs from a website sitemap automatically ($0.01)
+- **Start Markdownify**: Convert any webpage into clean, readable Markdown format ($0.03)
+- **Get SearchScraper Status**: Get the status and results of a previous search request (free)
+- **Get Markdownify Status**: Check the status and retrieve results of a Markdownify request (free)
+- **Get Sitemap Status**: Check the status and retrieve results of a Sitemap request (free)
+- **Get SmartCrawler Status**: Get the status and results of a previous smartcrawl request (free)
+- **Get SmartScraper Status**: Check the status and retrieve results of a SmartScraper request (free)
 
 ## Usage
 
-### SmartScraper - AI Extraction ($0.04)
+### Start SmartScraper ($0.04)
+Extract content from a webpage using AI by providing a natural language prompt and a URL.
+
+Parameters:
+- user_prompt* (string) - Natural language description of what information you want to extract from the webpage.
+- website_url* (string) - The URL of the webpage you want to extract information from. You must provide exactly one of: website_url, website_html, or website_markdown.
+- website_html (string) - Raw HTML content to process directly (max 2MB). Mutually exclusive with website_url and website_markdown. Useful when you already have HTML content cached or want to process modified HTML.
+- headers (object) - Optional custom HTTP headers to send with the request. Useful for setting User-Agent, cookies, authentication tokens, and other request metadata. Example: {"User-Agent": "Mozilla/5.0...", "Cookie": "session=abc123"}
+- output_schema (object) - Optional schema to structure the output. If provided, the AI will attempt to format the results according to this schema.
+- stealth (boolean) - Enable stealth mode to bypass bot protection using advanced anti-detection techniques. Adds +4 credits to the request cost
+-  website_markdown (string) - Raw Markdown content to process directly (max 2MB). Mutually exclusive with website_url and website_html. Perfect for extracting structured data from Markdown documentation, README files, or any content already in Markdown format.
+- total_pages (number) - Optional parameter to enable pagination and scrape multiple pages. Specify the number of pages to extract data from. Default: 1 Range: 1-100
+-  number_of_scrolls (number) - Optional parameter for infinite scroll pages. Specify how many times to scroll down to load more content before extraction. Default: 0 Range: 0-50
+-  render_heavy_js (boolean) - Optional parameter to enable enhanced JavaScript rendering for heavy JS websites (React, Vue, Angular, SPAs). Use when standard rendering doesn’t capture all content. Default: false
+-  mock (boolean) - Optional parameter to enable mock mode. When set to true, the request will return mock data instead of performing an actual extraction. Useful for testing and development. Default: false
+-  cookies (object) - Optional cookies object for authentication and session management. Useful for accessing authenticated pages or maintaining session state. Example: {"session_id": "abc123", "auth_token": "xyz789"}
+-  steps (array) - Optional array of interaction steps to perform on the webpage before extraction. Each step is a string describing the action to take (e.g., “click on filter button”, “wait for results to load”). Example: ["click on search button", "type query in search box", "wait for results"]
+
 ```bash
 orth api run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com/products",
@@ -26,19 +48,51 @@ orth api run scrapegraph /v1/smartscraper --body '{
 }'
 ```
 
-### Check SmartScraper Status (free)
+### Start SearchScraper ($0.12)
+Start a new AI-powered web search request
+
+Parameters:
+- user_prompt* (string) - The search query or question you want to ask. This should be a clear and specific prompt that will guide the AI in finding and extracting relevant information. Example: “What is the latest version of Python and what are its main features?”
+- headers (object) - Optional headers to customize the search behavior. This can include user agent, cookies, or other HTTP headers. Example: {   "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",   "Cookie": "cookie1=value1; cookie2=value2" }
+- output_schema (object) - Optional schema to structure the output. If provided, the AI will attempt to format the results according to this schema. Example: {   "properties": {     "version": {"type": "string"},     "release_date": {"type": "string"},     "major_features": {"type": "array", "items": {"type": "string"}}   },   "required": ["version", "release_date", "major_features"] }
+- mock (string) - Optional parameter to enable mock mode. When set to true, the request will return mock data instead of performing an actual search. Useful for testing and development. Default: false
+- stealth (boolean) - Optional parameter to enable stealth mode. When set to true, the scraper will use advanced anti-detection techniques to bypass bot protection and access protected websites. Adds +4 credits to the request cost. Default: false
+
 ```bash
-orth api run scrapegraph /v1/smartscraper/{request_id}
+orth api run scrapegraph /v1/searchscraper --body '{"user_prompt": "Find the latest iPhone prices from major retailers"}'
 ```
 
-### SearchScraper - AI Web Search ($0.12)
+### Scrape ($0.03)
+Extract raw HTML content from web pages with JavaScript rendering support
+
+Parameters:
+- website_url* (string) - The URL of the webpage to scrape. Example: "https://example.com"
+- render_heavy_js (boolean) - Set to true for heavy JavaScript rendering. Default: false
+- branding (boolean) - Return extracted brand design and metadata. Default: false
+- stealth (string) - Enable stealth mode for anti-bot protection. Adds additional credits. Default: false
+
 ```bash
-orth api run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "Find the latest iPhone prices from major retailers"
-}'
+orth api run scrapegraph /v1/scrape --body '{"website_url": "https://example.com"}'
 ```
 
-### Crawl with AI ($0.04)
+### Start SmartCrawler ($0.04)
+Start a new web crawl request with AI extraction or markdown conversion
+
+Parameters:
+- url* (string)
+- prompt (string)
+- extraction_mode (boolean)
+- cache_website (boolean)
+- depth (number)
+- max_pages (number)
+- same_domain_only (boolean)
+- batch_size (integer)
+- schema (object)
+- rules (object)
+- sitemap (string)
+- render_heavy_js (string)
+- stealth (string)
+
 ```bash
 orth api run scrapegraph /v1/crawl --body '{
   "url": "https://docs.example.com",
@@ -46,19 +100,64 @@ orth api run scrapegraph /v1/crawl --body '{
 }'
 ```
 
-### Convert to Markdown ($0.03)
-```bash
-orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
-```
+### Start Sitemap ($0.01)
+Extract all URLs from a website sitemap automatically.
 
-### Get Sitemap ($0.01)
+Parameters:
+- website_url* (string) - The URL of the website you want to extract the sitemap from. The API will automatically locate the sitemap.xml file.
+- headers (object) - Optional headers to customize the request behavior. This can include user agent, cookies, or other HTTP headers.
+- mock (boolean) - Optional parameter to enable mock mode. When set to true, the request will return mock data instead of performing an actual extraction. Useful for testing and development.
+- stealth (boolean) - Optional parameter to enable stealth mode. When set to true, the scraper will use advanced anti-detection techniques to bypass bot protection and access protected websites. Adds +4 credits to the request cost.
+
 ```bash
 orth api run scrapegraph /v1/sitemap --body '{"website_url": "https://example.com"}'
 ```
 
-### Raw HTML Scrape ($0.03)
+### Start Markdownify ($0.03)
+Convert any webpage into clean, readable Markdown format.
+
+Parameters:
+- website_url* (string) - The URL of the webpage you want to convert to markdown.
+- headers (object) - Optional headers to send with the request, including cookies and user agent
+- stealth (boolean) - Enable stealth mode to bypass bot protection using advanced anti-detection techniques. Adds +4 credits to the request cost
+
 ```bash
-orth api run scrapegraph /v1/scrape --body '{"website_url": "https://example.com"}'
+orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
+```
+
+### Get SearchScraper Status (free)
+Get the status and results of a previous search request
+
+```bash
+orth api run scrapegraph /v1/searchscraper/{request_id}
+```
+
+### Get Markdownify Status (free)
+Check the status and retrieve results of a Markdownify request.
+
+```bash
+orth api run scrapegraph /v1/markdownify/{request_id}
+```
+
+### Get Sitemap Status (free)
+Check the status and retrieve results of a Sitemap request.
+
+```bash
+orth api run scrapegraph /v1/sitemap/{request_id}
+```
+
+### Get SmartCrawler Status (free)
+Get the status and results of a previous smartcrawl request
+
+```bash
+orth api run scrapegraph /v1/crawl/{task_id}
+```
+
+### Get SmartScraper Status (free)
+Check the status and retrieve results of a SmartScraper request.
+
+```bash
+orth api run scrapegraph /v1/smartscraper/{request_id}
 ```
 
 ## Use Cases

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -20,82 +20,45 @@ Extract web content using AI with natural language prompts.
 
 ### SmartScraper - AI Extraction ($0.04)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://example.com/products",
-    "user_prompt": "Extract all product names and prices"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://example.com/products",
+  "user_prompt": "Extract all product names and prices"
+}'
 ```
 
 ### Check SmartScraper Status (free)
 ```bash
-curl "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper/{request_id}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run scrapegraph /v1/smartscraper/{request_id}
 ```
 
 ### SearchScraper - AI Web Search ($0.12)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/searchscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_prompt": "Find the latest iPhone prices from major retailers"
-  }'
+orth api run scrapegraph /v1/searchscraper --body '{
+  "user_prompt": "Find the latest iPhone prices from major retailers"
+}'
 ```
 
 ### Crawl with AI ($0.04)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/crawl" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://docs.example.com",
-    "user_prompt": "Extract all API endpoints and their descriptions"
-  }'
+orth api run scrapegraph /v1/crawl --body '{
+  "website_url": "https://docs.example.com",
+  "user_prompt": "Extract all API endpoints and their descriptions"
+}'
 ```
 
 ### Convert to Markdown ($0.03)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/markdownify" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"website_url": "https://example.com/article"}'
+orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
 ```
 
 ### Get Sitemap ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/sitemap" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"website_url": "https://example.com"}'
+orth api run scrapegraph /v1/sitemap --body '{"website_url": "https://example.com"}'
 ```
 
 ### Raw HTML Scrape ($0.03)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/scrape" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"website_url": "https://example.com"}'
-```
-
-## CLI Usage
-
-```bash
-# Extract data using natural language
-orth api run scrapegraph /v1/smartscraper --body '{
-  "website_url": "https://news.ycombinator.com",
-  "user_prompt": "Extract the top 10 story titles and their point counts"
-}'
-
-# Search and extract
-orth api run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "Find Tesla stock price from financial news sites"
-}'
-
-# Convert page to markdown
-orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/docs"}'
+orth api run scrapegraph /v1/scrape --body '{"website_url": "https://example.com"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -41,8 +41,8 @@ orth api run scrapegraph /v1/searchscraper --body '{
 ### Crawl with AI ($0.04)
 ```bash
 orth api run scrapegraph /v1/crawl --body '{
-  "website_url": "https://docs.example.com",
-  "user_prompt": "Extract all API endpoints and their descriptions"
+  "url": "https://docs.example.com",
+  "prompt": "Extract all API endpoints and their descriptions"
 }'
 ```
 

--- a/skills/orthogonal-searchapi/SKILL.md
+++ b/skills/orthogonal-searchapi/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: searchapi
+description: Multi-platform search - YouTube, Amazon, eBay, Walmart, TikTok, Instagram, and more
+---
+
+# SearchAPI - Multi-Platform Search
+
+Search across YouTube, Amazon, eBay, Walmart, TikTok, Instagram, Airbnb, and ad libraries.
+
+## Capabilities
+
+- **TripAdvisor Search**: Search TripAdvisor listings ($0.01)
+- **YouTube Comments**: Get comments on a YouTube video ($0.01)
+- **YouTube Channel**: Get YouTube channel info ($0.01)
+- **Reddit Ad Library**: Search Reddit ads library ($0.01)
+- **Meta Ad Library**: Search Meta/Facebook ads library ($0.01)
+- **YouTube Transcripts**: Get video transcript/captions ($0.01)
+- **Amazon Search**: Search Amazon products ($0.01)
+- **eBay Search**: Search eBay listings ($0.01)
+- **YouTube Video Details**: Get detailed info about a YouTube video ($0.01)
+- **YouTube Channel Videos**: Get videos from a YouTube channel ($0.01)
+- **Apple App Store Search**: Search Apple App Store apps ($0.01)
+- **Airbnb Search**: Search Airbnb listings ($0.01)
+- **TikTok Profile**: Get TikTok user profile info ($0.01)
+- **Instagram Profile**: Get Instagram profile info ($0.01)
+- **Walmart Search**: Search Walmart products ($0.01)
+- **TikTok Ads Library**: Search TikTok ads library ($0.01)
+- **LinkedIn Ad Library**: Search LinkedIn ads library ($0.01)
+- **YouTube Search**: Search YouTube videos by query ($0.01)
+
+## Usage
+
+### TripAdvisor Search ($0.01)
+Search TripAdvisor listings
+
+Parameters:
+- engine* (string)
+- q* (string) - Search query
+- tripadvisor_domain (string) - TripAdvisor domain
+- category (string) - Category filter (all, hotels, restaurants, attractions)
+- location (string) - Location filter
+- lat (number) - Latitude for geo search
+- lon (number) - Longitude for geo search
+- page (integer) - Page number
+- num (integer) - Number of results
+
+```bash
+orth api run searchapi /api/v1/search --query engine=tripadvisor q=best%20restaurants%20NYC
+```
+
+### YouTube Comments ($0.01)
+Get comments on a YouTube video
+
+Parameters:
+- engine* (string)
+- video_id* (string) - YouTube video ID
+- gl (string) - Country code
+- hl (string) - Language code
+- next_page_token (string) - Pagination token
+
+```bash
+orth api run searchapi /api/v1/search --query engine=youtube_comments video_id=dQw4w9WgXcQ
+```
+
+### YouTube Channel ($0.01)
+Get YouTube channel info
+
+Parameters:
+- engine* (string)
+- channel_id* (string) - YouTube channel ID
+- gl (string) - Country code
+- hl (string) - Language code
+
+```bash
+orth api run searchapi /api/v1/search --query engine=youtube_channel channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw
+```
+
+### Reddit Ad Library ($0.01)
+Search Reddit ads library
+
+Parameters:
+- engine* (string)
+- q* (string) - Search query
+- industry (string) - Industry filter
+- objective_type (string) - Campaign objective
+- budget_category (string) - Budget category
+- placements (string) - Ad placements
+- post_type (string) - Post type filter
+
+```bash
+orth api run searchapi /api/v1/search --query engine=reddit_ad_library q=software
+```
+
+### Meta Ad Library ($0.01)
+Search Meta/Facebook ads library
+
+Parameters:
+- engine* (string)
+- q (string) - Search query
+- page_id (string) - Facebook page ID
+- location_id (string) - Location ID
+- country (string) - Country code
+- content_languages (string) - Content language filter
+- active_status (string) - Active status filter
+- ad_type (string) - Ad type filter
+- media_type (string) - Media type filter
+- platforms (string) - Platform filter (facebook, instagram)
+- sort_by (string) - Sort order
+- start_date (string) - Start date filter
+- end_date (string) - End date filter
+- next_page_token (string) - Pagination token
+
+```bash
+orth api run searchapi /api/v1/search --query engine=meta_ad_library q=AI%20tools
+```
+
+### YouTube Transcripts ($0.01)
+Get video transcript/captions
+
+Parameters:
+- engine* (string)
+- video_id* (string) - YouTube video ID
+- lang (string) - Transcript language code
+- transcript_type (string) - Type of transcript
+- transcript_name (string) - Name of specific transcript
+- only_available (boolean) - Only return available transcripts
+
+```bash
+orth api run searchapi /api/v1/search --query engine=youtube_transcripts video_id=dQw4w9WgXcQ
+```
+
+### Amazon Search ($0.01)
+Search Amazon products
+
+Parameters:
+- engine* (string)
+- q* (string) - Search query
+- amazon_domain (string) - Amazon domain (e.g. amazon.com, amazon.co.uk)
+- language (string) - Language code
+- delivery_country (string) - Delivery country code
+- page (integer) - Page number
+- sort_by (string) - Sort order
+- price_min (number) - Minimum price filter
+- price_max (number) - Maximum price filter
+- rh (string) - Refinement filters
+
+```bash
+orth api run searchapi /api/v1/search --query engine=amazon_search q=wireless%20headphones
+```
+
+### eBay Search ($0.01)
+Search eBay listings
+
+Parameters:
+- engine* (string)
+- q* (string) - Search query
+- ebay_domain (string) - eBay domain (e.g. ebay.com)
+- country (string) - Country code
+- delivery_country (string) - Delivery country
+- page (integer) - Page number
+- num (integer) - Number of results
+- layout (string) - Results layout
+- sort_by (string) - Sort order
+- price_min (number) - Minimum price
+- price_max (number) - Maximum price
+- condition (string) - Item condition filter
+- buying_format (string) - Buying format filter
+- category_id (string) - Category ID
+- postal_code (string) - Postal code for local
+- distance_radius (integer) - Distance radius in miles
+
+```bash
+orth api run searchapi /api/v1/search --query engine=ebay_search q=vintage%20watch
+```
+
+### YouTube Video Details ($0.01)
+Get detailed info about a YouTube video
+
+Parameters:
+- engine* (string)
+- video_id* (string) - YouTube video ID
+- gl (string) - Country code
+- hl (string) - Language code
+
+```bash
+orth api run searchapi /api/v1/search --query engine=youtube_video video_id=dQw4w9WgXcQ
+```
+
+### YouTube Channel Videos ($0.01)
+Get videos from a YouTube channel
+
+Parameters:
+- engine* (string)
+- channel_id* (string) - YouTube channel ID
+- gl (string) - Country code
+- hl (string) - Language code
+
+```bash
+orth api run searchapi /api/v1/search --query engine=youtube_channel_videos channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw
+```
+
+### Apple App Store Search ($0.01)
+Search Apple App Store apps
+
+Parameters:
+- engine* (string)
+- term* (string) - Search term
+- country (string) - Country code (e.g. us, gb)
+- lang (string) - Language code
+- page (integer) - Page number
+- num (integer) - Number of results
+- device (string) - Device filter (iphone, ipad)
+- property (string) - Property filter
+- include_explicit (boolean) - Include explicit content
+
+```bash
+orth api run searchapi /api/v1/search --query engine=apple_app_store term=productivity
+```
+
+### Airbnb Search ($0.01)
+Search Airbnb listings
+
+Parameters:
+- engine* (string)
+- q* (string) - Location query
+- airbnb_domain (string) - Airbnb domain
+- currency (string) - Currency code (e.g. USD, EUR)
+- check_in_date (string) - Check-in date (YYYY-MM-DD)
+- check_out_date (string) - Check-out date (YYYY-MM-DD)
+- time_period (string) - Flexible time period
+- adults (integer) - Number of adults
+- children (integer) - Number of children
+- infants (integer) - Number of infants
+- pets (integer) - Number of pets
+- price_min (number) - Minimum price
+- price_max (number) - Maximum price
+- bedrooms (integer) - Number of bedrooms
+- beds (integer) - Number of beds
+- bathrooms (integer) - Number of bathrooms
+- property_types (string) - Property type filter
+- type_of_place (string) - Entire place/private room/shared
+- amenities (string) - Amenities filter
+
+```bash
+orth api run searchapi /api/v1/search --query engine=airbnb q=Paris
+```
+
+### TikTok Profile ($0.01)
+Get TikTok user profile info
+
+Parameters:
+- engine* (string)
+- username* (string) - TikTok username
+
+```bash
+orth api run searchapi /api/v1/search --query engine=tiktok_profile username=openai
+```
+
+### Instagram Profile ($0.01)
+Get Instagram profile info
+
+Parameters:
+- engine* (string)
+- username* (string) - Instagram username
+
+```bash
+orth api run searchapi /api/v1/search --query engine=instagram_profile username=openai
+```
+
+### Walmart Search ($0.01)
+Search Walmart products
+
+Parameters:
+- engine* (string)
+- q* (string) - Search query
+- page (integer) - Page number
+- sort_by (string) - Sort order
+- price_min (number) - Minimum price
+- price_max (number) - Maximum price
+- category_id (string) - Category ID
+- store_id (string) - Store ID for local inventory
+- filters (string) - Additional filters
+
+```bash
+orth api run searchapi /api/v1/search --query engine=walmart_search q=laptop
+```
+
+### TikTok Ads Library ($0.01)
+Search TikTok ads library
+
+Parameters:
+- engine* (string)
+- q (string) - Search query
+- advertiser_id (string) - Advertiser ID
+- country (string) - Country code
+- time_period (string) - Time period filter
+- sort_by (string) - Sort order
+- next_page_token (string) - Pagination token
+
+```bash
+orth api run searchapi /api/v1/search --query engine=tiktok_ads_library q=AI
+```
+
+### LinkedIn Ad Library ($0.01)
+Search LinkedIn ads library
+
+Parameters:
+- engine* (string)
+- q (string) - Search query
+- advertiser (string) - Advertiser name
+- country (string) - Country code
+- time_period (string) - Time period filter
+- next_page_token (string) - Pagination token
+
+```bash
+orth api run searchapi /api/v1/search --query engine=linkedin_ad_library q=hiring
+```
+
+### YouTube Search ($0.01)
+Search YouTube videos by query
+
+Parameters:
+- engine* (string)
+- q* (string) - Search query
+- sp (string) - Search filter parameter
+- gl (string) - Country code (e.g. us, uk, de)
+- hl (string) - Language code (e.g. en, de, fr)
+
+```bash
+orth api run searchapi /api/v1/search --query engine=youtube q=AI%20agents
+```
+
+## Use Cases
+
+1. **Product Research**: Compare products across Amazon, eBay, Walmart
+2. **Video Intelligence**: Search YouTube videos, channels, and transcripts
+3. **Ad Research**: Monitor ads on Meta, TikTok, Reddit, LinkedIn
+4. **Social Media**: Get TikTok and Instagram profiles
+5. **Travel**: Search Airbnb listings and TripAdvisor reviews

--- a/skills/orthogonal-seo-analyzer/SKILL.md
+++ b/skills/orthogonal-seo-analyzer/SKILL.md
@@ -13,65 +13,50 @@ Analyze websites for SEO performance, keywords, content quality, and competitor 
 Map the website structure:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/map" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+orth api run tavily /map --body '{"url": "https://example.com"}'
 ```
 
 ### Step 2: Extract Page Content
 Get content for analysis:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://example.com",
-    "user_prompt": "Extract page title, meta description, headings (H1, H2, H3), main content, and internal links"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://example.com",
+  "user_prompt": "Extract page title, meta description, headings (H1, H2, H3), main content, and internal links"
+}'
 ```
 
 ### Step 3: Analyze Competitor Keywords
 Research competitor SEO:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "site:competitor.com top ranking pages keywords",
-    "search_depth": "advanced"
-  }'
+orth api run tavily /search --body '{
+  "query": "site:competitor.com top ranking pages keywords",
+  "search_depth": "advanced"
+}'
 ```
 
 ### Step 4: Find Content Gaps
 Identify missing keywords:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "What keywords and topics should a SaaS productivity tool target for SEO? Include search volume estimates and difficulty."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "What keywords and topics should a SaaS productivity tool target for SEO? Include search volume estimates and difficulty."
+  }]
+}'
 ```
 
 ### Step 5: Get Backlink Ideas
 Find linking opportunities:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "blogs and websites that accept guest posts about productivity software",
-    "num_results": 20
-  }'
+orth api run exa /search --body '{
+  "query": "blogs and websites that accept guest posts about productivity software",
+  "num_results": 20
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-shofo/SKILL.md
+++ b/skills/orthogonal-shofo/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: shofo
+description: Social media scraping - Instagram, TikTok, LinkedIn, and X/Twitter profiles, posts, and comments
+---
+
+# Shofo - Social Media Scraping API
+
+Scrape profiles, posts, and comments from Instagram, TikTok, LinkedIn, and X/Twitter.
+
+## Capabilities
+
+- **Instagram Hashtag**: Get posts for an Instagram hashtag ($0.01)
+- **X/Twitter Tweet Comments**: Get comments/replies from an X tweet ($0.01)
+- **LinkedIn Company Posts**: Get recent posts from a LinkedIn company page ($0.01)
+- **TikTok Hashtag Videos**: Get videos for a specific hashtag ($0.01)
+- **X/Twitter User Profile**: Get X/Twitter profile data including bio, follower counts, and profile info ($0.01)
+- **TikTok Feed Videos**: Get videos from TikTok's recommendation feed ($0.01)
+- **Instagram User Profile**: Get Instagram profile data with optional followers and following lists ($0.01)
+- **TikTok User Profile Videos**: Get videos from a specific TikTok user's profile ($0.01)
+- **TikTok Video Comments**: Get comments from a TikTok video ($0.01)
+- **Linkedin User Profile**: Get comprehensive LinkedIn profile data including work experience, education, skills, and contact info ($0.01)
+- **Linkedin User Posts**: Get recent posts and activity from a LinkedIn user ($0.01)
+- **Linkedin Company Profile**: Get company information including size, industry, locations, and specialties ($0.01)
+- **Linkedin Search Employees**: Search LinkedIn people by company or school ($0.01)
+- **Instagram User Posts**: Get posts or reels from an Instagram user's profile ($0.01)
+- **Instagram Individual Post**: Get detailed data for a specific Instagram post by shortcode or URL ($0.01)
+- **Instagram Post Comments**: Get comments from an Instagram post ($0.01)
+- **X/Twitter User Posts**: Get tweets from a user's profile ($0.01)
+- **X/Twitter Individual Post**: Get detailed data for a specific tweet by ID or URL ($0.01)
+
+## Usage
+
+### Instagram Hashtag ($0.01)
+Get posts for an Instagram hashtag.
+
+Parameters:
+- keyword* (string) - Hashtag keyword (without #)
+- count* (string) - Number of posts to retrieve
+- feed_type (string) - Feed type: "top", "recent", or "reels"
+
+```bash
+orth api run shofo /instagram/hashtag --query 'hashtag=artificialintelligence'
+```
+
+### X/Twitter Tweet Comments ($0.01)
+Get comments/replies from an X tweet.
+
+Parameters:
+- tweet_id* (string) - X/Twitter tweet ID
+- count (string) - Number of comments (min: 10)
+- cursor (string) - Pagination cursor from previous response
+
+```bash
+orth api run shofo /x/comments --query 'tweet_url=https://x.com/OpenAI/status/123456'
+```
+
+### LinkedIn Company Posts ($0.01)
+Get recent posts from a LinkedIn company page.
+
+Parameters:
+- company (string) - Company name/slug (e.g., "orthogonal")
+- company_id (string) - LinkedIn company ID (if known)
+- count* (integer) - Number of posts to retrieve
+- sort_by (string) - "top" for popular, "recent" for newest (default: top)
+
+```bash
+orth api run shofo /linkedin/company-posts --query 'url=https://linkedin.com/company/openai'
+```
+
+### TikTok Hashtag Videos ($0.01)
+Get videos for a specific hashtag. Great for campaign tracking and trend monitoring.
+
+Parameters:
+- hashtag (string) - Hashtag to search (without #)
+- challenge_id (string) - Challenge ID (alternative to hashtag)
+- count* (integer) - Number of videos to retrieve
+- cursor (string) - Pagination cursor from previous response
+
+```bash
+orth api run shofo /tiktok/hashtag --query 'hashtag=ai'
+```
+
+### X/Twitter User Profile ($0.01)
+Get X/Twitter profile data including bio, follower counts, and profile info.
+
+Parameters:
+- username* (string) - X/Twitter username (without @)
+
+```bash
+orth api run shofo /x/user-profile --query 'username=OpenAI'
+```
+
+### TikTok Feed Videos ($0.01)
+Get videos from TikTok's recommendation feed. Perfect for trend analysis and content discovery.
+
+Parameters:
+- count* (integer) - Number of videos to retrieve (1-100)
+
+```bash
+orth api run shofo /tiktok/feed --query 'keyword=artificial%20intelligence'
+```
+
+### Instagram User Profile ($0.01)
+Get Instagram profile data with optional followers and following lists.
+
+Parameters:
+- username* (string) - Instagram username (without @)
+- max_followers (integer) - Number of followers to fetch (0 = skip)
+- max_following (integer) - Number of following to fetch (0 = skip)
+
+```bash
+orth api run shofo /instagram/user-profile --query 'username=openai'
+```
+
+### TikTok User Profile Videos ($0.01)
+Get videos from a specific TikTok user's profile.
+
+Parameters:
+- username (string) - TikTok username (without @)
+- sec_uid (string) - User's sec_uid (alternative to username)
+- count* (integer) - Number of videos to retrieve
+- cursor (string) - Pagination cursor from previous response
+
+```bash
+orth api run shofo /tiktok/profile --query 'username=openai'
+```
+
+### TikTok Video Comments ($0.01)
+Get comments from a TikTok video.
+
+Parameters:
+- video_id* (string) - TikTok video ID (aweme_id)
+- count (integer) - Number of comments (min: 10)
+- cursor (integer) - Pagination cursor from previous response
+
+```bash
+orth api run shofo /tiktok/comments --query 'video_url=https://tiktok.com/@user/video/123'
+```
+
+### Linkedin User Profile ($0.01)
+Get comprehensive LinkedIn profile data including work experience, education, skills, and contact info.
+
+Parameters:
+- username* (string) - LinkedIn username (from URL: linkedin.com/in/username). Provide either profile_url or username.
+
+```bash
+orth api run shofo /linkedin/user-profile --query 'url=https://linkedin.com/in/johndoe'
+```
+
+### Linkedin User Posts ($0.01)
+Get recent posts and activity from a LinkedIn user.
+
+Parameters:
+- username* (string) - LinkedIn username (from URL: linkedin.com/in/username)
+- count* (integer) - Number of posts to retrieve
+
+```bash
+orth api run shofo /linkedin/user-posts --query 'url=https://linkedin.com/in/johndoe'
+```
+
+### Linkedin Company Profile ($0.01)
+Get company information including size, industry, locations, and specialties.
+
+Parameters:
+- company (string) - Company name/slug (e.g., "orthogonal")
+- company_id (string) - LinkedIn company ID (if known)
+- employee_count (string) - Number of employees to fetch (default: 0)
+
+```bash
+orth api run shofo /linkedin/company-profile --query 'url=https://linkedin.com/company/openai'
+```
+
+### Linkedin Search Employees ($0.01)
+Search LinkedIn people by company or school.
+
+Parameters:
+- company (string) - Company name to search
+- school (string) - School name to search
+- current_company (string) - Current company ID filter
+- count* (integer) - Number of people to retrieve
+
+```bash
+orth api run shofo /linkedin/search-employees --query 'company_url=https://linkedin.com/company/openai'
+```
+
+### Instagram User Posts ($0.01)
+Get posts or reels from an Instagram user's profile.
+
+Parameters:
+- username* (string) - Instagram username
+- count* (integer) - Number of posts to retrieve
+- reels_only (boolean) - Fetch only reels instead of all posts
+
+```bash
+orth api run shofo /instagram/user-posts --query 'username=openai'
+```
+
+### Instagram Individual Post ($0.01)
+Get detailed data for a specific Instagram post by shortcode or URL.
+
+Parameters:
+- code_or_url* (string) - Post shortcode (e.g., DRhvwVLAHAG) or full Instagram URL. Accepted Input Formats The code_or_url parameter accepts either a shortcode or a full URL:  • Shortcode: CxYz123ABC • Post URL: https://www.instagram.com/p/CxYz123ABC/ • Reel URL: https://www.instagram.com/reel/CxYz123ABC/
+
+```bash
+orth api run shofo /instagram/post --query 'url=https://instagram.com/p/abc123'
+```
+
+### Instagram Post Comments ($0.01)
+Get comments from an Instagram post.
+
+Parameters:
+- media_id* (string) - Instagram post/media ID
+- count (integer) - Number of comments (min: 10)
+- sort_order (string) - Sort order: "popular" or "recent"
+- cursor (string) - Pagination cursor (next_min_id)
+
+```bash
+orth api run shofo /instagram/comments --query 'post_url=https://instagram.com/p/abc123'
+```
+
+### X/Twitter User Posts ($0.01)
+Get tweets from a user's profile.
+
+Parameters:
+- username* (string) - X/Twitter username
+- count* (integer) - Number of tweets to retrieve
+
+```bash
+orth api run shofo /x/user-posts --query 'username=OpenAI'
+```
+
+### X/Twitter Individual Post ($0.01)
+Get detailed data for a specific tweet by ID or URL.
+
+Parameters:
+- tweet_id_or_url* (string) - Tweet ID or full URL (twitter.com or x.com). Accepted Input Formats: The tweet_id_or_url parameter accepts either a tweet ID or a full URL:  • Tweet ID: 1808168603721650364 • twitter.com URL: https://twitter.com/user/status/1808168603721650364 • x.com URL: https://x.com/user/status/1808168603721650364
+
+```bash
+orth api run shofo /x/post --query 'url=https://x.com/OpenAI/status/123456'
+```
+
+## Use Cases
+
+1. **Social Listening**: Monitor brand mentions across platforms
+2. **Influencer Research**: Analyze influencer profiles and engagement
+3. **Competitive Analysis**: Track competitor social media activity
+4. **Content Research**: Discover trending content and hashtags
+5. **Lead Generation**: Find prospects through social profiles

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -19,34 +19,44 @@ Find contact information and enrich lead data using AI-powered discovery.
 ### Find Email ($0.05)
 ```bash
 orth api run sixtyfour /find-email --body '{
-  "first_name": "John",
-  "last_name": "Doe",
-  "company": "Acme Inc",
-  "domain": "acme.com"
+  "lead": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "company": "Acme Inc",
+    "domain": "acme.com"
+  }
 }'
 ```
 
 ### Find Phone ($0.30)
 ```bash
 orth api run sixtyfour /find-phone --body '{
-  "first_name": "John",
-  "last_name": "Doe",
-  "company": "Acme Inc"
+  "lead": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "company": "Acme Inc"
+  }
 }'
 ```
 
 ### Enrich Company ($0.10)
 ```bash
-orth api run sixtyfour /enrich-company --body '{"domain": "acme.com"}'
+orth api run sixtyfour /enrich-company --body '{
+  "target_company": {"domain": "acme.com"},
+  "struct": {"description": "Company description", "industry": "Industry"}
+}'
 ```
 
 ### Enrich Lead ($0.10)
 ```bash
 orth api run sixtyfour /enrich-lead --body '{
-  "first_name": "John",
-  "last_name": "Doe",
-  "company": "Acme Inc",
-  "linkedin_url": "https://linkedin.com/in/johndoe"
+  "lead_info": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "company": "Acme Inc",
+    "linkedin_url": "https://linkedin.com/in/johndoe"
+  },
+  "struct": {"email": "Work email", "phone": "Phone number"}
 }'
 ```
 

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -18,61 +18,36 @@ Find contact information and enrich lead data using AI-powered discovery.
 
 ### Find Email ($0.05)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/find-email" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "John",
-    "last_name": "Doe",
-    "company": "Acme Inc",
-    "domain": "acme.com"
-  }'
+orth api run sixtyfour /find-email --body '{
+  "first_name": "John",
+  "last_name": "Doe",
+  "company": "Acme Inc",
+  "domain": "acme.com"
+}'
 ```
 
 ### Find Phone ($0.30)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/find-phone" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "John",
-    "last_name": "Doe",
-    "company": "Acme Inc"
-  }'
+orth api run sixtyfour /find-phone --body '{
+  "first_name": "John",
+  "last_name": "Doe",
+  "company": "Acme Inc"
+}'
 ```
 
 ### Enrich Company ($0.10)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/enrich-company" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"domain": "acme.com"}'
+orth api run sixtyfour /enrich-company --body '{"domain": "acme.com"}'
 ```
 
 ### Enrich Lead ($0.10)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/sixtyfour/enrich-lead" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "first_name": "John",
-    "last_name": "Doe",
-    "company": "Acme Inc",
-    "linkedin_url": "https://linkedin.com/in/johndoe"
-  }'
-```
-
-## CLI Usage
-
-```bash
-# Find email for a lead
-orth api run sixtyfour /find-email --body '{"first_name": "John", "last_name": "Doe", "domain": "acme.com"}'
-
-# Enrich company data
-orth api run sixtyfour /enrich-company --body '{"domain": "stripe.com"}'
-
-# Full lead enrichment
-orth api run sixtyfour /enrich-lead --body '{"first_name": "Jane", "last_name": "Smith", "company": "OpenAI"}'
+orth api run sixtyfour /enrich-lead --body '{
+  "first_name": "John",
+  "last_name": "Doe",
+  "company": "Acme Inc",
+  "linkedin_url": "https://linkedin.com/in/johndoe"
+}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -9,14 +9,20 @@ Find contact information and enrich lead data using AI-powered discovery.
 
 ## Capabilities
 
-- **Find Phone**: Discover phone numbers for leads ($0.30)
-- **Find Email**: Find email addresses for leads ($0.05)
-- **Enrich Company**: Get comprehensive company data ($0.10)
-- **Enrich Lead**: Get complete lead profile with contact info ($0.10)
+- **Find email**: Find email address for a lead ($0.05)
+- **Enrich lead**: Enrich lead information with additional details such as contact information, social profiles, and company details ($0.10)
+- **Find Phone API**: The Find Phone API uses Sixtyfour AI to discover phone numbers for leads ($0.30)
+- **Enrich company**: Enrich company data with additional information and find associated people ($0.10)
 
 ## Usage
 
-### Find Email ($0.05)
+### Find email ($0.05)
+Find email address for a lead.
+
+Parameters:
+- lead* (object) - Lead information to find email for
+- mode (string) - Email discovery mode. Allowed values: `"PROFESSIONAL"` (default) for company emails, `"PERSONAL"` for personal emails.
+
 ```bash
 orth api run sixtyfour /find-email --body '{
   "lead": {
@@ -28,7 +34,37 @@ orth api run sixtyfour /find-email --body '{
 }'
 ```
 
-### Find Phone ($0.30)
+### Enrich lead ($0.10)
+Enrich lead information with additional details such as contact information, social profiles, and company details.
+
+Parameters:
+- lead_info* (object) - Initial lead information as key-value pairs
+- struct* (object) - Fields to collect about the lead
+- research_plan (string) - Optional research plan to guide enrichment
+
+```bash
+orth api run sixtyfour /enrich-lead --body '{
+  "lead_info": {
+    "first_name": "John",
+    "last_name": "Doe",
+    "company": "Acme Inc",
+    "linkedin_url": "https://linkedin.com/in/johndoe"
+  },
+  "struct": {"email": "Work email", "phone": "Phone number"}
+}'
+```
+
+### Find Phone API ($0.30)
+The Find Phone API uses Sixtyfour AI to discover phone numbers for leads. It extracts contact information from lead data and returns enriched results with phone numbers.
+
+Parameters:
+- lead* (object) - Lead information object
+- name (string) - Full name of the person
+- company (string) - Company name
+- linkedin_url (string) - LinkedIn profile URL
+- domain (string) - Company website domain
+- email (string) - Email address
+
 ```bash
 orth api run sixtyfour /find-phone --body '{
   "lead": {
@@ -39,24 +75,21 @@ orth api run sixtyfour /find-phone --body '{
 }'
 ```
 
-### Enrich Company ($0.10)
+### Enrich company ($0.10)
+Enrich company data with additional information and find associated people.
+
+Parameters:
+- target_company* (object) - Company data to enrich
+- struct* (object) - Fields to collect
+- lead_struct (object) - Custom schema to define the structure of returned lead data.
+- find_people (boolean) - Whether to find people associated with the company
+- research_plan (string) - Optional strategy describing how the agent should search for information
+- people_focus_prompt (string) - Description of people to find, typically includes the roles or responsibilities of the people you’re looking for
+
 ```bash
 orth api run sixtyfour /enrich-company --body '{
   "target_company": {"domain": "acme.com"},
   "struct": {"description": "Company description", "industry": "Industry"}
-}'
-```
-
-### Enrich Lead ($0.10)
-```bash
-orth api run sixtyfour /enrich-lead --body '{
-  "lead_info": {
-    "first_name": "John",
-    "last_name": "Doe",
-    "company": "Acme Inc",
-    "linkedin_url": "https://linkedin.com/in/johndoe"
-  },
-  "struct": {"email": "Work email", "phone": "Phone number"}
 }'
 ```
 

--- a/skills/orthogonal-social-listening/SKILL.md
+++ b/skills/orthogonal-social-listening/SKILL.md
@@ -13,69 +13,54 @@ Track brand mentions, competitor activity, and industry conversations across the
 Find mentions of your brand:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "\"YourBrand\" OR \"@yourbrand\" mentions reviews discussions",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "\"YourBrand\" OR \"@yourbrand\" mentions reviews discussions",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 2: Monitor Competitors
 Track competitor mentions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/exa/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Notion reviews opinions user feedback",
-    "num_results": 30,
-    "contents": {"text": true}
-  }'
+orth api run exa /search --body '{
+  "query": "Notion reviews opinions user feedback",
+  "num_results": 30,
+  "contents": {"text": true}
+}'
 ```
 
 ### Step 3: Track Industry Trends
 Monitor industry conversations:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "What are people saying about productivity software trends on Twitter, Reddit, and HackerNews this week?"
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "What are people saying about productivity software trends on Twitter, Reddit, and HackerNews this week?"
+  }]
+}'
 ```
 
 ### Step 4: Find User Feedback
 Search for product feedback:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/searchscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "user_prompt": "Find user reviews and feedback about Notion on G2, Capterra, and ProductHunt"
-  }'
+orth api run scrapegraph /v1/searchscraper --body '{
+  "user_prompt": "Find user reviews and feedback about Notion on G2, Capterra, and ProductHunt"
+}'
 ```
 
 ### Step 5: Monitor Forum Discussions
 Track community discussions:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "site:reddit.com OR site:news.ycombinator.com productivity software recommendations",
-    "search_depth": "advanced"
-  }'
+orth api run tavily /search --body '{
+  "query": "site:reddit.com OR site:news.ycombinator.com productivity software recommendations",
+  "search_depth": "advanced"
+}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -19,73 +19,44 @@ Comprehensive web search, crawling, content extraction, and deep research.
 
 ### Search ($0.02)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "latest developments in AI agents",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "latest developments in AI agents",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Deep Research ($0.50)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/research" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Compare different AI agent frameworks for production use",
-    "max_results": 20
-  }'
+orth api run tavily /research --body '{
+  "query": "Compare different AI agent frameworks for production use",
+  "max_results": 20
+}'
 ```
 
 ### Check Research Status (free)
 ```bash
-curl "https://api.orth.sh/v1/run/tavily/research/{request_id}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run tavily /research/{request_id}
 ```
 
 ### Extract Content ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/extract" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "urls": ["https://example.com/article1", "https://example.com/article2"]
-  }'
+orth api run tavily /extract --body '{
+  "urls": ["https://example.com/article1", "https://example.com/article2"]
+}'
 ```
 
 ### Crawl Website ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/crawl" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://docs.example.com",
-    "max_depth": 3
-  }'
+orth api run tavily /crawl --body '{
+  "url": "https://docs.example.com",
+  "max_depth": 3
+}'
 ```
 
 ### Map Website ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/map" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
-```
-
-## CLI Usage
-
-```bash
-# Quick search
-orth api run tavily /search --body '{"query": "best practices for RAG systems", "include_answer": true}'
-
-# Deep research
-orth api run tavily /research --body '{"query": "AI startup funding trends 2024"}'
-
-# Extract from multiple URLs
-orth api run tavily /extract --body '{"urls": ["https://news.ycombinator.com"]}'
+orth api run tavily /map --body '{"url": "https://example.com"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -9,15 +9,37 @@ Comprehensive web search, crawling, content extraction, and deep research.
 
 ## Capabilities
 
-- **Search**: Execute search queries with AI ranking ($0.02)
-- **Research**: Deep multi-query research on topics ($0.50)
-- **Extract**: Extract content from URLs ($0.01)
-- **Crawl**: Graph-based website crawling ($0.01)
-- **Map**: Explore website structure ($0.01)
+- **Tavily Search**: Execute a search query using Tavily Search ($0.016)
+- **Get Research Task Status**: Retrieve the status and results of a research task using its request ID (free)
+- **Create Research Task**: Tavily Research performs comprehensive research on a given topic by conducting multiple searches, analyzing sources, and generating a detailed research report ($0.50)
+- **Tavily Extract**: Extract web page content from one or more specified URLs using Tavily Extract ($0.01)
+- **Tavily Map**: Tavily Map traverses websites like a graph and can explore hundreds of paths in parallel with intelligent discovery to generate comprehensive site maps ($0.01)
+- **Tavily Crawl**: Tavily Crawl is a graph-based website traversal tool that can explore hundreds of paths in parallel with built-in extraction and intelligent discovery ($0.01)
 
 ## Usage
 
-### Search ($0.02)
+### Tavily Search ($0.016)
+Execute a search query using Tavily Search.
+
+Parameters:
+- query* (string) - The search query to execute with Tavily.
+- search_depth (enum<string>) - Controls the latency vs. relevance tradeoff and how results[].content is generated: advanced: Highest relevance with increased latency. Best for detailed, high-precision queries. Returns multiple semantically relevant snippets per URL (configurable via chunks_per_source). basic: A balanced option for relevance and latency. Ideal for general-purpose searches. Returns one NLP summary per URL. fast: Prioritizes lower latency while maintaining good relevance. Returns multiple semantically relevant snippets per URL (configurable via chunks_per_source). ultra-fast: Minimizes latency above all else. Best for time-critical use cases. Returns one NLP summary per URL. Cost: basic, fast, ultra-fast: 1 API Credit advanced: 2 API Credits See Search Best Practices for guidance on choosing the right search depth.
+- chunks_per_source (integer) - Chunks are short content snippets (maximum 500 characters each) pulled directly from the source. Use chunks_per_source to define the maximum number of relevant chunks returned per source and to control the content length. Chunks will appear in the content field as: <chunk 1> [...] <chunk 2> [...] <chunk 3>. Available only when search_depth is advanced.
+- max_results (integer) - The maximum number of search results to return.
+- topic (enum<string>) - The category of the search.news is useful for retrieving real-time updates, particularly about politics, sports, and major current events covered by mainstream media sources. general is for broader, more general-purpose searches that may include a wide range of sources.
+- time_range (enum<string>) - The time range back from the current date to filter results based on publish date or last updated date. Useful when looking for sources that have published or updated data.
+- start_date (string) - Will return all results after the specified start date based on publish date or last updated date. Required to be written in the format YYYY-MM-DD
+- end_date (string) - Will return all results before the specified end date based on publish date or last updated date. Required to be written in the format YYYY-MM-DD
+- include_answer (boolean) - Include an LLM-generated answer to the provided query. basic or true returns a quick answer. advanced returns a more detailed answer.
+- include_raw_content (boolean) - Include the cleaned and parsed HTML content of each search result. markdown or true returns search result content in markdown format. text returns the plain text from the results and may increase latency.
+- include_images (boolean) - Also perform an image search and include the results in the response.
+- include_image_descriptions (boolean) - When include_images is true, also add a descriptive text for each image.
+- include_favicon (boolean) - Whether to include the favicon URL for each result.
+- include_domains (string[]) - A list of domains to specifically include in the search results. Maximum 300 domains.
+- exclude_domains (string[]) - A list of domains to specifically exclude from the search results. Maximum 150 domains.
+- country (enum<string>) - Boost search results from a specific country. This will prioritize content from the selected country in the search results. Available only if topic is general.
+- auto_parameters (boolean) - When auto_parameters is enabled, Tavily automatically configures search parameters based on your query's content and intent. You can still set other parameters manually, and your explicit values will override the automatic ones. The parameters include_answer, include_raw_content, and max_results must always be set manually, as they directly affect response size. Note: search_depth may be automatically set to advanced when it's likely to improve results. This uses 2 API credits per request. To avoid the extra cost, you can explicitly set search_depth to basic.
+
 ```bash
 orth api run tavily /search --body '{
   "query": "latest developments in AI agents",
@@ -26,36 +48,90 @@ orth api run tavily /search --body '{
 }'
 ```
 
-### Deep Research ($0.50)
-```bash
-orth api run tavily /research --body '{
-  "input": "Compare different AI agent frameworks for production use"
-}'
-```
+### Get Research Task Status (free)
+Retrieve the status and results of a research task using its request ID.
 
-### Check Research Status (free)
 ```bash
 orth api run tavily /research/{request_id}
 ```
 
-### Extract Content ($0.01)
+### Create Research Task ($0.50)
+Tavily Research performs comprehensive research on a given topic by conducting multiple searches, analyzing sources, and generating a detailed research report.
+
+Parameters:
+- input* (string) - The research task or question to investigate.
+- model (enum<string>) - The model used by the research agent. "mini" is optimized for targeted, efficient research and works best for narrow or well-scoped questions. "pro" provides comprehensive, multi-angle research and is suited for complex topics that span multiple subtopics or domains
+- stream (boolean) - Whether to stream the research results as they are generated. When 'true', returns a Server-Sent Events (SSE) stream. See Streaming documentation for details.
+- output_schema (object) - A JSON Schema object that defines the structure of the research output. When provided, the research response will be structured to match this schema, ensuring a predictable and validated output shape. Must include a 'properties' field, and may optionally include 'required' field.
+- citation_format (enum<string>) - The format for citations in the research report.
+
 ```bash
-orth api run tavily /extract --body '{
-  "urls": ["https://example.com/article1", "https://example.com/article2"]
-}'
+orth api run tavily /research --body '{"input": "Compare different AI agent frameworks for production use"}'
 ```
 
-### Crawl Website ($0.01)
+### Tavily Extract ($0.01)
+Extract web page content from one or more specified URLs using Tavily Extract.
+
+Parameters:
+- urls* (string[]) - The URL to extract content from.
+- query (string) - User intent for reranking extracted content chunks. When provided, chunks are reranked based on relevance to this query.
+- chunks_per_source (integer) - Chunks are short content snippets (maximum 500 characters each) pulled directly from the source. Use chunks_per_source to define the maximum number of relevant chunks returned per source and to control the raw_content length. Chunks will appear in the raw_content field as: <chunk 1> [...] <chunk 2> [...] <chunk 3>. Available only when query is provided. Must be between 1 and 5.
+- extract_depth (enum<string>) - The depth of the extraction process. advanced extraction retrieves more data, including tables and embedded content, with higher success but may increase latency.basic extraction costs 1 credit per 5 successful URL extractions, while advanced extraction costs 2 credits per 5 successful URL extractions.
+- include_images (boolean) - Include a list of images extracted from the URLs in the response. Default is false.
+- include_favicon (boolean) - Whether to include the favicon URL for each result.
+- format (enum<string>) - The format of the extracted web page content. markdown returns content in markdown format. text returns plain text and may increase latency.
+- timeout (number) - Maximum time in seconds to wait for the URL extraction before timing out. Must be between 1.0 and 60.0 seconds. If not specified, default timeouts are applied based on extract_depth: 10 seconds for basic extraction and 30 seconds for advanced extraction.
+
+```bash
+orth api run tavily /extract --body '{"urls": ["https://example.com/article1", "https://example.com/article2"]}'
+```
+
+### Tavily Map ($0.01)
+Tavily Map traverses websites like a graph and can explore hundreds of paths in parallel with intelligent discovery to generate comprehensive site maps.
+
+Parameters:
+- url* (string) - The root URL to begin the mapping.
+- instructions (string) - Natural language instructions for the crawler. When specified, the cost increases to 2 API credits per 10 successful pages instead of 1 API credit per 10 pages.
+- max_depth (integer) - Max depth of the mapping. Defines how far from the base URL the crawler can explore.
+- max_breadth (integer) - Max number of links to follow per level of the tree (i.e., per page).
+- limit (integer) - Total number of links the crawler will process before stopping.
+- select_paths (string[]) - Regex patterns to select only URLs with specific path patterns (e.g., /docs/.*, /api/v1.*).
+- select_domains (string[]) - Regex patterns to select crawling to specific domains or subdomains (e.g., ^docs\.example\.com$).
+- exclude_paths (string[]) - Regex patterns to exclude URLs with specific path patterns (e.g., /private/.*, /admin/.*).
+- exclude_domains (string[]) - Regex patterns to exclude specific domains or subdomains from crawling (e.g., ^private\.example\.com$).
+- allow_external (boolean) - Whether to include external domain links in the final results list.
+- timeout (number<float>) - Maximum time in seconds to wait for the map operation before timing out. Must be between 10 and 150 seconds.
+
+```bash
+orth api run tavily /map --body '{"url": "https://example.com"}'
+```
+
+### Tavily Crawl ($0.01)
+Tavily Crawl is a graph-based website traversal tool that can explore hundreds of paths in parallel with built-in extraction and intelligent discovery.
+
+Parameters:
+- url* (string) - The root URL to begin the crawl.
+- instructions (string) - Natural language instructions for the crawler. When specified, the mapping cost increases to 2 API credits per 10 successful pages instead of 1 API credit per 10 pages.
+- chunks_per_source (integer) - Chunks are short content snippets (maximum 500 characters each) pulled directly from the source. Use chunks_per_source to define the maximum number of relevant chunks returned per source and to control the raw_content length. Chunks will appear in the raw_content field as: <chunk 1> [...] <chunk 2> [...] <chunk 3>. Available only when instructions are provided. Must be between 1 and 5.
+- max_depth (integer) - Max depth of the crawl. Defines how far from the base URL the crawler can explore.
+- max_breadth (integer) - Max number of links to follow per level of the tree (i.e., per page).
+- limit (integer) - Total number of links the crawler will process before stopping.
+- select_paths (string[]) - Regex patterns to select only URLs with specific path patterns (e.g., /docs/.*, /api/v1.*).
+- select_domains (string[]) - Regex patterns to select crawling to specific domains or subdomains (e.g., ^docs\.example\.com$).
+- exclude_paths (string[]) - Regex patterns to exclude URLs with specific path patterns (e.g., /private/.*, /admin/.*).
+- exclude_domains (string[]) - Regex patterns to exclude specific domains or subdomains from crawling (e.g., ^private\.example\.com$).
+- allow_external (boolean) - Whether to include external domain links in the final results list.
+- include_images (boolean) - Whether to include images in the crawl results.
+- extract_depth (enum<string>) - Advanced extraction retrieves more data, including tables and embedded content, with higher success but may increase latency. basic extraction costs 1 credit per 5 successful extractions, while advanced extraction costs 2 credits per 5 successful extractions.
+- format (enum<string>) - The format of the extracted web page content. markdown returns content in markdown format. text returns plain text and may increase latency.
+- include_favicon (boolean) - Whether to include the favicon URL for each result.
+- timeout (number<float>) - Maximum time in seconds to wait for the crawl operation before timing out. Must be between 10 and 150 seconds.
+
 ```bash
 orth api run tavily /crawl --body '{
   "url": "https://docs.example.com",
   "max_depth": 3
 }'
-```
-
-### Map Website ($0.01)
-```bash
-orth api run tavily /map --body '{"url": "https://example.com"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -29,8 +29,7 @@ orth api run tavily /search --body '{
 ### Deep Research ($0.50)
 ```bash
 orth api run tavily /research --body '{
-  "query": "Compare different AI agent frameworks for production use",
-  "max_results": 20
+  "input": "Compare different AI agent frameworks for production use"
 }'
 ```
 

--- a/skills/orthogonal-tavus/SKILL.md
+++ b/skills/orthogonal-tavus/SKILL.md
@@ -16,29 +16,15 @@ Create real-time video conversations with AI-powered digital personas.
 
 ### List Available Personas ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/tavus/v2/personas" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run tavus /v2/personas
 ```
 
 ### Start Video Conversation ($0.02)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavus/v2/conversations" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "persona_id": "your-persona-id",
-    "conversation_name": "Customer Support Call"
-  }'
-```
-
-## CLI Usage
-
-```bash
-# List all personas
-orth api run tavus /v2/personas
-
-# Start a conversation
-orth api run tavus /v2/conversations --body '{"persona_id": "abc123", "conversation_name": "Demo Call"}'
+orth api run tavus /v2/conversations --body '{
+  "persona_id": "your-persona-id",
+  "conversation_name": "Customer Support Call"
+}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-tavus/SKILL.md
+++ b/skills/orthogonal-tavus/SKILL.md
@@ -9,17 +9,24 @@ Create real-time video conversations with AI-powered digital personas.
 
 ## Capabilities
 
-- **List Personas**: Get available AI personas ($0.01)
-- **Start Conversation**: Begin a real-time video call with AI ($0.02)
+- **List Personas**: This endpoint returns a list of all Personas ($0.01)
+- **Create Conversation**: This endpoint starts a real-time video conversation with your AI replica, powered by a persona that allows it to see, hear, and respond like a human ($0.02)
 
 ## Usage
 
-### List Available Personas ($0.01)
+### List Personas ($0.01)
+This endpoint returns a list of all Personas. You can first list the Personas to choose which one you'd like to create a conversation with. Then, using the Create Conversation endpoint, you can start a conversation with that persona providing the persona ID.
+
 ```bash
 orth api run tavus /v2/personas
 ```
 
-### Start Video Conversation ($0.02)
+### Create Conversation ($0.02)
+This endpoint starts a real-time video conversation with your AI replica, powered by a persona that allows it to see, hear, and respond like a human. Provide the most relevant persona_id obtained from the List Personas endpoint.
+
+Parameters:
+- persona_id* (string) - p1b06420cfdc
+
 ```bash
 orth api run tavus /v2/conversations --body '{
   "persona_id": "your-persona-id",

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -16,29 +16,15 @@ Send SMS messages via simple HTTP API.
 
 ### Send SMS ($0.03)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/textbelt/text" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "phone": "+1234567890",
-    "message": "Hello from Orthogonal!"
-  }'
+orth api run textbelt /text --body '{
+  "phone": "+1234567890",
+  "message": "Hello from Orthogonal!"
+}'
 ```
 
 ### Check Delivery Status (free)
 ```bash
-curl "https://api.orth.sh/v1/run/textbelt/status/{message_id}" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Send a text message
-orth api run textbelt /text --body '{"phone": "+1234567890", "message": "Your code is 123456"}'
-
-# Check delivery status
-orth api run textbelt /status/{id}
+orth api run textbelt /status/{message_id}
 ```
 
 ## Limitations

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -9,22 +9,35 @@ Send SMS messages via simple HTTP API.
 
 ## Capabilities
 
-- **Send SMS**: Send text messages ($0.03)
-- **Check Status**: Check delivery status (free)
+- **Status**: Checking SMS delivery status (free)
+- **Send an SMS**: Send an SMS using HTTP POST ($0.025)
 
 ## Usage
 
-### Send SMS ($0.03)
+### Status (free)
+Checking SMS delivery status
+
+```bash
+orth api run textbelt /status/{message_id}
+```
+
+### Send an SMS ($0.025)
+Send an SMS using HTTP POST.
+Note: No Urls in text message.
+Max 800 characters
+
+Parameters:
+- phone* (string) - A phone number.  If you're in the U.S. or Canada, you can just send a normal 10-digit phone number with area code.  Outside the U.S., it is best to send the phone number in E.164 format with your country code.
+- message* (string) - The content of your SMS.
+- sender (string) - Optionally, the name of the business/organization you represent.  This field is for regulatory purposes and is not visible to the end user in most countries. If not set, sender will default to your account-wide sender name.
+- replyWebhookUrl (string) - U.S. phone numbers only: Textbelt lets you receive replies to SMS you've sent. Replies are sent by webhook, meaning you will have to set up an HTTP or HTTPS route on your website that will process inbound SMS.This will send an SMS.  If the recipient responds, Textbelt will send an HTTP POST request to the specified endpoint (in this case, https://my.site/api/handleSmsReply).  The webhook payload is application/json encoded.  Your server must interpret it like any other HTTP POST request with a JSON payload.  The JSON payload contains the following:  textId: The ID of the original text that began the conversation.  fromNumber:  The phone number of the user that sent the reply (you can use this, for example, to send them a response depending on their reply).  text: The content of their reply. Here's an example payload:  {   "textId": "123456",   "fromNumber": "+1555123456",   "text": "Here is my reply" }
+- webhookData (string) - Endpoint supports a webhookData field.  This data is passed as data in the webhook request. There is a maximum length of 100 characters in the webhookData field.
+
 ```bash
 orth api run textbelt /text --body '{
   "phone": "+1234567890",
   "message": "Hello from Orthogonal!"
 }'
-```
-
-### Check Delivery Status (free)
-```bash
-orth api run textbelt /status/{message_id}
 ```
 
 ## Limitations

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -50,7 +50,7 @@ orth api run tomba /v1/companies/find --query 'domain=anthropic.com'
 
 ### Domain Suggestions ($0.01)
 ```bash
-orth api run tomba /v1/domain-suggestions --query 'company=Google'
+orth api run tomba /v1/domain-suggestions --query 'query=Google'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -20,62 +20,37 @@ Find and verify email addresses from domains, LinkedIn profiles, or natural lang
 
 ### Domain Search ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/tomba/v1/domain-search?domain=stripe.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run tomba /v1/domain-search --query 'domain=stripe.com'
 ```
 
 ### Find Email from LinkedIn ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/tomba/v1/linkedin?url=https://linkedin.com/in/johndoe" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run tomba /v1/linkedin --query 'url=https://linkedin.com/in/johndoe'
 ```
 
 ### Verify Email ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/tomba/v1/email-verifier?email=john@example.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run tomba /v1/email-verifier --query 'email=john@example.com'
 ```
 
 ### AI Company Search ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tomba/v1/reveal/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "AI startups in San Francisco with 50+ employees"}'
+orth api run tomba /v1/reveal/search --body '{"query": "AI startups in San Francisco with 50+ employees"}'
 ```
 
 ### Email Count by Department ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/tomba/v1/email-count?domain=openai.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run tomba /v1/email-count --query 'domain=openai.com'
 ```
 
 ### Get Company Info ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/tomba/v1/companies/find?domain=anthropic.com" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run tomba /v1/companies/find --query 'domain=anthropic.com'
 ```
 
 ### Domain Suggestions ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/tomba/v1/domain-suggestions?company=Google" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
-```
-
-## CLI Usage
-
-```bash
-# Find all emails for a company
-orth api run tomba /v1/domain-search --query 'domain=notion.so'
-
-# Find email from LinkedIn profile
-orth api run tomba /v1/linkedin --query 'url=https://linkedin.com/in/example'
-
-# Verify an email
-orth api run tomba /v1/email-verifier --query 'email=test@company.com'
-
-# Search companies with AI
-orth api run tomba /v1/reveal/search --body '{"query": "fintech companies in NYC"}'
+orth api run tomba /v1/domain-suggestions --query 'company=Google'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -9,48 +9,245 @@ Find and verify email addresses from domains, LinkedIn profiles, or natural lang
 
 ## Capabilities
 
-- **Domain Search**: Find all emails for a domain ($0.01)
-- **LinkedIn Lookup**: Find email from LinkedIn URL ($0.01)
-- **Email Verification**: Verify deliverability ($0.01)
-- **Company Search**: AI-powered company search ($0.01)
-- **Email Count**: Get email counts by department ($0.01)
-- **Company Info**: Get company details from domain ($0.01)
+- **Validate Phone**: Validate a phone number and get carrier information ($0.01)
+- **Domain Status**: Check the status and availability of a domain ($0.01)
+- **Email Format**: Get the email format patterns used by a domain (e ($0.01)
+- **Find Person**: Get person information from an email address ($0.01)
+- **Combined Enrichment**: Get combined person and company information from an email ($0.01)
+- **Domain Suggestions**: Get domain suggestions for a company name ($0.01)
+- **Email Count**: Get the count of email addresses for a domain, broken down by department and seniority ($0.01)
+- **Author Finder**: Find the email address of a blog post author from the article URL ($0.01)
+- **LinkedIn Finder**: Find the email address from a LinkedIn profile URL ($0.01)
+- **Technology Stack**: Discover technologies used by a website ($0.01)
+- **Verify Email**: Verify the deliverability of an email address ($0.01)
+- **Find Company**: Get company information from a domain ($0.01)
+- **Location**: Get employee location distribution for a domain ($0.01)
+- **Domain Search**: Search emails based on a website domain ($0.01)
+- **Email Enrichment**: Enrich an email address with person and company data (name, location, social handles) ($0.01)
+- **Find Phone**: Find phone numbers associated with an email, domain, or LinkedIn profile ($0.01)
+- **Similar Domains**: Find domains similar to a given domain ($0.01)
+- **Email Finder**: Find the most likely email address from a domain name, first name, and last name ($0.01)
+- **Email Sources**: Find the sources where an email was found on the web ($0.01)
+- **Search Companies**: Search for companies using natural language queries or structured filters ($0.01)
 
 ## Usage
 
-### Domain Search ($0.01)
+### Validate Phone ($0.01)
+Validate a phone number and get carrier information.
+
+Parameters:
+- phone* (string) - Phone number to validate
+- country_code (string) - Country code (e.g., US)
+
 ```bash
-orth api run tomba /v1/domain-search --query 'domain=stripe.com'
+orth api run tomba /v1/phone-validator --query 'phone=+14155552671'
 ```
 
-### Find Email from LinkedIn ($0.01)
+### Domain Status ($0.01)
+Check the status and availability of a domain.
+
+Parameters:
+- domain* (string) - Domain to check
+
 ```bash
-orth api run tomba /v1/linkedin --query 'url=https://linkedin.com/in/johndoe'
+orth api run tomba /v1/domain-status --query 'domain=stripe.com'
 ```
 
-### Verify Email ($0.01)
+### Email Format ($0.01)
+Get the email format patterns used by a domain (e.g. first.last, firstlast).
+
+Parameters:
+- domain* (string) - Domain name, e.g. stripe.com
+
 ```bash
-orth api run tomba /v1/email-verifier --query 'email=john@example.com'
+orth api run tomba /v1/email-format --query 'domain=stripe.com'
 ```
 
-### AI Company Search ($0.01)
+### Find Person ($0.01)
+Get person information from an email address.
+
+Parameters:
+- email* (string) - Email address to look up
+
 ```bash
-orth api run tomba /v1/reveal/search --body '{"query": "AI startups in San Francisco with 50+ employees"}'
+orth api run tomba /v1/people/find --query 'email=john@stripe.com'
 ```
 
-### Email Count by Department ($0.01)
+### Combined Enrichment ($0.01)
+Get combined person and company information from an email.
+
+Parameters:
+- email* (string) - Email address to enrich
+
+```bash
+orth api run tomba /v1/combined/find --query 'email=john@stripe.com'
+```
+
+### Domain Suggestions ($0.01)
+Get domain suggestions for a company name
+
+Parameters:
+- query* (string) - The domain or company name to find suggestions for
+
+```bash
+orth api run tomba /v1/domain-suggestions --query 'query=Google'
+```
+
+### Email Count ($0.01)
+Get the count of email addresses for a domain, broken down by department and seniority.
+
+Parameters:
+- domain* (string) - Domain name, e.g. stripe.com
+
 ```bash
 orth api run tomba /v1/email-count --query 'domain=openai.com'
 ```
 
-### Get Company Info ($0.01)
+### Author Finder ($0.01)
+Find the email address of a blog post author from the article URL.
+
+Parameters:
+- url* (string) - URL of the blog post/article
+
+```bash
+orth api run tomba /v1/author-finder --query 'url=https://example.com/blog/post'
+```
+
+### LinkedIn Finder ($0.01)
+Find the email address from a LinkedIn profile URL.
+
+Parameters:
+- url* (string) - LinkedIn profile URL
+- enrich_mobile (string) - Set to true to get phone number
+
+```bash
+orth api run tomba /v1/linkedin --query 'url=https://linkedin.com/in/johndoe'
+```
+
+### Technology Stack ($0.01)
+Discover technologies used by a website.
+
+Parameters:
+- domain* (string) - Domain to analyze
+
+```bash
+orth api run tomba /v1/technology --query 'domain=stripe.com'
+```
+
+### Verify Email ($0.01)
+Verify the deliverability of an email address.
+
+Parameters:
+- email* (string) - The email address to verify
+
+```bash
+orth api run tomba /v1/email-verifier --query 'email=john@example.com'
+```
+
+### Find Company ($0.01)
+Get company information from a domain.
+
+Parameters:
+- domain* (string) - Domain name (e.g., stripe.com)
+
 ```bash
 orth api run tomba /v1/companies/find --query 'domain=anthropic.com'
 ```
 
-### Domain Suggestions ($0.01)
+### Location ($0.01)
+Get employee location distribution for a domain.
+
+Parameters:
+- domain* (string) - Domain name, e.g. stripe.com
+
 ```bash
-orth api run tomba /v1/domain-suggestions --query 'query=Google'
+orth api run tomba /v1/location --query 'ip=8.8.8.8'
+```
+
+### Domain Search ($0.01)
+Search emails based on a website domain. Returns all email addresses found on the internet for a given domain, with organization info and employee details.
+
+Parameters:
+- domain* (string) - Domain name to search, e.g. stripe.com
+- company* (string) - Company name (3-75 chars)
+- page (string) - Page number (default 1)
+- limit (string) - Results per page: 10, 20, or 50 (default 10)
+- country (string) - Two-letter country code filter
+- department (string) - Department filter: engineering, sales, finance, hr, it, marketing, operations, management, executive, legal, support, communication, software, security, pr, warehouse, diversity, administrative, facilities, accounting
+
+```bash
+orth api run tomba /v1/domain-search --query 'domain=stripe.com'
+```
+
+### Email Enrichment ($0.01)
+Enrich an email address with person and company data (name, location, social handles).
+
+Parameters:
+- email* (string) - Email address to enrich
+- enrich_mobile (string) - Set to true to get phone number
+
+```bash
+orth api run tomba /v1/enrich --query 'email=john@stripe.com'
+```
+
+### Find Phone ($0.01)
+Find phone numbers associated with an email, domain, or LinkedIn profile.
+
+Parameters:
+- email (string) - Email address to find phone for
+- domain (string) - Domain to find phone numbers for
+- linkedin (string) - LinkedIn profile URL
+- full (boolean) - Set to true to get all phone numbers
+
+```bash
+orth api run tomba /v1/phone-finder --query domain=stripe.com first_name=John last_name=Doe
+```
+
+### Similar Domains ($0.01)
+Find domains similar to a given domain.
+
+Parameters:
+- domain* (string) - Domain to find similar domains for
+
+```bash
+orth api run tomba /v1/similar --query 'domain=stripe.com'
+```
+
+### Email Finder ($0.01)
+Find the most likely email address from a domain name, first name, and last name.
+
+Parameters:
+- domain* (string) - Domain name, e.g. stripe.com
+- company* (string) - Company name (3-75 chars)
+- full_name (string) - Full name of the person
+- first_name (string) - First name of the person
+- last_name (string) - Last name of the person
+- enrich_mobile (string) - Set to true to get phone number
+
+```bash
+orth api run tomba /v1/email-finder --query domain=stripe.com first_name=John last_name=Doe
+```
+
+### Email Sources ($0.01)
+Find the sources where an email was found on the web.
+
+Parameters:
+- email* (string) - Email address to find sources for
+
+```bash
+orth api run tomba /v1/email-sources --query 'email=john@stripe.com'
+```
+
+### Search Companies ($0.01)
+Search for companies using natural language queries or structured filters. AI assistant generates appropriate filters from your query.
+
+Parameters:
+- query (string) - Natural language query (8-100 chars). AI generates filters from this. Use only on first request, then use filters for pagination.
+- filters (object) - Structured filters: company, location_country, location_city, location_state, industry, size, type, keywords, founded, technologies, similar, revenue, sic, naics. Each has include/exclude arrays.
+- page (integer) - Page number for pagination (1-1000, default: 1)
+
+```bash
+orth api run tomba /v1/reveal/search --body '{"query": "AI startups in San Francisco with 50+ employees"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-travel-planner/SKILL.md
+++ b/skills/orthogonal-travel-planner/SKILL.md
@@ -13,78 +13,62 @@ Create comprehensive travel plans including flights, hotels, activities, and day
 Get an overview of your destination:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/research" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "Complete travel guide to Tokyo Japan - best time to visit, neighborhoods, attractions, food, culture tips"
-  }'
+orth api run tavily /research --body '{
+  "query": "Complete travel guide to Tokyo Japan - best time to visit, neighborhoods, attractions, food, culture tips"
+}'
 ```
 
 ### Step 2: Find Flights
 Search for flight options:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/answers" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "What are the best flights from Los Angeles to Tokyo in March 2025? Compare prices and airlines."
-  }'
+orth api run olostep /v1/answers --body '{
+  "question": "What are the best flights from Los Angeles to Tokyo in March 2025? Compare prices and airlines."
+}'
 ```
 
 ### Step 3: Find Accommodations
 Search for hotels by neighborhood:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Best hotels in Shibuya Tokyo for tourists. Include price ranges and what each area is best for."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Best hotels in Shibuya Tokyo for tourists. Include price ranges and what each area is best for."
+  }]
+}'
 ```
 
 ### Step 4: Plan Activities
 Get activity and attraction recommendations:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "query": "best things to do in Tokyo 5 days itinerary must-see attractions hidden gems",
-    "search_depth": "advanced",
-    "include_answer": true
-  }'
+orth api run tavily /search --body '{
+  "query": "best things to do in Tokyo 5 days itinerary must-see attractions hidden gems",
+  "search_depth": "advanced",
+  "include_answer": true
+}'
 ```
 
 ### Step 5: Create Itinerary
 Generate a day-by-day plan:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/perplexity/chat/completions" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "sonar",
-    "messages": [{
-      "role": "user",
-      "content": "Create a detailed 5-day Tokyo itinerary. Day 1: Shibuya/Harajuku, Day 2: Historic sites, etc. Include specific attractions, restaurants, and time estimates."
-    }]
-  }'
+orth api run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{
+    "role": "user",
+    "content": "Create a detailed 5-day Tokyo itinerary. Day 1: Shibuya/Harajuku, Day 2: Historic sites, etc. Include specific attractions, restaurants, and time estimates."
+  }]
+}'
 ```
 
 ### Step 6: Get Weather Info
 Check weather for packing:
 
 ```bash
-curl "https://api.orth.sh/v1/run/precip/api/v1/daily?lat=35.6762&lon=139.6503&start=2025-03-01&end=2025-03-07" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run precip /api/v1/daily --query lat=35.6762 lon=139.6503 start=2025-03-01 end=2025-03-07
 ```
 
 ## Example Usage

--- a/skills/orthogonal-travel-planner/SKILL.md
+++ b/skills/orthogonal-travel-planner/SKILL.md
@@ -14,7 +14,7 @@ Get an overview of your destination:
 
 ```bash
 orth api run tavily /research --body '{
-  "query": "Complete travel guide to Tokyo Japan - best time to visit, neighborhoods, attractions, food, culture tips"
+  "input": "Complete travel guide to Tokyo Japan - best time to visit, neighborhoods, attractions, food, culture tips"
 }'
 ```
 
@@ -23,7 +23,7 @@ Search for flight options:
 
 ```bash
 orth api run olostep /v1/answers --body '{
-  "question": "What are the best flights from Los Angeles to Tokyo in March 2025? Compare prices and airlines."
+  "task": "What are the best flights from Los Angeles to Tokyo in March 2025? Compare prices and airlines."
 }'
 ```
 
@@ -68,7 +68,7 @@ orth api run perplexity /chat/completions --body '{
 Check weather for packing:
 
 ```bash
-orth api run precip /api/v1/daily --query lat=35.6762 lon=139.6503 start=2025-03-01 end=2025-03-07
+orth api run precip /api/v1/daily --query latitude=35.6762 longitude=139.6503 start=2025-03-01 end=2025-03-07
 ```
 
 ## Example Usage
@@ -76,7 +76,7 @@ orth api run precip /api/v1/daily --query lat=35.6762 lon=139.6503 start=2025-03
 ```bash
 # Quick destination research
 orth api run tavily /research --body '{
-  "query": "Barcelona Spain travel guide best neighborhoods beaches food nightlife"
+  "input": "Barcelona Spain travel guide best neighborhoods beaches food nightlife"
 }'
 
 # Budget trip planning

--- a/skills/orthogonal-uptime-monitor/SKILL.md
+++ b/skills/orthogonal-uptime-monitor/SKILL.md
@@ -13,76 +13,58 @@ Monitor website uptime, check response times, and verify service availability.
 Verify site is accessible:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://yoursite.com"}'
+orth api run linkup /fetch --body '{"url": "https://yoursite.com"}'
 ```
 
 ### Step 2: Verify Page Content
 Ensure page loads correctly:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://yoursite.com",
-    "user_prompt": "Check if page loads and contains expected content. Report any error messages."
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://yoursite.com",
+  "user_prompt": "Check if page loads and contains expected content. Report any error messages."
+}'
 ```
 
 ### Step 3: Test API Health
 Check API endpoints:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/linkup/fetch" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://api.yoursite.com/health"}'
+orth api run linkup /fetch --body '{"url": "https://api.yoursite.com/health"}'
 ```
 
 ### Step 4: Check Multiple Endpoints
 Monitor critical paths:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/batches" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "urls": [
-      "https://yoursite.com",
-      "https://yoursite.com/login",
-      "https://api.yoursite.com/health",
-      "https://yoursite.com/dashboard"
-    ]
-  }'
+orth api run olostep /v1/batches --body '{
+  "urls": [
+    "https://yoursite.com",
+    "https://yoursite.com/login",
+    "https://api.yoursite.com/health",
+    "https://yoursite.com/dashboard"
+  ]
+}'
 ```
 
 ### Step 5: Research Status Page
 Check official status:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://status.yoursite.com",
-    "user_prompt": "Extract current service status, any incidents, and affected components"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://status.yoursite.com",
+  "user_prompt": "Extract current service status, any incidents, and affected components"
+}'
 ```
 
 ### Step 6: Send Alert (if down)
 Use SMS for critical alerts:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/textbelt/text" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "phone": "+1234567890",
-    "message": "ALERT: yoursite.com is down! Check immediately."
-  }'
+orth api run textbelt /text --body '{
+  "phone": "+1234567890",
+  "message": "ALERT: yoursite.com is down! Check immediately."
+}'
 ```
 
 ## Monitoring Script

--- a/skills/orthogonal-valyu/SKILL.md
+++ b/skills/orthogonal-valyu/SKILL.md
@@ -9,42 +9,180 @@ Search the web, get AI answers, extract content, and run deep research tasks.
 
 ## Capabilities
 
-- **Search**: Search web and proprietary data ($0.01)
-- **Answer**: AI-generated answers from search ($0.01)
-- **Contents**: Extract content from URLs ($0.01)
-- **Deep Research**: Async comprehensive research ($0.01)
-- **Batch Research**: Run multiple research tasks ($0.01)
+- **Get Status**: Reference for getting deep research task status via GET /v1/deepresearch/tasks/{id}/status ($0.01)
+- **Update Task**: Reference for adding follow-up instructions to a running task via POST /v1/deepresearch/tasks/{id}/update ($0.01)
+- **Cancel Task**: Reference for cancelling a running task via POST /v1/deepresearch/tasks/{id}/cancel ($0.01)
+- **Delete Task**: Reference for deleting a task via DELETE /v1/deepresearch/tasks/{id}/delete ($0.01)
+- **Get Batch Status**: Reference for getting batch status via GET /v1/deepresearch/batches/ ($0.01)
+- **List Batch Tasks**: Reference for listing tasks in a batch via GET /v1/deepresearch/batches//tasks ($0.01)
+- **Cancel Batch**: Reference for cancelling a batch via POST /v1/deepresearch/batches//cancel ($0.01)
+- **Search**: Reference for the Valyu Search endpoint to search the web, research, and proprietary datasets via POST /v1/search ($0.01)
+- **Answer**: Reference for the Valyu Answer endpoint that blends search results into AI-generated answers via POST /v1/answer ($0.01)
+- **Contents**: Reference for the Valyu Contents endpoint that extracts clean, structured content from any URL via POST /v1/contents ($0.01)
+- **Create Batch**: Reference for creating a new batch via POST /v1/deepresearch/batches ($0.01)
+- **Create Task**: Reference for creating a new deep research task via POST /v1/deepresearch/tasks ($0.01)
+- **Add Tasks to Batch**: Reference for adding tasks to a batch via POST /v1/deepresearch/batches//tasks ($0.01)
 
 ## Usage
 
-### Search ($0.01)
-```bash
-orth api run valyu /v1/search --body '{"query": "AI agent frameworks comparison"}'
-```
+### Get Status ($0.01)
+Reference for getting deep research task status via GET /v1/deepresearch/tasks/{id}/status.
 
-### Get AI Answer ($0.01)
-```bash
-orth api run valyu /v1/answer --body '{"query": "What are the best practices for building AI agents?"}'
-```
-
-### Extract Content ($0.01)
-```bash
-orth api run valyu /v1/contents --body '{"urls": ["https://example.com/article"]}'
-```
-
-### Start Deep Research ($0.01)
-```bash
-orth api run valyu /v1/deepresearch/tasks --body '{"query": "Comprehensive analysis of vector databases market"}'
-```
-
-### Check Research Status ($0.01)
 ```bash
 orth api run valyu /v1/deepresearch/tasks/{id}/status
 ```
 
-### Create Research Batch ($0.01)
+### Update Task ($0.01)
+Reference for adding follow-up instructions to a running task via POST /v1/deepresearch/tasks/{id}/update.
+
+Parameters:
+- instruction* (string) - Follow-up instruction to add to the running task. Must be submitted before the writing phase begins.
+
+```bash
+orth api run valyu /v1/deepresearch/tasks/{id}/update --body '{"query": "Updated research query"}'
+```
+
+### Cancel Task ($0.01)
+Reference for cancelling a running task via POST /v1/deepresearch/tasks/{id}/cancel.
+
+```bash
+orth api run valyu /v1/deepresearch/tasks/{id}/cancel
+```
+
+### Delete Task ($0.01)
+Reference for deleting a task via DELETE /v1/deepresearch/tasks/{id}/delete.
+
+```bash
+orth api run valyu /v1/deepresearch/tasks/{id}/delete
+```
+
+### Get Batch Status ($0.01)
+Reference for getting batch status via GET /v1/deepresearch/batches/.
+
+```bash
+orth api run valyu /v1/deepresearch/batches/{id}
+```
+
+### List Batch Tasks ($0.01)
+Reference for listing tasks in a batch via GET /v1/deepresearch/batches//tasks.
+
+```bash
+orth api run valyu /v1/deepresearch/batches/{id}/tasks
+```
+
+### Cancel Batch ($0.01)
+Reference for cancelling a batch via POST /v1/deepresearch/batches//cancel.
+
+```bash
+orth api run valyu /v1/deepresearch/batches/{id}/cancel
+```
+
+### Search ($0.01)
+Reference for the Valyu Search endpoint to search the web, research, and proprietary datasets via POST /v1/search.
+
+Parameters:
+- query* (string) - The query string for the search
+- max_num_results (integer) - Maximum number of results to return (1-20 for standard API keys, up to 100 with a special API key)
+- search_type (enum<string>) - Type of search to perform.'web' searches and returns web content. 'proprietary' uses Valyu's full-text multimodal indicies (arxiv/pubmed/proprietary academic content). 'news' searches and returns only news articles.
+- fast_mode (boolean) - Enable fast mode for reduced latency but shorter results. Best for general purpose queries.
+- max_price (number<float>) - Maximum price in dollars for a thousand retrievals (CPM). Only applies when provided. If not provided, adjusts automatically based on search type and max number of results.
+- relevance_threshold (number<float>) - Minimum relevance score for results (0.0-1.0)
+- included_sources (string[]) - List of specific sources to search (URLs, domains or dataset names). When a URL or domain path is provided (e.g., 'https://valyu.ai/blog' or 'valyu.ai/blog'), only that specific path will be searched. For entire domains, use either the domain name (e.g., 'valyu.ai') or the base URL (e.g., 'https://valyu.ai').
+- excluded_sources (string[]) - List of specific sources to exclude from search (URLs, domains, or dataset names). When a URL or domain path is provided (e.g., 'https://valyu.ai/blog' or 'valyu.ai/blog'), only that specific path will be excluded. For entire domains, use either the domain name (e.g., 'valyu.ai') or the base URL (e.g., 'https://valyu.ai').
+- category (string) - Natural language category/guide phrase to help guide the search to the most relevant content. For example 'agentic use-cases
+- response_length (default:short) - Controls the length of content returned per result. Can be an integer for character count or predefined values: 'short' (25k), 'medium' (50k), 'large' (100k), 'max' (full)
+- country_code (string) - 2-letter ISO country code to bias search results to a specific country
+- is_tool_call (boolean) - Tunes retrieval process based on whether the API is being called by an AI agent as a tool call, or a user query.
+- start_date (string<date>) - Start date for time-filtered searches (YYYY-MM-DD)
+- end_date (string<date>) - End date for time-filtered searches (YYYY-MM-DD)
+- url_only (boolean) - When set to true, only returns URLs for results (no content). Only applies when search_type is 'web' or 'news'.
+
+```bash
+orth api run valyu /v1/search --body '{"query": "AI agent frameworks comparison"}'
+```
+
+### Answer ($0.01)
+Reference for the Valyu Answer endpoint that blends search results into AI-generated answers via POST /v1/answer.
+
+Parameters:
+- query* (string) - The search query
+- system_instructions (string) - Custom instructions for AI processing
+- structured_output (object) - JSON schema for structured output. When provided, enables JSON mode and returns structured data
+- search_type (string) - Type of search to perform
+- fast_mode (boolean) - Enable fast mode for reduced latency but shorter results. Best for general purpose queries.
+- data_max_price (number) - Maximum price in dollars for data retrieval (search costs only, does not affect AI costs)
+- included_sources (string[]) - List of specific sources to search (URLs, domains or dataset names). When a URL or domain path is provided (e.g., 'https://valyu.ai/blog' or 'valyu.ai/blog'), only that specific path will be searched. For entire domains, use either the domain name (e.g., 'valyu.ai') or the base URL (e.g., 'https://valyu.ai').
+- excluded_sources (string[]) - List of specific sources to exclude from search (URLs, domains, or dataset names). When a URL or domain path is provided (e.g., 'https://valyu.ai/blog' or 'valyu.ai/blog'), only that specific path will be excluded. For entire domains, use either the domain name (e.g., 'valyu.ai') or the base URL (e.g., 'https://valyu.ai').
+- start_date (string) - Start date filter (YYYY-MM-DD)
+- end_date (string) - End date filter (YYYY-MM-DD)
+- country_code (string) - 2-letter ISO country code to bias search results to a specific country
+- streaming (boolean) - Enable Server-Sent Events (SSE) streaming. When true, returns a stream of chunks: search_results first, then content deltas, then metadata, then [DONE].
+
+```bash
+orth api run valyu /v1/answer --body '{"query": "What are the best practices for building AI agents?"}'
+```
+
+### Contents ($0.01)
+Reference for the Valyu Contents endpoint that extracts clean, structured content from any URL via POST /v1/contents.
+
+Parameters:
+- urls* (string[]) - List of URLs to process (maximum 10 URLs per request)
+- response_length (default:short) - Content length configuration: "short": 25,000 characters (good for summaries) "medium": 50,000 characters (good for articles) "large": 100,000 characters (good for academic papers) "max": No character limit Custom integer: Specific character limit
+- max_price_dollars (number) - Maximum cost limit in dollars for the entire request. If not specified, defaults to 2x the estimated cost.
+- extract_effort (string) - Processing effort level: "normal": Fastest extraction speed (Fastest) "high": Enhanced extraction with better content quality and reliability (Slower) "auto": Automatically chooses the right effort level (Slowest)
+- screenshot (boolean) - Request page screenshots. When true, each result will include a screenshot_url field containing a pre-signed URL to a screenshot image of the page. Screenshots are captured during page rendering.
+- summary (boolean) - Toggle AI processing (false is default)
+
+```bash
+orth api run valyu /v1/contents --body '{"urls": ["https://example.com/article"]}'
+```
+
+### Create Batch ($0.01)
+Reference for creating a new batch via POST /v1/deepresearch/batches.
+
+Parameters:
+- name (string) - Optional name for the batch
+- mode (enum<string>) - DeepResearch mode for all tasks in this batch
+- output_formats ((string | object)[]) - Default output formats for all tasks (markdown, pdf, toon, or structured JSON schema). Cannot mix JSON schema with markdown/pdf. toon requires a JSON schema.
+- search (object) - Search configuration applied to all tasks in the batch (cannot be overridden per task)
+- webhook_url (string<uri>) - HTTPS URL to receive notifications when the batch completes
+- metadata (object) - Custom metadata for tracking and organization
+
 ```bash
 orth api run valyu /v1/deepresearch/batches --body '{"name": "Competitor Research"}'
+```
+
+### Create Task ($0.01)
+Reference for creating a new deep research task via POST /v1/deepresearch/tasks.
+
+Parameters:
+- query* (string) - Research query or task description
+- mode (string) - DeepResearch mode: fast: Ideal for quicker answers and lightweight research. Typically completes in ~2–5 minutes. standard: A balanced option for deeper insights without long wait times. Runs for ~10–20 minutes. heavy: Designed for in-depth, long-running research tasks. Can run for up to ~90 minutes.
+- model (string) - DeepResearch mode (deprecated, use 'mode' instead)
+- output_formats (string) - Output formats. Use ['markdown'], ['markdown', 'pdf'], or a JSON schema object for structured output. Cannot mix JSON schema with markdown/pdf.
+- strategy (string) - Natural language strategy instructions prepended to the system prompt
+- search (object) - Search configuration parameters
+- urls (string[]) - URLs to extract content from (max 10)
+- files (object[]) - File attachments (PDFs, images, documents). Max 10 files.
+- mcp_servers (object[]) - MCP server configurations for custom tools (max 5 servers)
+- code_execution (boolean) - Enable/disable code execution during research
+- previous_reports (string[]) - Previous deep research IDs to use as context (max 3)
+- webhook_url (string) - HTTPS URL for webhook notifications. When provided, Valyu will POST the full task result to this URL when the task completes or fails. The request includes X-Webhook-Signature and X-Webhook-Timestamp headers for verification. HTTP URLs are rejected—only HTTPS is supported.
+- metadata (object) - Custom metadata for tracking
+- deliverables (object[]) - Additional file outputs to generate from the research (CSV, Excel, PowerPoint, Word, PDF). Max 10 deliverables.
+
+```bash
+orth api run valyu /v1/deepresearch/tasks --body '{"query": "Comprehensive analysis of vector databases market"}'
+```
+
+### Add Tasks to Batch ($0.01)
+Reference for adding tasks to a batch via POST /v1/deepresearch/batches//tasks.
+
+Parameters:
+- tasks* (object[]) - Array of tasks to add to the batch (1-100 tasks per request)
+
+```bash
+orth api run valyu /v1/deepresearch/batches/{id}/tasks
 ```
 
 ## Use Cases

--- a/skills/orthogonal-valyu/SKILL.md
+++ b/skills/orthogonal-valyu/SKILL.md
@@ -19,61 +19,32 @@ Search the web, get AI answers, extract content, and run deep research tasks.
 
 ### Search ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/valyu/v1/search" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "AI agent frameworks comparison"}'
+orth api run valyu /v1/search --body '{"query": "AI agent frameworks comparison"}'
 ```
 
 ### Get AI Answer ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/valyu/v1/answer" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "What are the best practices for building AI agents?"}'
+orth api run valyu /v1/answer --body '{"query": "What are the best practices for building AI agents?"}'
 ```
 
 ### Extract Content ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/valyu/v1/contents" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"urls": ["https://example.com/article"]}'
+orth api run valyu /v1/contents --body '{"urls": ["https://example.com/article"]}'
 ```
 
 ### Start Deep Research ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/valyu/v1/deepresearch/tasks" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "Comprehensive analysis of vector databases market"}'
+orth api run valyu /v1/deepresearch/tasks --body '{"query": "Comprehensive analysis of vector databases market"}'
 ```
 
 ### Check Research Status ($0.01)
 ```bash
-curl "https://api.orth.sh/v1/run/valyu/v1/deepresearch/tasks/{id}/status" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY"
+orth api run valyu /v1/deepresearch/tasks/{id}/status
 ```
 
 ### Create Research Batch ($0.01)
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/valyu/v1/deepresearch/batches" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "Competitor Research"}'
-```
-
-## CLI Usage
-
-```bash
-# Quick search
-orth api run valyu /v1/search --body '{"query": "latest LLM developments"}'
-
-# Get AI answer
-orth api run valyu /v1/answer --body '{"query": "How does RAG work?"}'
-
-# Start deep research
-orth api run valyu /v1/deepresearch/tasks --body '{"query": "AI startup landscape 2024"}'
+orth api run valyu /v1/deepresearch/batches --body '{"name": "Competitor Research"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-web-scraper/SKILL.md
+++ b/skills/orthogonal-web-scraper/SKILL.md
@@ -13,76 +13,58 @@ Scrape websites, extract structured data, and convert content to usable formats.
 Extract content from a single page:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/scrapes" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com/page"}'
+orth api run olostep /v1/scrapes --body '{"url": "https://example.com/page"}'
 ```
 
 ### Step 2: AI-Powered Extraction
 Extract specific data using natural language:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/smartscraper" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "website_url": "https://example.com/products",
-    "user_prompt": "Extract all product names, prices, descriptions, and image URLs"
-  }'
+orth api run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://example.com/products",
+  "user_prompt": "Extract all product names, prices, descriptions, and image URLs"
+}'
 ```
 
 ### Step 3: Structured Extraction
 Define a schema for consistent output:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/riveter/v1/run" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://example.com/products",
-    "schema": {
-      "products": [{
-        "name": "string",
-        "price": "number",
-        "description": "string",
-        "url": "string"
-      }]
-    }
-  }'
+orth api run riveter /v1/run --body '{
+  "url": "https://example.com/products",
+  "schema": {
+    "products": [{
+      "name": "string",
+      "price": "number",
+      "description": "string",
+      "url": "string"
+    }]
+  }
+}'
 ```
 
 ### Step 4: Crawl Entire Site
 Crawl multiple pages:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/olostep/v1/crawls" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "url": "https://docs.example.com",
-    "max_pages": 50
-  }'
+orth api run olostep /v1/crawls --body '{
+  "url": "https://docs.example.com",
+  "max_pages": 50
+}'
 ```
 
 ### Step 5: Convert to Markdown
 Get clean markdown output:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/scrapegraph/v1/markdownify" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"website_url": "https://example.com/article"}'
+orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
 ```
 
 ### Step 6: Get Site Map
 Discover all URLs on a site:
 
 ```bash
-curl -X POST "https://api.orth.sh/v1/run/tavily/map" \
-  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"url": "https://example.com"}'
+orth api run tavily /map --body '{"url": "https://example.com"}'
 ```
 
 ## Example Usage

--- a/skills/orthogonal-web-scraper/SKILL.md
+++ b/skills/orthogonal-web-scraper/SKILL.md
@@ -13,7 +13,7 @@ Scrape websites, extract structured data, and convert content to usable formats.
 Extract content from a single page:
 
 ```bash
-orth api run olostep /v1/scrapes --body '{"url": "https://example.com/page"}'
+orth api run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
 ```
 
 ### Step 2: AI-Powered Extraction
@@ -31,14 +31,13 @@ Define a schema for consistent output:
 
 ```bash
 orth api run riveter /v1/run --body '{
-  "url": "https://example.com/products",
-  "schema": {
-    "products": [{
-      "name": "string",
-      "price": "number",
-      "description": "string",
-      "url": "string"
-    }]
+  "input": {
+    "urls": ["https://example.com/products"]
+  },
+  "output": {
+    "name": {"prompt": "Product name", "contexts": ["urls"]},
+    "price": {"prompt": "Product price", "contexts": ["urls"]},
+    "description": {"prompt": "Product description", "contexts": ["urls"]}
   }
 }'
 ```
@@ -48,7 +47,7 @@ Crawl multiple pages:
 
 ```bash
 orth api run olostep /v1/crawls --body '{
-  "url": "https://docs.example.com",
+  "start_url": "https://docs.example.com",
   "max_pages": 50
 }'
 ```


### PR DESCRIPTION
## Summary

- Replace all curl examples with `orth api run` CLI equivalents across 51 SKILL.md files
- Consolidate Category 1 (direct API) files from dual `## Usage` (curl) + `## CLI Usage` sections into a single `## Usage` section with CLI examples
- Convert Category 2 (workflow) files by replacing inline curl blocks in workflow steps with CLI equivalents
- Fix multi-param `--query` format to use space-separated args (`--query key1=val1 key2=val2`) instead of `&`-joined strings, per CLI spec
- All endpoints from original curl sections preserved in CLI form
- 6 files excluded per plan (weather, cool-weather, raysurfer x2, testing, email-finderer)
- Net reduction of ~924 lines (803 insertions, 1727 deletions)

## Test plan

- [x] Verified `orth api run` CLI is installed and working (v0.2.0)
- [x] Tested `--body` auto-POSTs correctly (exa /search, perplexity /search)
- [x] Tested single-param `--query` format (hunter /v2/domain-search, brand-dev, jina-s)
- [x] Tested multi-param `--query key1=val1 key2=val2` format (hunter /v2/email-finder)
- [x] Tested bare GET with no params (tavus /v2/personas)
- [x] Verified zero `curl.*api.orth.sh` references remain in modified files
- [x] Verified excluded files are untouched
- [x] Verified markdown backtick fences are balanced
- [x] Verified frontmatter intact across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)