### PR TITLE
feat: add CLI discovery hints to API skills

### DIFF
--- a/skills/orthogonal-andi/SKILL.md
+++ b/skills/orthogonal-andi/SKILL.md
@@ -54,5 +54,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show andi              # List all endpoints
-orth api show andi <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-andi/SKILL.md
+++ b/skills/orthogonal-andi/SKILL.md
@@ -54,4 +54,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show andi              # List all endpoints
+orth api show andi /v1/search   # Get endpoint details
 ```

--- a/skills/orthogonal-andi/SKILL.md
+++ b/skills/orthogonal-andi/SKILL.md
@@ -47,3 +47,12 @@ orth api run andi /v1/search --query 'q=how%20does%20RAG%20work'
 3. **Technical Lookup**: Find documentation and guides
 4. **News Monitoring**: Track current events
 5. **Competitive Intelligence**: Research companies and products
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show andi              # List all endpoints
+orth api show andi <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-apartment-hunter/SKILL.md
+++ b/skills/orthogonal-apartment-hunter/SKILL.md
@@ -74,3 +74,11 @@ orth api run perplexity /chat/completions --body '{
 - Check crime stats for the neighborhood
 - Factor in commute time and transit access
 - Ask about utilities included vs separate
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-apartment-hunter/SKILL.md
+++ b/skills/orthogonal-apartment-hunter/SKILL.md
@@ -80,5 +80,8 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep perplexity scrapegraph tavily 
+orth api show olostep
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-apartment-hunter/SKILL.md
+++ b/skills/orthogonal-apartment-hunter/SKILL.md
@@ -77,7 +77,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -85,3 +85,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-api-tester/SKILL.md
+++ b/skills/orthogonal-api-tester/SKILL.md
@@ -85,3 +85,11 @@ orth api run linkup /fetch --body '{"url": "https://api.openai.com/v1/models"}'
 - Verify response schemas match documentation
 - Check rate limits and authentication
 - Document any discrepancies found
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show linkup perplexity riveter scrapegraph 
+```

--- a/skills/orthogonal-api-tester/SKILL.md
+++ b/skills/orthogonal-api-tester/SKILL.md
@@ -91,5 +91,8 @@ orth api run linkup /fetch --body '{"url": "https://api.openai.com/v1/models"}'
 For full endpoint details and parameters:
 
 ```bash
-orth api show linkup perplexity riveter scrapegraph 
+orth api show linkup
+orth api show perplexity
+orth api show riveter
+orth api show scrapegraph 
 ```

--- a/skills/orthogonal-api-tester/SKILL.md
+++ b/skills/orthogonal-api-tester/SKILL.md
@@ -88,7 +88,7 @@ orth api run linkup /fetch --body '{"url": "https://api.openai.com/v1/models"}'
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show linkup
@@ -96,3 +96,5 @@ orth api show perplexity
 orth api show riveter
 orth api show scrapegraph 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -210,5 +210,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show brand-dev              # List all endpoints
-orth api show brand-dev <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -203,3 +203,12 @@ orth api run brand-dev /v1/brand/ai/query --body '{
 3. **Lead Enrichment**: Get company info from domains or emails
 4. **Transaction Identification**: Identify companies from transaction data
 5. **Market Research**: Classify and categorize companies
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev              # List all endpoints
+orth api show brand-dev <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -210,4 +210,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show brand-dev              # List all endpoints
+orth api show brand-dev /v1/brand/fonts   # Get endpoint details
 ```

--- a/skills/orthogonal-bug-reporter/SKILL.md
+++ b/skills/orthogonal-bug-reporter/SKILL.md
@@ -120,7 +120,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
@@ -128,3 +128,5 @@ orth api show olostep
 orth api show perplexity
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-bug-reporter/SKILL.md
+++ b/skills/orthogonal-bug-reporter/SKILL.md
@@ -123,5 +123,8 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa olostep perplexity tavily 
+orth api show exa
+orth api show olostep
+orth api show perplexity
+orth api show tavily 
 ```

--- a/skills/orthogonal-bug-reporter/SKILL.md
+++ b/skills/orthogonal-bug-reporter/SKILL.md
@@ -117,3 +117,11 @@ orth api run perplexity /chat/completions --body '{
   "messages": [{"role": "user", "content": "Write a bug report for: Server crashes after 24 hours with out of memory error"}]
 }'
 ```
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa olostep perplexity tavily 
+```

--- a/skills/orthogonal-changelog-writer/SKILL.md
+++ b/skills/orthogonal-changelog-writer/SKILL.md
@@ -83,3 +83,11 @@ orth api run scrapegraph /v1/smartscraper --body '{
 - **Removed**: Removed features
 - **Fixed**: Bug fixes
 - **Security**: Security fixes
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa linkup perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-changelog-writer/SKILL.md
+++ b/skills/orthogonal-changelog-writer/SKILL.md
@@ -86,7 +86,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
@@ -95,3 +95,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-changelog-writer/SKILL.md
+++ b/skills/orthogonal-changelog-writer/SKILL.md
@@ -89,5 +89,9 @@ orth api run scrapegraph /v1/smartscraper --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa linkup perplexity scrapegraph tavily 
+orth api show exa
+orth api show linkup
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-code-reviewer/SKILL.md
+++ b/skills/orthogonal-code-reviewer/SKILL.md
@@ -89,3 +89,11 @@ orth api run exa /search --body '{
 3. **Best Practices**: Naming, structure, documentation
 4. **Error Handling**: Try/catch, validation, logging
 5. **Testing**: Test coverage, edge cases
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa linkup olostep perplexity tavily 
+```

--- a/skills/orthogonal-code-reviewer/SKILL.md
+++ b/skills/orthogonal-code-reviewer/SKILL.md
@@ -95,5 +95,9 @@ orth api run exa /search --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa linkup olostep perplexity tavily 
+orth api show exa
+orth api show linkup
+orth api show olostep
+orth api show perplexity
+orth api show tavily 
 ```

--- a/skills/orthogonal-code-reviewer/SKILL.md
+++ b/skills/orthogonal-code-reviewer/SKILL.md
@@ -92,7 +92,7 @@ orth api run exa /search --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
@@ -101,3 +101,5 @@ orth api show olostep
 orth api show perplexity
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-company-intel/SKILL.md
+++ b/skills/orthogonal-company-intel/SKILL.md
@@ -114,7 +114,7 @@ orth api run tavily /search --body "{\"query\": \"$COMPANY news 2024\", \"includ
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show brand-dev
@@ -123,3 +123,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-company-intel/SKILL.md
+++ b/skills/orthogonal-company-intel/SKILL.md
@@ -111,3 +111,11 @@ orth api run tavily /search --body "{\"query\": \"$COMPANY news 2024\", \"includ
 - Verify funding data from multiple sources
 - Track company over time for changes
 - Note any discrepancies between sources
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev fiber perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-company-intel/SKILL.md
+++ b/skills/orthogonal-company-intel/SKILL.md
@@ -117,5 +117,9 @@ orth api run tavily /search --body "{\"query\": \"$COMPANY news 2024\", \"includ
 For full endpoint details and parameters:
 
 ```bash
-orth api show brand-dev fiber perplexity scrapegraph tavily 
+orth api show brand-dev
+orth api show fiber
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-competitor-research/SKILL.md
+++ b/skills/orthogonal-competitor-research/SKILL.md
@@ -101,5 +101,10 @@ orth api run exa /search --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show brand-dev exa fiber perplexity scrapegraph tavily 
+orth api show brand-dev
+orth api show exa
+orth api show fiber
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-competitor-research/SKILL.md
+++ b/skills/orthogonal-competitor-research/SKILL.md
@@ -95,3 +95,11 @@ orth api run exa /search --body '{
 - Track their job postings for strategic insights
 - Monitor their social media and blog
 - Analyze their customer reviews
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev exa fiber perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-competitor-research/SKILL.md
+++ b/skills/orthogonal-competitor-research/SKILL.md
@@ -98,7 +98,7 @@ orth api run exa /search --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show brand-dev
@@ -108,3 +108,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-content-research/SKILL.md
+++ b/skills/orthogonal-content-research/SKILL.md
@@ -91,10 +91,12 @@ orth api run exa /search --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
 orth api show perplexity
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-content-research/SKILL.md
+++ b/skills/orthogonal-content-research/SKILL.md
@@ -88,3 +88,11 @@ orth api run exa /search --body '{
 - Gather multiple sources for credibility
 - Look for unique angles not covered elsewhere
 - Include data and statistics when possible
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa perplexity tavily 
+```

--- a/skills/orthogonal-content-research/SKILL.md
+++ b/skills/orthogonal-content-research/SKILL.md
@@ -94,5 +94,7 @@ orth api run exa /search --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa perplexity tavily 
+orth api show exa
+orth api show perplexity
+orth api show tavily 
 ```

--- a/skills/orthogonal-date-night-planner/SKILL.md
+++ b/skills/orthogonal-date-night-planner/SKILL.md
@@ -86,3 +86,11 @@ orth api run olostep /v1/answers --body '{
 - Plan the logistics (parking, Uber, walking distance)
 - Have a backup plan for weather
 - Mix familiar favorites with new experiences
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep perplexity precip tavily 
+```

--- a/skills/orthogonal-date-night-planner/SKILL.md
+++ b/skills/orthogonal-date-night-planner/SKILL.md
@@ -92,5 +92,8 @@ orth api run olostep /v1/answers --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep perplexity precip tavily 
+orth api show olostep
+orth api show perplexity
+orth api show precip
+orth api show tavily 
 ```

--- a/skills/orthogonal-date-night-planner/SKILL.md
+++ b/skills/orthogonal-date-night-planner/SKILL.md
@@ -89,7 +89,7 @@ orth api run olostep /v1/answers --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -97,3 +97,5 @@ orth api show perplexity
 orth api show precip
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-deploy-checker/SKILL.md
+++ b/skills/orthogonal-deploy-checker/SKILL.md
@@ -103,5 +103,8 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show brand-dev linkup perplexity scrapegraph 
+orth api show brand-dev
+orth api show linkup
+orth api show perplexity
+orth api show scrapegraph 
 ```

--- a/skills/orthogonal-deploy-checker/SKILL.md
+++ b/skills/orthogonal-deploy-checker/SKILL.md
@@ -100,7 +100,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show brand-dev
@@ -108,3 +108,5 @@ orth api show linkup
 orth api show perplexity
 orth api show scrapegraph 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-deploy-checker/SKILL.md
+++ b/skills/orthogonal-deploy-checker/SKILL.md
@@ -97,3 +97,11 @@ orth api run perplexity /chat/completions --body '{
 - Check error handling endpoints
 - Verify SSL certificates
 - Test from multiple regions if possible
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev linkup perplexity scrapegraph 
+```

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -122,3 +122,12 @@ orth api run didit /v3/database-validation --body '{"issuing_state": "ESP", "val
 2. **Two-Factor Authentication**: Add OTP verification to login flows
 3. **KYC Compliance**: Validate identity data for financial services
 4. **AML Compliance**: Screen customers against sanctions and watchlists
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show didit              # List all endpoints
+orth api show didit <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -129,4 +129,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show didit              # List all endpoints
+orth api show didit /v3/email/send   # Get endpoint details
 ```

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -129,5 +129,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show didit              # List all endpoints
-orth api show didit <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-docs-generator/SKILL.md
+++ b/skills/orthogonal-docs-generator/SKILL.md
@@ -89,7 +89,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
@@ -98,3 +98,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-docs-generator/SKILL.md
+++ b/skills/orthogonal-docs-generator/SKILL.md
@@ -92,5 +92,9 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa linkup perplexity scrapegraph tavily 
+orth api show exa
+orth api show linkup
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-docs-generator/SKILL.md
+++ b/skills/orthogonal-docs-generator/SKILL.md
@@ -86,3 +86,11 @@ orth api run perplexity /chat/completions --body '{
 - Add error handling documentation
 - Keep language simple and clear
 - Include quick start guides
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa linkup perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -264,3 +264,12 @@ orth api run dome /kalshi/markets --query 'search=fed%20rate'
 3. **Portfolio Tracking**: Monitor positions and P&L
 4. **Arbitrage**: Find price differences across platforms
 5. **Forecasting**: Use market prices as probability estimates
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show dome              # List all endpoints
+orth api show dome <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -271,5 +271,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show dome              # List all endpoints
-orth api show dome <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -271,4 +271,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show dome              # List all endpoints
+orth api show dome /kalshi/orderbooks   # Get endpoint details
 ```

--- a/skills/orthogonal-email-campaign/SKILL.md
+++ b/skills/orthogonal-email-campaign/SKILL.md
@@ -92,5 +92,8 @@ orth api run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John",
 For full endpoint details and parameters:
 
 ```bash
-orth api show brand-dev fiber hunter sixtyfour 
+orth api show brand-dev
+orth api show fiber
+orth api show hunter
+orth api show sixtyfour 
 ```

--- a/skills/orthogonal-email-campaign/SKILL.md
+++ b/skills/orthogonal-email-campaign/SKILL.md
@@ -89,7 +89,7 @@ orth api run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John",
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show brand-dev
@@ -97,3 +97,5 @@ orth api show fiber
 orth api show hunter
 orth api show sixtyfour 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-email-campaign/SKILL.md
+++ b/skills/orthogonal-email-campaign/SKILL.md
@@ -86,3 +86,11 @@ orth api run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John",
 - Personalize using enrichment data
 - Segment by role, industry, or company size
 - Track bounces and clean your list
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev fiber hunter sixtyfour 
+```

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -160,4 +160,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show exa              # List all endpoints
+orth api show exa /research   # Get endpoint details
 ```

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -160,5 +160,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show exa              # List all endpoints
-orth api show exa <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -153,3 +153,12 @@ orth api run exa /contents --body '{
 3. **Market Research**: Discover companies in specific niches
 4. **Fact-Finding**: Get sourced answers to questions
 5. **Deep Research**: Comprehensive research on complex topics
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa              # List all endpoints
+orth api show exa <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -275,4 +275,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show fiber              # List all endpoints
+orth api show fiber /v1/natural-language-search/profiles   # Get endpoint details
 ```

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -275,5 +275,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show fiber              # List all endpoints
-orth api show fiber <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -268,3 +268,12 @@ orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier":
 3. **Fundraising**: Research investors in your space
 4. **Competitive Intel**: Track companies and their employees
 5. **Job Search**: Find relevant job opportunities
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show fiber              # List all endpoints
+orth api show fiber <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-flight-search/SKILL.md
+++ b/skills/orthogonal-flight-search/SKILL.md
@@ -63,10 +63,12 @@ orth api run olostep /v1/answers --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-flight-search/SKILL.md
+++ b/skills/orthogonal-flight-search/SKILL.md
@@ -60,3 +60,11 @@ orth api run olostep /v1/answers --body '{
 - Search for "flexible dates" to find deals
 - Compare one-way vs round-trip pricing
 - Check for airline sales and promotions
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep scrapegraph tavily 
+```

--- a/skills/orthogonal-flight-search/SKILL.md
+++ b/skills/orthogonal-flight-search/SKILL.md
@@ -66,5 +66,7 @@ orth api run olostep /v1/answers --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep scrapegraph tavily 
+orth api show olostep
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-gift-finder/SKILL.md
+++ b/skills/orthogonal-gift-finder/SKILL.md
@@ -85,5 +85,8 @@ orth api run olostep /v1/answers --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep perplexity scrapegraph tavily 
+orth api show olostep
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-gift-finder/SKILL.md
+++ b/skills/orthogonal-gift-finder/SKILL.md
@@ -79,3 +79,11 @@ orth api run olostep /v1/answers --body '{
 - Think about experiences, not just physical items
 - Check for gift cards if unsure
 - Look for personalization options
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-gift-finder/SKILL.md
+++ b/skills/orthogonal-gift-finder/SKILL.md
@@ -82,7 +82,7 @@ orth api run olostep /v1/answers --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -90,3 +90,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-hotel-finder/SKILL.md
+++ b/skills/orthogonal-hotel-finder/SKILL.md
@@ -67,7 +67,7 @@ orth api run olostep /v1/answers --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -75,3 +75,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-hotel-finder/SKILL.md
+++ b/skills/orthogonal-hotel-finder/SKILL.md
@@ -64,3 +64,11 @@ orth api run olostep /v1/answers --body '{
 - Include amenity requirements (pool, gym, breakfast)
 - Check cancellation policies
 - Compare booking sites for best rates
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-hotel-finder/SKILL.md
+++ b/skills/orthogonal-hotel-finder/SKILL.md
@@ -70,5 +70,8 @@ orth api run olostep /v1/answers --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep perplexity scrapegraph tavily 
+orth api show olostep
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -132,4 +132,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show hunter              # List all endpoints
+orth api show hunter /v2/combined/find   # Get endpoint details
 ```

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -125,3 +125,12 @@ orth api run hunter /v2/email-verifier --query 'email=john@example.com'
 3. **Email Validation**: Clean lists before campaigns
 4. **Company Research**: Find companies matching criteria
 5. **Contact Enrichment**: Get full profiles from emails
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show hunter              # List all endpoints
+orth api show hunter <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -132,5 +132,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show hunter              # List all endpoints
-orth api show hunter <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-image-analyzer/SKILL.md
+++ b/skills/orthogonal-image-analyzer/SKILL.md
@@ -86,3 +86,11 @@ orth api run brand-dev /v1/brand/screenshot --query 'domain=openai.com'
 - Specify exact data needed for extraction
 - Combine with OCR for text-heavy images
 - Use screenshots for website analysis
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev linkup perplexity riveter scrapegraph 
+```

--- a/skills/orthogonal-image-analyzer/SKILL.md
+++ b/skills/orthogonal-image-analyzer/SKILL.md
@@ -89,7 +89,7 @@ orth api run brand-dev /v1/brand/screenshot --query 'domain=openai.com'
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show brand-dev
@@ -98,3 +98,5 @@ orth api show perplexity
 orth api show riveter
 orth api show scrapegraph 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-image-analyzer/SKILL.md
+++ b/skills/orthogonal-image-analyzer/SKILL.md
@@ -92,5 +92,9 @@ orth api run brand-dev /v1/brand/screenshot --query 'domain=openai.com'
 For full endpoint details and parameters:
 
 ```bash
-orth api show brand-dev linkup perplexity riveter scrapegraph 
+orth api show brand-dev
+orth api show linkup
+orth api show perplexity
+orth api show riveter
+orth api show scrapegraph 
 ```

--- a/skills/orthogonal-investor-research/SKILL.md
+++ b/skills/orthogonal-investor-research/SKILL.md
@@ -116,5 +116,9 @@ orth api run exa /search --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa fiber perplexity sixtyfour tavily 
+orth api show exa
+orth api show fiber
+orth api show perplexity
+orth api show sixtyfour
+orth api show tavily 
 ```

--- a/skills/orthogonal-investor-research/SKILL.md
+++ b/skills/orthogonal-investor-research/SKILL.md
@@ -110,3 +110,11 @@ orth api run exa /search --body '{
 - Find warm intros through mutual connections
 - Research partner's personal investment interests
 - Time outreach when raising (not too early/late)
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa fiber perplexity sixtyfour tavily 
+```

--- a/skills/orthogonal-investor-research/SKILL.md
+++ b/skills/orthogonal-investor-research/SKILL.md
@@ -113,7 +113,7 @@ orth api run exa /search --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
@@ -122,3 +122,5 @@ orth api show perplexity
 orth api show sixtyfour
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-jina-s/SKILL.md
+++ b/skills/orthogonal-jina-s/SKILL.md
@@ -36,5 +36,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show jina-s              # List all endpoints
-orth api show jina-s <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-jina-s/SKILL.md
+++ b/skills/orthogonal-jina-s/SKILL.md
@@ -29,3 +29,12 @@ orth api run jina-s / --query 'q=latest%20AI%20news'
 2. **Information Gathering**: Get relevant web results
 3. **Fact Checking**: Find sources for verification
 4. **Technical Lookup**: Search documentation and guides
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show jina-s              # List all endpoints
+orth api show jina-s <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-jina-s/SKILL.md
+++ b/skills/orthogonal-jina-s/SKILL.md
@@ -36,4 +36,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show jina-s              # List all endpoints
+orth api show jina-s /   # Get endpoint details
 ```

--- a/skills/orthogonal-job-search/SKILL.md
+++ b/skills/orthogonal-job-search/SKILL.md
@@ -86,10 +86,12 @@ orth api run fiber /v1/natural-language-search/companies --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show brand-dev
 orth api show fiber
 orth api show hunter 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-job-search/SKILL.md
+++ b/skills/orthogonal-job-search/SKILL.md
@@ -83,3 +83,11 @@ orth api run fiber /v1/natural-language-search/companies --body '{
 - Research company culture before applying
 - Network with people at target companies
 - Set up alerts for new postings
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev fiber hunter 
+```

--- a/skills/orthogonal-job-search/SKILL.md
+++ b/skills/orthogonal-job-search/SKILL.md
@@ -89,5 +89,7 @@ orth api run fiber /v1/natural-language-search/companies --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show brand-dev fiber hunter 
+orth api show brand-dev
+orth api show fiber
+orth api show hunter 
 ```

--- a/skills/orthogonal-lead-enrichment/SKILL.md
+++ b/skills/orthogonal-lead-enrichment/SKILL.md
@@ -98,10 +98,12 @@ orth api run hunter /v2/companies/find --query "domain=stripe.com"
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show fiber
 orth api show hunter
 orth api show sixtyfour 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-lead-enrichment/SKILL.md
+++ b/skills/orthogonal-lead-enrichment/SKILL.md
@@ -101,5 +101,7 @@ orth api run hunter /v2/companies/find --query "domain=stripe.com"
 For full endpoint details and parameters:
 
 ```bash
-orth api show fiber hunter sixtyfour 
+orth api show fiber
+orth api show hunter
+orth api show sixtyfour 
 ```

--- a/skills/orthogonal-lead-enrichment/SKILL.md
+++ b/skills/orthogonal-lead-enrichment/SKILL.md
@@ -95,3 +95,11 @@ orth api run hunter /v2/companies/find --query "domain=stripe.com"
 - Use multiple sources for better coverage
 - LinkedIn URLs dramatically improve match rates
 - Cache results to avoid duplicate lookups
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show fiber hunter sixtyfour 
+```

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -65,5 +65,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show linkup              # List all endpoints
-orth api show linkup <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -58,3 +58,12 @@ orth api run linkup /fetch --body '{"url": "https://example.com/article"}'
 2. **Content Aggregation**: Fetch and process web content
 3. **Fact Checking**: Verify information from multiple sources
 4. **News Monitoring**: Track news on specific topics
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show linkup              # List all endpoints
+orth api show linkup <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -65,4 +65,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show linkup              # List all endpoints
+orth api show linkup /search   # Get endpoint details
 ```

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -30,3 +30,12 @@ orth api run logo /search --query 'q=Stripe'
 2. **Brand Research**: Identify company websites
 3. **Lead Enrichment**: Get domains from company names
 4. **Data Cleaning**: Standardize company domains in datasets
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show logo              # List all endpoints
+orth api show logo <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -37,5 +37,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show logo              # List all endpoints
-orth api show logo <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -37,4 +37,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show logo              # List all endpoints
+orth api show logo /search   # Get endpoint details
 ```

--- a/skills/orthogonal-market-research/SKILL.md
+++ b/skills/orthogonal-market-research/SKILL.md
@@ -93,7 +93,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show fiber
@@ -102,3 +102,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-market-research/SKILL.md
+++ b/skills/orthogonal-market-research/SKILL.md
@@ -90,3 +90,11 @@ orth api run perplexity /chat/completions --body '{
 - Compare multiple analyst reports
 - Look for both bullish and bearish perspectives
 - Update research quarterly for fast-moving markets
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show fiber olostep perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-market-research/SKILL.md
+++ b/skills/orthogonal-market-research/SKILL.md
@@ -96,5 +96,9 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show fiber olostep perplexity scrapegraph tavily 
+orth api show fiber
+orth api show olostep
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-movie-night/SKILL.md
+++ b/skills/orthogonal-movie-night/SKILL.md
@@ -74,3 +74,11 @@ orth api run perplexity /chat/completions --body '{
 - Include rating preferences (PG, R, etc.)
 - Check multiple theaters for best times
 - Look for IMAX or Dolby showings for big releases
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-movie-night/SKILL.md
+++ b/skills/orthogonal-movie-night/SKILL.md
@@ -80,5 +80,8 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep perplexity scrapegraph tavily 
+orth api show olostep
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-movie-night/SKILL.md
+++ b/skills/orthogonal-movie-night/SKILL.md
@@ -77,7 +77,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -85,3 +85,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-notte/SKILL.md
+++ b/skills/orthogonal-notte/SKILL.md
@@ -229,5 +229,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show notte              # List all endpoints
-orth api show notte <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-notte/SKILL.md
+++ b/skills/orthogonal-notte/SKILL.md
@@ -222,3 +222,12 @@ orth api run notte /sessions/{session_id}/page/scrape --body '{}'
 3. **Testing**: Run automated browser tests
 4. **AI Agents**: Deploy autonomous agents for web tasks
 5. **Monitoring**: Track website changes and content
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show notte              # List all endpoints
+orth api show notte <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-notte/SKILL.md
+++ b/skills/orthogonal-notte/SKILL.md
@@ -229,4 +229,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show notte              # List all endpoints
+orth api show notte /sessions   # Get endpoint details
 ```

--- a/skills/orthogonal-nyne/SKILL.md
+++ b/skills/orthogonal-nyne/SKILL.md
@@ -234,3 +234,12 @@ orth api run nyne /company/funders --body '{"company_name": "OpenAI"}'
 3. **Investment Research**: Research company funding and investors
 4. **Market Research**: Track company signals and news
 5. **Lead Scoring**: Score leads based on interests and events
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show nyne              # List all endpoints
+orth api show nyne <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-nyne/SKILL.md
+++ b/skills/orthogonal-nyne/SKILL.md
@@ -241,5 +241,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show nyne              # List all endpoints
-orth api show nyne <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-nyne/SKILL.md
+++ b/skills/orthogonal-nyne/SKILL.md
@@ -241,4 +241,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show nyne              # List all endpoints
+orth api show nyne /person/search   # Get endpoint details
 ```

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -181,4 +181,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show olostep              # List all endpoints
+orth api show olostep /v1/scrapes   # Get endpoint details
 ```

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -174,3 +174,12 @@ orth api run olostep /v1/retrieve --body '{"retrieve_id": "abc123"}'
 2. **Content Monitoring**: Track changes on competitor sites
 3. **Research Automation**: Get AI-synthesized answers from web sources
 4. **SEO Analysis**: Crawl and analyze site structure
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep              # List all endpoints
+orth api show olostep <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -181,5 +181,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show olostep              # List all endpoints
-orth api show olostep <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -175,3 +175,12 @@ orth api run parallel /v1/tasks/runs --body '{
 2. **OpenAI Drop-in**: Use with existing OpenAI SDK code
 3. **Competitive Analysis**: Research competitors and market
 4. **Due Diligence**: Gather information for investment decisions
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show parallel              # List all endpoints
+orth api show parallel <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -182,4 +182,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show parallel              # List all endpoints
+orth api show parallel /v1beta/findall   # Get endpoint details
 ```

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -182,5 +182,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show parallel              # List all endpoints
-orth api show parallel <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-pdf-processor/SKILL.md
+++ b/skills/orthogonal-pdf-processor/SKILL.md
@@ -88,3 +88,11 @@ orth api run riveter /v1/run --body '{
 - Use schemas for consistent structured output
 - Handle multi-page documents in chunks
 - Verify extracted numbers against source
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show linkup olostep perplexity riveter scrapegraph 
+```

--- a/skills/orthogonal-pdf-processor/SKILL.md
+++ b/skills/orthogonal-pdf-processor/SKILL.md
@@ -94,5 +94,9 @@ orth api run riveter /v1/run --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show linkup olostep perplexity riveter scrapegraph 
+orth api show linkup
+orth api show olostep
+orth api show perplexity
+orth api show riveter
+orth api show scrapegraph 
 ```

--- a/skills/orthogonal-pdf-processor/SKILL.md
+++ b/skills/orthogonal-pdf-processor/SKILL.md
@@ -91,7 +91,7 @@ orth api run riveter /v1/run --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show linkup
@@ -100,3 +100,5 @@ orth api show perplexity
 orth api show riveter
 orth api show scrapegraph 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-perplexity/SKILL.md
+++ b/skills/orthogonal-perplexity/SKILL.md
@@ -124,5 +124,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show perplexity              # List all endpoints
-orth api show perplexity <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-perplexity/SKILL.md
+++ b/skills/orthogonal-perplexity/SKILL.md
@@ -117,3 +117,12 @@ orth api run perplexity /async/chat/completions
 3. **Technical Questions**: Get accurate technical answers
 4. **Fact-Checking**: Verify information with web sources
 5. **Content Creation**: Generate content grounded in facts
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show perplexity              # List all endpoints
+orth api show perplexity <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-perplexity/SKILL.md
+++ b/skills/orthogonal-perplexity/SKILL.md
@@ -124,4 +124,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show perplexity              # List all endpoints
+orth api show perplexity /chat/completions   # Get endpoint details
 ```

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -288,3 +288,12 @@ orth api run precip /api/v1/relative-humidity-hourly --query latitude=37.7749 lo
 3. **Event Planning**: Check precipitation forecasts for outdoor events
 4. **Research**: Access historical weather data for analysis
 5. **IoT/Smart Home**: Integrate weather data into automation
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show precip              # List all endpoints
+orth api show precip <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -295,4 +295,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show precip              # List all endpoints
+orth api show precip /api/v1/last-48   # Get endpoint details
 ```

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -295,5 +295,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show precip              # List all endpoints
-orth api show precip <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-recipe-finder/SKILL.md
+++ b/skills/orthogonal-recipe-finder/SKILL.md
@@ -73,7 +73,7 @@ orth api run olostep /v1/answers --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -81,3 +81,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-recipe-finder/SKILL.md
+++ b/skills/orthogonal-recipe-finder/SKILL.md
@@ -76,5 +76,8 @@ orth api run olostep /v1/answers --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep perplexity scrapegraph tavily 
+orth api show olostep
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-recipe-finder/SKILL.md
+++ b/skills/orthogonal-recipe-finder/SKILL.md
@@ -70,3 +70,11 @@ orth api run olostep /v1/answers --body '{
 - Include cooking time constraints
 - Mention skill level (beginner, intermediate)
 - List ingredients you want to use or avoid
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -85,3 +85,12 @@ orth api run riveter /v1/stop_run --query 'run_key=abc123'
 2. **Job Listings**: Gather job postings with structured fields
 3. **News Aggregation**: Extract articles with title, date, content
 4. **Price Monitoring**: Track prices across competitor sites
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show riveter              # List all endpoints
+orth api show riveter <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -92,5 +92,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show riveter              # List all endpoints
-orth api show riveter <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -92,4 +92,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show riveter              # List all endpoints
+orth api show riveter /v1/scrape   # Get endpoint details
 ```

--- a/skills/orthogonal-sales-prospecting/SKILL.md
+++ b/skills/orthogonal-sales-prospecting/SKILL.md
@@ -102,7 +102,7 @@ orth api run fiber /v1/validate-email/single --body '{"email": "lead@company.com
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show brand-dev
@@ -110,3 +110,5 @@ orth api show fiber
 orth api show hunter
 orth api show sixtyfour 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-sales-prospecting/SKILL.md
+++ b/skills/orthogonal-sales-prospecting/SKILL.md
@@ -105,5 +105,8 @@ orth api run fiber /v1/validate-email/single --body '{"email": "lead@company.com
 For full endpoint details and parameters:
 
 ```bash
-orth api show brand-dev fiber hunter sixtyfour 
+orth api show brand-dev
+orth api show fiber
+orth api show hunter
+orth api show sixtyfour 
 ```

--- a/skills/orthogonal-sales-prospecting/SKILL.md
+++ b/skills/orthogonal-sales-prospecting/SKILL.md
@@ -99,3 +99,11 @@ orth api run fiber /v1/validate-email/single --body '{"email": "lead@company.com
 - Verify all emails before adding to sequences
 - Personalize outreach with company context
 - Track email engagement for list optimization
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show brand-dev fiber hunter sixtyfour 
+```

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -167,3 +167,12 @@ orth api run scrapegraph /v1/smartscraper/{request_id}
 3. **Price Monitoring**: Track prices across e-commerce sites
 4. **Content Conversion**: Convert web pages to markdown for LLMs
 5. **Site Analysis**: Map site structure and content
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show scrapegraph              # List all endpoints
+orth api show scrapegraph <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -174,4 +174,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show scrapegraph              # List all endpoints
+orth api show scrapegraph /v1/smartscraper   # Get endpoint details
 ```

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -174,5 +174,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show scrapegraph              # List all endpoints
-orth api show scrapegraph <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-searchapi/SKILL.md
+++ b/skills/orthogonal-searchapi/SKILL.md
@@ -344,5 +344,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show searchapi              # List all endpoints
-orth api show searchapi <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-searchapi/SKILL.md
+++ b/skills/orthogonal-searchapi/SKILL.md
@@ -337,3 +337,12 @@ orth api run searchapi /api/v1/search --query engine=youtube q=AI%20agents
 3. **Ad Research**: Monitor ads on Meta, TikTok, Reddit, LinkedIn
 4. **Social Media**: Get TikTok and Instagram profiles
 5. **Travel**: Search Airbnb listings and TripAdvisor reviews
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show searchapi              # List all endpoints
+orth api show searchapi <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-searchapi/SKILL.md
+++ b/skills/orthogonal-searchapi/SKILL.md
@@ -344,4 +344,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show searchapi              # List all endpoints
+orth api show searchapi /api/v1/search   # Get endpoint details
 ```

--- a/skills/orthogonal-seo-analyzer/SKILL.md
+++ b/skills/orthogonal-seo-analyzer/SKILL.md
@@ -93,5 +93,8 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa perplexity scrapegraph tavily 
+orth api show exa
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-seo-analyzer/SKILL.md
+++ b/skills/orthogonal-seo-analyzer/SKILL.md
@@ -87,3 +87,11 @@ orth api run perplexity /chat/completions --body '{
 - Analyze top 3 competitors for each target keyword
 - Prioritize pages with existing traffic for optimization
 - Track rankings over time to measure progress
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-seo-analyzer/SKILL.md
+++ b/skills/orthogonal-seo-analyzer/SKILL.md
@@ -90,7 +90,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
@@ -98,3 +98,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-shofo/SKILL.md
+++ b/skills/orthogonal-shofo/SKILL.md
@@ -253,4 +253,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show shofo              # List all endpoints
+orth api show shofo /instagram/hashtag   # Get endpoint details
 ```

--- a/skills/orthogonal-shofo/SKILL.md
+++ b/skills/orthogonal-shofo/SKILL.md
@@ -253,5 +253,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show shofo              # List all endpoints
-orth api show shofo <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-shofo/SKILL.md
+++ b/skills/orthogonal-shofo/SKILL.md
@@ -246,3 +246,12 @@ orth api run shofo /x/post --query 'url=https://x.com/OpenAI/status/123456'
 3. **Competitive Analysis**: Track competitor social media activity
 4. **Content Research**: Discover trending content and hashtags
 5. **Lead Generation**: Find prospects through social profiles
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show shofo              # List all endpoints
+orth api show shofo <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -106,4 +106,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show sixtyfour              # List all endpoints
+orth api show sixtyfour /find-email   # Get endpoint details
 ```

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -106,5 +106,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show sixtyfour              # List all endpoints
-orth api show sixtyfour <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -99,3 +99,12 @@ orth api run sixtyfour /enrich-company --body '{
 2. **Lead Enrichment**: Complete partial lead data with emails/phones
 3. **CRM Data Quality**: Fill in missing fields in your CRM
 4. **Account Research**: Get comprehensive company information
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show sixtyfour              # List all endpoints
+orth api show sixtyfour <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-social-listening/SKILL.md
+++ b/skills/orthogonal-social-listening/SKILL.md
@@ -91,3 +91,11 @@ orth api run tavily /search --body '{
 - Track both positive and negative sentiment
 - Respond quickly to negative mentions
 - Use insights for product development
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show exa perplexity scrapegraph tavily 
+```

--- a/skills/orthogonal-social-listening/SKILL.md
+++ b/skills/orthogonal-social-listening/SKILL.md
@@ -97,5 +97,8 @@ orth api run tavily /search --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show exa perplexity scrapegraph tavily 
+orth api show exa
+orth api show perplexity
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-social-listening/SKILL.md
+++ b/skills/orthogonal-social-listening/SKILL.md
@@ -94,7 +94,7 @@ orth api run tavily /search --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show exa
@@ -102,3 +102,5 @@ orth api show perplexity
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -148,5 +148,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show tavily              # List all endpoints
-orth api show tavily <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -148,4 +148,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show tavily              # List all endpoints
+orth api show tavily /search   # Get endpoint details
 ```

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -141,3 +141,12 @@ orth api run tavily /crawl --body '{
 3. **Market Intelligence**: Track industry trends
 4. **Documentation**: Crawl and index documentation sites
 5. **Fact-Finding**: Get accurate, sourced answers
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show tavily              # List all endpoints
+orth api show tavily <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-tavus/SKILL.md
+++ b/skills/orthogonal-tavus/SKILL.md
@@ -48,4 +48,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show tavus              # List all endpoints
+orth api show tavus /v2/personas   # Get endpoint details
 ```

--- a/skills/orthogonal-tavus/SKILL.md
+++ b/skills/orthogonal-tavus/SKILL.md
@@ -48,5 +48,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show tavus              # List all endpoints
-orth api show tavus <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-tavus/SKILL.md
+++ b/skills/orthogonal-tavus/SKILL.md
@@ -41,3 +41,12 @@ orth api run tavus /v2/conversations --body '{
 3. **Training**: Interactive video training sessions
 4. **Onboarding**: Automated new user onboarding calls
 5. **Interviews**: AI-assisted screening interviews
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show tavus              # List all endpoints
+orth api show tavus <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -53,3 +53,12 @@ orth api run textbelt /text --body '{
 3. **Reminders**: Appointment and event reminders
 4. **Updates**: Order and delivery updates
 5. **Marketing**: Promotional messages (with consent)
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show textbelt              # List all endpoints
+orth api show textbelt <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -60,5 +60,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show textbelt              # List all endpoints
-orth api show textbelt <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -60,4 +60,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show textbelt              # List all endpoints
+orth api show textbelt /text   # Get endpoint details
 ```

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -257,3 +257,12 @@ orth api run tomba /v1/reveal/search --body '{"query": "AI startups in San Franc
 3. **Email Validation**: Clean email lists before campaigns
 4. **Company Research**: Find companies matching criteria
 5. **Outreach**: Verify emails before sending
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show tomba              # List all endpoints
+orth api show tomba <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -264,4 +264,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show tomba              # List all endpoints
+orth api show tomba /v1/phone-validator   # Get endpoint details
 ```

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -264,5 +264,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show tomba              # List all endpoints
-orth api show tomba <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-travel-planner/SKILL.md
+++ b/skills/orthogonal-travel-planner/SKILL.md
@@ -98,5 +98,8 @@ orth api run perplexity /chat/completions --body '{
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep perplexity precip tavily 
+orth api show olostep
+orth api show perplexity
+orth api show precip
+orth api show tavily 
 ```

--- a/skills/orthogonal-travel-planner/SKILL.md
+++ b/skills/orthogonal-travel-planner/SKILL.md
@@ -92,3 +92,11 @@ orth api run perplexity /chat/completions --body '{
 - Stay in central neighborhoods to save on transport
 - Mix popular attractions with local experiences
 - Leave buffer time for spontaneous discoveries
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep perplexity precip tavily 
+```

--- a/skills/orthogonal-travel-planner/SKILL.md
+++ b/skills/orthogonal-travel-planner/SKILL.md
@@ -95,7 +95,7 @@ orth api run perplexity /chat/completions --body '{
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -103,3 +103,5 @@ orth api show perplexity
 orth api show precip
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-uptime-monitor/SKILL.md
+++ b/skills/orthogonal-uptime-monitor/SKILL.md
@@ -101,3 +101,11 @@ orth api run linkup /fetch --body '{"url": "https://competitor.com"}'
 3. **Login/Auth**: Authentication working
 4. **Critical Features**: Core functionality
 5. **Status Page**: Official service status
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show linkup olostep scrapegraph textbelt 
+```

--- a/skills/orthogonal-uptime-monitor/SKILL.md
+++ b/skills/orthogonal-uptime-monitor/SKILL.md
@@ -104,7 +104,7 @@ orth api run linkup /fetch --body '{"url": "https://competitor.com"}'
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show linkup
@@ -112,3 +112,5 @@ orth api show olostep
 orth api show scrapegraph
 orth api show textbelt 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-uptime-monitor/SKILL.md
+++ b/skills/orthogonal-uptime-monitor/SKILL.md
@@ -107,5 +107,8 @@ orth api run linkup /fetch --body '{"url": "https://competitor.com"}'
 For full endpoint details and parameters:
 
 ```bash
-orth api show linkup olostep scrapegraph textbelt 
+orth api show linkup
+orth api show olostep
+orth api show scrapegraph
+orth api show textbelt 
 ```

--- a/skills/orthogonal-valyu/SKILL.md
+++ b/skills/orthogonal-valyu/SKILL.md
@@ -192,3 +192,12 @@ orth api run valyu /v1/deepresearch/batches/{id}/tasks
 3. **Market Analysis**: Research markets and competitors
 4. **Due Diligence**: Gather information for decisions
 5. **Knowledge Base Building**: Collect structured information
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show valyu              # List all endpoints
+orth api show valyu <endpoint>   # Get endpoint parameters
+```

--- a/skills/orthogonal-valyu/SKILL.md
+++ b/skills/orthogonal-valyu/SKILL.md
@@ -199,4 +199,5 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show valyu              # List all endpoints
+orth api show valyu /v1/deepresearch   # Get endpoint details
 ```

--- a/skills/orthogonal-valyu/SKILL.md
+++ b/skills/orthogonal-valyu/SKILL.md
@@ -199,5 +199,4 @@ For full endpoint details and parameters:
 
 ```bash
 orth api show valyu              # List all endpoints
-orth api show valyu <endpoint>   # Get endpoint parameters
 ```

--- a/skills/orthogonal-web-scraper/SKILL.md
+++ b/skills/orthogonal-web-scraper/SKILL.md
@@ -94,5 +94,8 @@ orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://docs.o
 For full endpoint details and parameters:
 
 ```bash
-orth api show olostep riveter scrapegraph tavily 
+orth api show olostep
+orth api show riveter
+orth api show scrapegraph
+orth api show tavily 
 ```

--- a/skills/orthogonal-web-scraper/SKILL.md
+++ b/skills/orthogonal-web-scraper/SKILL.md
@@ -91,7 +91,7 @@ orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://docs.o
 
 ## Discover More
 
-For full endpoint details and parameters:
+List all endpoints, or add a path for parameter details:
 
 ```bash
 orth api show olostep
@@ -99,3 +99,5 @@ orth api show riveter
 orth api show scrapegraph
 orth api show tavily 
 ```
+
+Example: `orth api show olostep /v1/scrapes` for endpoint parameters.

--- a/skills/orthogonal-web-scraper/SKILL.md
+++ b/skills/orthogonal-web-scraper/SKILL.md
@@ -88,3 +88,11 @@ orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://docs.o
 - Define schemas for consistent data
 - Respect rate limits and robots.txt
 - Cache results to avoid duplicate requests
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show olostep riveter scrapegraph tavily 
+```


### PR DESCRIPTION
## Summary
Add 'Discover More' section to 26 API skills showing how to look up endpoint details via CLI.

## Changes
Added to each API skill:
```markdown
## Discover More

For full endpoint details and parameters:

\`\`\`bash
orth api show <slug>              # List all endpoints
orth api show <slug> <endpoint>   # Get endpoint parameters
\`\`\`
```

## Skills Updated
hunter, tomba, fiber, olostep, sixtyfour, andi, brand-dev, didit, dome, exa, jina-s, linkup, logo, notte, nyne, parallel, perplexity, precip, riveter, scrapegraph, searchapi, shofo, tavily, tavus, textbelt, valyu