### PR TITLE
chore: remove hardcoded prices from all skills

### DIFF
--- a/skills/orthogonal-andi/SKILL.md
+++ b/skills/orthogonal-andi/SKILL.md
@@ -9,11 +9,11 @@ Fast, high-quality search with intelligent ranking, instant answers, and researc
 
 ## Capabilities
 
-- **Search**: Fast, high-quality search API with intelligent ranking, instant answers, and result enrichment ($0.01)
+- **Search**: Fast, high-quality search API with intelligent ranking, instant answers, and result enrichment
 
 ## Usage
 
-### Search ($0.01)
+### Search
 Fast, high-quality search API with intelligent ranking, instant answers, and result enrichment.
 
 Parameters:

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -9,23 +9,23 @@ Extract comprehensive brand information from any domain - logos, colors, fonts, 
 
 ## Capabilities
 
-- **Extract fonts from website**: Extract font information from a brand’s website including font families, usage statistics, fallbacks, and element/word counts ($0.03)
-- **Identify brand from transaction data**: Endpoint specially designed for platforms that want to identify transaction data by the transaction title ($0.03)
-- **Retrieve NAICS code for any brand**: Endpoint to classify any brand into a 2022 NAICS code ($0.03)
-- **Retrieve brand data by email address**: Retrieve brand information using an email address while detecting disposable and free email addresses ($0.03)
-- **Retrieve simplified brand data by domain**: Returns a simplified version of brand data containing only essential information: domain, title, colors, logos, and backdrops ($0.03)
-- **Retrieve brand data by ISIN**: Retrieve brand information using an ISIN (International Securities Identification Number) ($0.03)
-- **Extract products from a brand's website**: Beta feature: Extract product information from a brand’s website ($0.03)
-- **Retrieve brand data by domain**: Retrieve logos, backdrops, colors, industry, description, and more from any domain ($0.03)
-- **Retrieve brand data by company name**: Retrieve brand information using a company name ($0.03)
-- **Retrieve brand data by stock ticker**: Retrieve brand information using a stock ticker symbol ($0.03)
-- **Extract design system and styleguide from website**: Automatically extract comprehensive design system information from a brand’s website including colors, typography, spacing, shadows, and UI components ($0.03)
-- **Take screenshot of website**: Capture a screenshot of a website ($0.03)
-- **Query website data using AI**: Use AI to extract specific data points from a brand’s website ($0.03)
+- **Extract fonts from website**: Extract font information from a brand’s website including font families, usage statistics, fallbacks, and element/word counts
+- **Identify brand from transaction data**: Endpoint specially designed for platforms that want to identify transaction data by the transaction title
+- **Retrieve NAICS code for any brand**: Endpoint to classify any brand into a 2022 NAICS code
+- **Retrieve brand data by email address**: Retrieve brand information using an email address while detecting disposable and free email addresses
+- **Retrieve simplified brand data by domain**: Returns a simplified version of brand data containing only essential information: domain, title, colors, logos, and backdrops
+- **Retrieve brand data by ISIN**: Retrieve brand information using an ISIN (International Securities Identification Number)
+- **Extract products from a brand's website**: Beta feature: Extract product information from a brand’s website
+- **Retrieve brand data by domain**: Retrieve logos, backdrops, colors, industry, description, and more from any domain
+- **Retrieve brand data by company name**: Retrieve brand information using a company name
+- **Retrieve brand data by stock ticker**: Retrieve brand information using a stock ticker symbol
+- **Extract design system and styleguide from website**: Automatically extract comprehensive design system information from a brand’s website including colors, typography, spacing, shadows, and UI components
+- **Take screenshot of website**: Capture a screenshot of a website
+- **Query website data using AI**: Use AI to extract specific data points from a brand’s website
 
 ## Usage
 
-### Extract fonts from website ($0.03)
+### Extract fonts from website
 Extract font information from a brand’s website including font families, usage statistics, fallbacks, and element/word counts.
 
 Parameters:
@@ -36,7 +36,7 @@ Parameters:
 orth api run brand-dev /v1/brand/fonts --query 'domain=vercel.com'
 ```
 
-### Identify brand from transaction data ($0.03)
+### Identify brand from transaction data
 Endpoint specially designed for platforms that want to identify transaction data by the transaction title.
 
 Parameters:
@@ -53,7 +53,7 @@ Parameters:
 orth api run brand-dev /v1/brand/transaction_identifier --query 'transaction_title=STRIPE%20PAYMENT'
 ```
 
-### Retrieve NAICS code for any brand ($0.03)
+### Retrieve NAICS code for any brand
 Endpoint to classify any brand into a 2022 NAICS code.
 
 Parameters:
@@ -66,7 +66,7 @@ Parameters:
 orth api run brand-dev /v1/brand/naics --query 'input=openai.com'
 ```
 
-### Retrieve brand data by email address ($0.03)
+### Retrieve brand data by email address
 Retrieve brand information using an email address while detecting disposable and free email addresses. This endpoint extracts the domain from the email address and returns brand data for that domain. Disposable and free email addresses (like gmail.com, yahoo.com) will throw a 422 error.
 
 Parameters:
@@ -79,7 +79,7 @@ Parameters:
 orth api run brand-dev /v1/brand/retrieve-by-email --query 'email=john@stripe.com'
 ```
 
-### Retrieve simplified brand data by domain ($0.03)
+### Retrieve simplified brand data by domain
 Returns a simplified version of brand data containing only essential information: domain, title, colors, logos, and backdrops. This endpoint is optimized for faster responses and reduced data transfer.
 
 Parameters:
@@ -90,7 +90,7 @@ Parameters:
 orth api run brand-dev /v1/brand/retrieve-simplified --query 'domain=notion.so'
 ```
 
-### Retrieve brand data by ISIN ($0.03)
+### Retrieve brand data by ISIN
 Retrieve brand information using an ISIN (International Securities Identification Number). This endpoint looks up the company associated with the ISIN and returns its brand data.
 
 Parameters:
@@ -103,7 +103,7 @@ Parameters:
 orth api run brand-dev /v1/brand/retrieve-by-isin --query 'isin=US0378331005'
 ```
 
-### Extract products from a brand's website ($0.03)
+### Extract products from a brand's website
 Beta feature: Extract product information from a brand’s website. Brand.dev will analyze the website and return a list of products with details such as name, description, image, pricing, features, and more.
 
 Parameters:
@@ -115,7 +115,7 @@ Parameters:
 orth api run brand-dev /v1/brand/ai/products --body '{"domain": "stripe.com"}'
 ```
 
-### Retrieve brand data by domain ($0.03)
+### Retrieve brand data by domain
 Retrieve logos, backdrops, colors, industry, description, and more from any domain
 
 Parameters:
@@ -128,7 +128,7 @@ Parameters:
 orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
-### Retrieve brand data by company name ($0.03)
+### Retrieve brand data by company name
 Retrieve brand information using a company name. This endpoint searches for the company by name and returns its brand data.
 
 Parameters:
@@ -141,7 +141,7 @@ Parameters:
 orth api run brand-dev /v1/brand/retrieve-by-name --query 'name=Stripe'
 ```
 
-### Retrieve brand data by stock ticker ($0.03)
+### Retrieve brand data by stock ticker
 Retrieve brand information using a stock ticker symbol. This endpoint looks up the company associated with the ticker and returns its brand data.
 
 Parameters:
@@ -155,7 +155,7 @@ Parameters:
 orth api run brand-dev /v1/brand/retrieve-by-ticker --query 'ticker=AAPL'
 ```
 
-### Extract design system and styleguide from website ($0.03)
+### Extract design system and styleguide from website
 Automatically extract comprehensive design system information from a brand’s website including colors, typography, spacing, shadows, and UI components.
 
 Parameters:
@@ -167,7 +167,7 @@ Parameters:
 orth api run brand-dev /v1/brand/styleguide --query 'domain=linear.app'
 ```
 
-### Take screenshot of website ($0.03)
+### Take screenshot of website
 Capture a screenshot of a website. Supports both viewport (standard browser view) and full-page screenshots. Can also screenshot specific page types (login, pricing, etc.) by using heuristics to find the appropriate URL. Returns a URL to the uploaded screenshot image hosted on our CDN.
 
 Parameters:
@@ -180,7 +180,7 @@ Parameters:
 orth api run brand-dev /v1/brand/screenshot --query 'domain=github.com'
 ```
 
-### Query website data using AI ($0.03)
+### Query website data using AI
 Use AI to extract specific data points from a brand’s website. The AI will crawl the website and extract the requested information based on the provided data points.
 
 Parameters:

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -9,16 +9,16 @@ Verify user identities through phone/email OTP codes and screen against AML data
 
 ## Capabilities
 
-- **Send Email Code**: Send a one-time verification code to an email address ($0.04)
+- **Send Email Code**: Send a one-time verification code to an email address
 - **Check Phone Code**: Verify a one-time code sent to a phone number (free)
-- **Send Phone Code**: Send a one-time verification code to a phone number ($0.30)
-- **AML Screening**: The AML Screening API allows you to screen individuals or companies against global watchlists and high-risk databases ($0.36)
+- **Send Phone Code**: Send a one-time verification code to a phone number
+- **AML Screening**: The AML Screening API allows you to screen individuals or companies against global watchlists and high-risk databases
 - **Check Email Code**: Verify a code sent to an email address (free)
-- **Database Validation API**: Validate user-provided identity data against authoritative national and global data sources ($0.31)
+- **Database Validation API**: Validate user-provided identity data against authoritative national and global data sources
 
 ## Usage
 
-### Send Email Code ($0.04)
+### Send Email Code
 Send a one-time verification code to an email address.
 
 Parameters:
@@ -45,7 +45,7 @@ Parameters:
 orth api run didit /v3/phone/check --body '{"phone_number": "+1234567890", "code": "123456"}'
 ```
 
-### Send Phone Code ($0.30)
+### Send Phone Code
 Send a one-time verification code to a phone number.
 
 Parameters:
@@ -58,7 +58,7 @@ Parameters:
 orth api run didit /v3/phone/send --body '{"phone_number": "+1234567890"}'
 ```
 
-### AML Screening ($0.36)
+### AML Screening
 The AML Screening API allows you to screen individuals or companies against global watchlists and high-risk databases. This API provides real-time screening capabilities to detect potential matches and mitigate risks associated with financial fraud and terrorism.
 
 Parameters:
@@ -97,7 +97,7 @@ Parameters:
 orth api run didit /v3/email/check --body '{"email": "user@example.com", "code": "123456"}'
 ```
 
-### Database Validation API ($0.31)
+### Database Validation API
 Validate user-provided identity data against authoritative national and global data sources.
 
 Parameters:

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -9,27 +9,27 @@ Access data from Polymarket and Kalshi prediction markets.
 
 ## Capabilities
 
-- **Orderbook History**: Fetches historical orderbook snapshots for a specific Kalshi market (ticker) over a specified time range ($0.01)
-- **Market Price**: Fetches the current market price for a market by token_id ($0.01)
-- **Market Price**: Fetches the current market price for a Kalshi market by market_ticker ($0.01)
-- **Trade History**: Fetches historical trade data for Kalshi markets with optional filtering by ticker and time range ($0.01)
-- **Sport by Date**: Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc ($0.01)
-- **Sports**: Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc ($0.01)
-- **Positions**: Fetches all Polymarket positions for a proxy wallet address ($0.01)
-- **Binance Prices**: Fetches historical crypto price data from Binance ($0.01)
-- **Activity**: Fetches activity data for a specific user with optional filtering by market, condition, and time range ($0.01)
-- **Markets**: Find markets on Polymarket using various filters including the ability to search ($0.01)
-- **Orderbook History**: Fetches historical orderbook snapshots for a specific asset (token ID) over a specified time range ($0.01)
-- **Wallet**: Fetches wallet information by providing either an EOA (Externally Owned Account) address or a proxy wallet address ($0.01)
-- **Candlesticks**: Fetches historical candlestick data for a market identified by condition_id, over a specified interval ($0.01)
-- **Chainlink Prices**: Fetches historical crypto price data from Chainlink ($0.01)
-- **Wallet Profit-and-Loss**: Fetches the realized profit and loss (PnL) for a specific wallet address over a specified time range and granularity ($0.01)
-- **Trade History**: Fetches historical trade data with optional filtering by market, condition, token, time range, and user’s wallet address ($0.01)
-- **Markets**: Find markets on Kalshi using various filters including market ticker, event ticker, status, and volume ($0.01)
+- **Orderbook History**: Fetches historical orderbook snapshots for a specific Kalshi market (ticker) over a specified time range
+- **Market Price**: Fetches the current market price for a market by token_id
+- **Market Price**: Fetches the current market price for a Kalshi market by market_ticker
+- **Trade History**: Fetches historical trade data for Kalshi markets with optional filtering by ticker and time range
+- **Sport by Date**: Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc
+- **Sports**: Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc
+- **Positions**: Fetches all Polymarket positions for a proxy wallet address
+- **Binance Prices**: Fetches historical crypto price data from Binance
+- **Activity**: Fetches activity data for a specific user with optional filtering by market, condition, and time range
+- **Markets**: Find markets on Polymarket using various filters including the ability to search
+- **Orderbook History**: Fetches historical orderbook snapshots for a specific asset (token ID) over a specified time range
+- **Wallet**: Fetches wallet information by providing either an EOA (Externally Owned Account) address or a proxy wallet address
+- **Candlesticks**: Fetches historical candlestick data for a market identified by condition_id, over a specified interval
+- **Chainlink Prices**: Fetches historical crypto price data from Chainlink
+- **Wallet Profit-and-Loss**: Fetches the realized profit and loss (PnL) for a specific wallet address over a specified time range and granularity
+- **Trade History**: Fetches historical trade data with optional filtering by market, condition, token, time range, and user’s wallet address
+- **Markets**: Find markets on Kalshi using various filters including market ticker, event ticker, status, and volume
 
 ## Usage
 
-### Orderbook History ($0.01)
+### Orderbook History
 Fetches historical orderbook snapshots for a specific Kalshi market (ticker) over a specified time range. If no start_time and end_time are provided, returns the latest orderbook snapshot for the market.
 
 Parameters:
@@ -42,7 +42,7 @@ Parameters:
 orth api run dome /kalshi/orderbooks --query 'ticker={ticker}'
 ```
 
-### Market Price ($0.01)
+### Market Price
 Fetches the current market price for a market by token_id. Allows historical lookups via the at_time query parameter.
 
 Parameters:
@@ -52,7 +52,7 @@ Parameters:
 orth api run dome /polymarket/market-price/{token_id}
 ```
 
-### Market Price ($0.01)
+### Market Price
 Fetches the current market price for a Kalshi market by market_ticker. Returns prices for both yes and no sides. Allows historical lookups via the at_time query parameter.
 
 Parameters:
@@ -62,7 +62,7 @@ Parameters:
 orth api run dome /kalshi/market-price/{market_ticker}
 ```
 
-### Trade History ($0.01)
+### Trade History
 Fetches historical trade data for Kalshi markets with optional filtering by ticker and time range. Returns executed trades with pricing, volume, and taker side information. All timestamps are in seconds.
 
 Parameters:
@@ -76,7 +76,7 @@ Parameters:
 orth api run dome /kalshi/trades --query 'ticker={ticker}'
 ```
 
-### Sport by Date ($0.01)
+### Sport by Date
 Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc.) for sports events by sport and date.
 
 Parameters:
@@ -86,7 +86,7 @@ Parameters:
 orth api run dome /matching-markets/sports/nba --query 'date=2024-03-01'
 ```
 
-### Sports ($0.01)
+### Sports
 Find equivalent markets across different prediction market platforms (Polymarket, Kalshi, etc.) for sports events using a Polymarket market slug or a Kalshi event ticker.
 
 Parameters:
@@ -97,7 +97,7 @@ Parameters:
 orth api run dome /matching-markets/sports
 ```
 
-### Positions ($0.01)
+### Positions
 Fetches all Polymarket positions for a proxy wallet address. Returns positions with balance >= 10,000 shares (0.01 normalized) with market info.
 
 Parameters:
@@ -108,7 +108,7 @@ Parameters:
 orth api run dome /polymarket/positions/wallet/{wallet_address}
 ```
 
-### Binance Prices ($0.01)
+### Binance Prices
 Fetches historical crypto price data from Binance. Returns price data for a specific currency pair over an optional time range. When no time range is provided, returns the most recent price. All timestamps are in Unix milliseconds.
 
 Parameters:
@@ -122,7 +122,7 @@ Parameters:
 orth api run dome /crypto-prices/binance --query 'currency=btcusdt'
 ```
 
-### Activity ($0.01)
+### Activity
 Fetches activity data for a specific user with optional filtering by market, condition, and time range. Returns trading activity including MERGES, SPLITS, and REDEEMS.
 
 Parameters:
@@ -138,7 +138,7 @@ Parameters:
 orth api run dome /polymarket/activity --query 'user={wallet_address}'
 ```
 
-### Markets ($0.01)
+### Markets
 Find markets on Polymarket using various filters including the ability to search
 
 Parameters:
@@ -158,7 +158,7 @@ Parameters:
 orth api run dome /polymarket/markets --query 'search=election' 'status=open'
 ```
 
-### Orderbook History ($0.01)
+### Orderbook History
 Fetches historical orderbook snapshots for a specific asset (token ID) over a specified time range. If no start_time and end_time are provided, returns the latest orderbook snapshot for the market.
 
 Parameters:
@@ -172,7 +172,7 @@ Parameters:
 orth api run dome /polymarket/orderbooks --query 'token_id={token_id}'
 ```
 
-### Wallet ($0.01)
+### Wallet
 Fetches wallet information by providing either an EOA (Externally Owned Account) address or a proxy wallet address. Returns the associated EOA, proxy, and wallet type. Optionally returns trading metrics including total volume, number of trades, and unique markets traded when with_metrics=true.
 
 Parameters:
@@ -186,7 +186,7 @@ Parameters:
 orth api run dome /polymarket/wallet --query 'address={wallet_address}'
 ```
 
-### Candlesticks ($0.01)
+### Candlesticks
 Fetches historical candlestick data for a market identified by condition_id, over a specified interval.
 
 Parameters:
@@ -198,7 +198,7 @@ Parameters:
 orth api run dome /polymarket/candlesticks/{condition_id} --query 'interval=1h'
 ```
 
-### Chainlink Prices ($0.01)
+### Chainlink Prices
 Fetches historical crypto price data from Chainlink. Returns price data for a specific currency pair over an optional time range. When no time range is provided, returns the most recent price. All timestamps are in Unix milliseconds. Currency format: slash-separated (e.g., btc/usd, eth/usd).
 
 Parameters:
@@ -212,7 +212,7 @@ Parameters:
 orth api run dome /crypto-prices/chainlink --query 'currency=btc/usd'
 ```
 
-### Wallet Profit-and-Loss ($0.01)
+### Wallet Profit-and-Loss
 Fetches the realized profit and loss (PnL) for a specific wallet address over a specified time range and granularity. Note: This will differ to what you see on Polymarket’s dashboard since Polymarket showcases historical unrealized PnL.
 
 Parameters:
@@ -224,7 +224,7 @@ Parameters:
 orth api run dome /polymarket/wallet/pnl/{wallet_address}
 ```
 
-### Trade History ($0.01)
+### Trade History
 Fetches historical trade data with optional filtering by market, condition, token, time range, and user’s wallet address.
 
 Parameters:
@@ -241,7 +241,7 @@ Parameters:
 orth api run dome /polymarket/orders --query 'market={market_id}'
 ```
 
-### Markets ($0.01)
+### Markets
 Find markets on Kalshi using various filters including market ticker, event ticker, status, and volume
 
 Parameters:

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -9,17 +9,17 @@ Neural search engine for finding similar content, extracting pages, and deep res
 
 ## Capabilities
 
-- **Exa Research**: Retrieve a paginated list of your research tasks ($0.01)
-- **Answer**: Get an LLM answer to a question informed by Exa search results ($0.01)
-- **Search**: The search endpoint lets you intelligently search the web and extract contents from the results ($0.01)
-- **Get a task**: Retrieve the status and results of a previously created research task ($0.01)
-- **Find similar links**: Find similar links to the link provided and optionally return the contents of the pages ($0.01)
-- **Create a task**: Create an asynchronous research task that explores the web, gathers sources, synthesizes findings, and returns results with citations ($0.01)
-- **Get contents**: Get the full page contents, summaries, and metadata for a list of URLs ($0.01)
+- **Exa Research**: Retrieve a paginated list of your research tasks
+- **Answer**: Get an LLM answer to a question informed by Exa search results
+- **Search**: The search endpoint lets you intelligently search the web and extract contents from the results
+- **Get a task**: Retrieve the status and results of a previously created research task
+- **Find similar links**: Find similar links to the link provided and optionally return the contents of the pages
+- **Create a task**: Create an asynchronous research task that explores the web, gathers sources, synthesizes findings, and returns results with citations
+- **Get contents**: Get the full page contents, summaries, and metadata for a list of URLs
 
 ## Usage
 
-### Exa Research ($0.01)
+### Exa Research
 Retrieve a paginated list of your research tasks. The response follows a cursor-based pagination pattern. Pass the `limit` parameter to control page size (max 50) and use the `cursor` token returned in the response to fetch subsequent pages.
 
 Parameters:
@@ -30,7 +30,7 @@ Parameters:
 orth api run exa /research/v1
 ```
 
-### Answer ($0.01)
+### Answer
 Get an LLM answer to a question informed by Exa search results. /answer performs an Exa search and uses an LLM to generate either:
 
 A direct answer for specific queries. (i.e.
@@ -44,7 +44,7 @@ Parameters:
 orth api run exa /answer --body '{"query": "What are the best practices for prompt engineering?"}'
 ```
 
-### Search ($0.01)
+### Search
 The search endpoint lets you intelligently search the web and extract contents from the results.By default, it automatically chooses the best search method using Exa’s embeddings-based model and other techniques to find the most relevant results for your query.
 
 Parameters:
@@ -74,7 +74,7 @@ orth api run exa /search --body '{
 }'
 ```
 
-### Get a task ($0.01)
+### Get a task
 Retrieve the status and results of a previously created research task.Use the unique researchId returned from POST /research/v1 to poll until the task is finished.
 
 Parameters:
@@ -85,7 +85,7 @@ Parameters:
 orth api run exa /research/v1/{researchId}
 ```
 
-### Find similar links ($0.01)
+### Find similar links
 Find similar links to the link provided and optionally return the contents of the pages.
 
 Parameters:
@@ -110,7 +110,7 @@ orth api run exa /findSimilar --body '{
 }'
 ```
 
-### Create a task ($0.01)
+### Create a task
 Create an asynchronous research task that explores the web, gathers sources, synthesizes findings, and returns results with citations.
 
 Parameters:
@@ -122,7 +122,7 @@ Parameters:
 orth api run exa /research/v1 --body '{"instructions": "Research the current state of AI coding assistants"}'
 ```
 
-### Get contents ($0.01)
+### Get contents
 Get the full page contents, summaries, and metadata for a list of URLs.Returns instant results from our cache, with automatic live crawling as fallback for uncached pages.
 
 Parameters:

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -9,27 +9,27 @@ Comprehensive search and enrichment for people, companies, investors, and jobs.
 
 ## Capabilities
 
-- **Search profiles from text**: Takes free-form text (e ($0.54)
-- **Search companies from text**: Takes free-form text (e ($0.54)
-- **Find person by email**: Do a reverse lookup: given an email address, find someone's LinkedIn profile and personal details ($0.04)
-- **Live fetch LinkedIn profile**: Returns an enriched profile with details for a given LinkedIn profile identifier ($0.04)
-- **Validate a single email**: Checks if a given email is likely to bounce using a waterfall of strategies ($0.02)
-- **Kitchen sink person lookup**: Search for a person using a variety of parameters such as LinkedIn slug, LinkedIn URL, or their current company information ($0.01)
-- **Kitchen sink company lookup**: Search for a company using a variety of parameters such as LinkedIn slug, LinkedIn URL, name, etc ($0.01)
-- **Investor search**: Search for investors with flexible filtering capabilities ($1.50)
-- **Fetch LinkedIn profile posts**: Fetches recent posts from a LinkedIn profile ($0.04)
-- **Live fetch LinkedIn company**: Returns an enriched company with details for a given LinkedIn company identifier ($0.04)
-- **People search**: Search for people using filters ($0.01)
-- **Fetch LinkedIn post comments**: Fetches paginated comments for a LinkedIn post ($0.04)
-- **Company search**: Search for companies using filters ($0.01)
-- **Convert text into company search filters**: Takes free-form text (e ($0.04)
-- **Convert text into profile search filters**: Takes free-form text (e ($0.04)
-- **Job postings search**: Search for job postings with flexible filtering capabilities ($0.50)
-- **Fetch LinkedIn post reactions**: Fetches paginated reactions of a specific type for a LinkedIn post ($0.04)
+- **Search profiles from text**: Takes free-form text (e
+- **Search companies from text**: Takes free-form text (e
+- **Find person by email**: Do a reverse lookup: given an email address, find someone's LinkedIn profile and personal details
+- **Live fetch LinkedIn profile**: Returns an enriched profile with details for a given LinkedIn profile identifier
+- **Validate a single email**: Checks if a given email is likely to bounce using a waterfall of strategies
+- **Kitchen sink person lookup**: Search for a person using a variety of parameters such as LinkedIn slug, LinkedIn URL, or their current company information
+- **Kitchen sink company lookup**: Search for a company using a variety of parameters such as LinkedIn slug, LinkedIn URL, name, etc
+- **Investor search**: Search for investors with flexible filtering capabilities
+- **Fetch LinkedIn profile posts**: Fetches recent posts from a LinkedIn profile
+- **Live fetch LinkedIn company**: Returns an enriched company with details for a given LinkedIn company identifier
+- **People search**: Search for people using filters
+- **Fetch LinkedIn post comments**: Fetches paginated comments for a LinkedIn post
+- **Company search**: Search for companies using filters
+- **Convert text into company search filters**: Takes free-form text (e
+- **Convert text into profile search filters**: Takes free-form text (e
+- **Job postings search**: Search for job postings with flexible filtering capabilities
+- **Fetch LinkedIn post reactions**: Fetches paginated reactions of a specific type for a LinkedIn post
 
 ## Usage
 
-### Search profiles from text ($0.54)
+### Search profiles from text
 Takes free-form text (e.g., 'Software engineers in US with 5+ years of experience') and returns a list of matching profiles.
 
 Parameters:
@@ -43,7 +43,7 @@ Parameters:
 orth api run fiber /v1/natural-language-search/profiles --body '{"query": "Software engineers in San Francisco with 5+ years experience"}'
 ```
 
-### Search companies from text ($0.54)
+### Search companies from text
 Takes free-form text (e.g., 'Series A startups in USA with 50–200 employees') and returns a list of matching companies.
 
 Parameters:
@@ -55,7 +55,7 @@ Parameters:
 orth api run fiber /v1/natural-language-search/companies --body '{"query": "Series A startups in fintech with 50-200 employees"}'
 ```
 
-### Find person by email ($0.04)
+### Find person by email
 Do a reverse lookup: given an email address, find someone's LinkedIn profile and personal details. Note: if you also have the person's name, company, etc., you'll get better results with the Kitchen Sink endpoint, where you can pass all the information you have.
 
 Parameters:
@@ -66,7 +66,7 @@ Parameters:
 orth api run fiber /v1/email-to-person/single --body '{"email": "john@company.com"}'
 ```
 
-### Live fetch LinkedIn profile ($0.04)
+### Live fetch LinkedIn profile
 Returns an enriched profile with details for a given LinkedIn profile identifier
 
 Parameters:
@@ -78,7 +78,7 @@ Parameters:
 orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
-### Validate a single email ($0.02)
+### Validate a single email
 Checks if a given email is likely to bounce using a waterfall of strategies. Works for catch-all email addresses, which are increasingly common yet hard for other APIs to validate.
 
 Parameters:
@@ -88,7 +88,7 @@ Parameters:
 orth api run fiber /v1/validate-email/single --body '{"email": "john@example.com"}'
 ```
 
-### Kitchen sink person lookup ($0.01)
+### Kitchen sink person lookup
 Search for a person using a variety of parameters such as LinkedIn slug, LinkedIn URL, or their current company information. Returns profile data for the person if found.
 
 Parameters:
@@ -110,7 +110,7 @@ Parameters:
 orth api run fiber /v1/kitchen-sink/person --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
 ```
 
-### Kitchen sink company lookup ($0.01)
+### Kitchen sink company lookup
 Search for a company using a variety of parameters such as LinkedIn slug, LinkedIn URL, name, etc. Returns complete company data if found.
 
 Parameters:
@@ -123,7 +123,7 @@ Parameters:
 orth api run fiber /v1/kitchen-sink/company --body '{"domain": "openai.com"}'
 ```
 
-### Investor search ($1.50)
+### Investor search
 Search for investors with flexible filtering capabilities
 
 Parameters:
@@ -140,7 +140,7 @@ orth api run fiber /v1/investor-search --body '{
 }'
 ```
 
-### Fetch LinkedIn profile posts ($0.04)
+### Fetch LinkedIn profile posts
 Fetches recent posts from a LinkedIn profile. Returns a paginated feed of posts with optional cursor for pagination. Each page returns up to 50 posts.
 
 Parameters:
@@ -151,7 +151,7 @@ Parameters:
 orth api run fiber /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
-### Live fetch LinkedIn company ($0.04)
+### Live fetch LinkedIn company
 Returns an enriched company with details for a given LinkedIn company identifier
 
 Parameters:
@@ -162,7 +162,7 @@ Parameters:
 orth api run fiber /v1/linkedin-live-fetch/company/single --body '{"identifier": "https://linkedin.com/company/openai"}'
 ```
 
-### People search ($0.01)
+### People search
 Search for people using filters
 
 Parameters:
@@ -182,7 +182,7 @@ orth api run fiber /v1/people-search --body '{
 }'
 ```
 
-### Fetch LinkedIn post comments ($0.04)
+### Fetch LinkedIn post comments
 Fetches paginated comments for a LinkedIn post. Each page contains up to 10 comments.
 
 Parameters:
@@ -193,7 +193,7 @@ Parameters:
 orth api run fiber /v1/linkedin-live-fetch/post-comments --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
 ```
 
-### Company search ($0.01)
+### Company search
 Search for companies using filters
 
 Parameters:
@@ -212,7 +212,7 @@ orth api run fiber /v1/company-search --body '{
 }'
 ```
 
-### Convert text into company search filters ($0.04)
+### Convert text into company search filters
 Takes free-form text (e.g., 'Series A startups in USA with 50–200 employees') and converts it into a structured set of filters for company search.
 
 Parameters:
@@ -222,7 +222,7 @@ Parameters:
 orth api run fiber /v1/text-to-search-params/companies --body '{"query": "AI startups in healthcare"}'
 ```
 
-### Convert text into profile search filters ($0.04)
+### Convert text into profile search filters
 Takes free-form text (e.g., 'Software engineers in US with 5+ years of experience') and converts it into a structured set of filters for profile search.
 
 Parameters:
@@ -232,7 +232,7 @@ Parameters:
 orth api run fiber /v1/text-to-search-params/profiles --body '{"query": "Senior engineers at FAANG companies"}'
 ```
 
-### Job postings search ($0.50)
+### Job postings search
 Search for job postings with flexible filtering capabilities
 
 Parameters:
@@ -249,7 +249,7 @@ orth api run fiber /v1/job-search --body '{
 }'
 ```
 
-### Fetch LinkedIn post reactions ($0.04)
+### Fetch LinkedIn post reactions
 Fetches paginated reactions of a specific type for a LinkedIn post. Each page contains up to 10 reactions.
 
 Parameters:

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -9,18 +9,18 @@ Find email addresses, verify deliverability, and discover companies.
 
 ## Capabilities
 
-- **Combined Enrichment**: Get both person AND company information from an email address in a single request ($0.01)
-- **Email Enrichment**: Get detailed person information from an email address - name, location, employment, social profiles ($0.01)
-- **Email Count**: Get count of email addresses we have for a domain, broken down by department and seniority ($0.01)
-- **Discover Companies**: Find companies matching criteria using filters or natural language ($0.01)
-- **Company Enrichment**: Get detailed company information from a domain - industry, description, location, size, tech stack, funding ($0.01)
-- **Domain Search**: Find all email addresses for a domain ($0.01)
-- **Email Finder**: Find the most likely email address for a person given their name and company domain ($0.01)
-- **Email Verifier**: Verify if an email address is deliverable ($0.01)
+- **Combined Enrichment**: Get both person AND company information from an email address in a single request
+- **Email Enrichment**: Get detailed person information from an email address - name, location, employment, social profiles
+- **Email Count**: Get count of email addresses we have for a domain, broken down by department and seniority
+- **Discover Companies**: Find companies matching criteria using filters or natural language
+- **Company Enrichment**: Get detailed company information from a domain - industry, description, location, size, tech stack, funding
+- **Domain Search**: Find all email addresses for a domain
+- **Email Finder**: Find the most likely email address for a person given their name and company domain
+- **Email Verifier**: Verify if an email address is deliverable
 
 ## Usage
 
-### Combined Enrichment ($0.01)
+### Combined Enrichment
 Get both person AND company information from an email address in a single request.
 
 Parameters:
@@ -30,7 +30,7 @@ Parameters:
 orth api run hunter /v2/combined/find --query 'email=jane@company.com'
 ```
 
-### Email Enrichment ($0.01)
+### Email Enrichment
 Get detailed person information from an email address - name, location, employment, social profiles.
 
 Parameters:
@@ -41,7 +41,7 @@ Parameters:
 orth api run hunter /v2/people/find --query 'email=john@company.com'
 ```
 
-### Email Count ($0.01)
+### Email Count
 Get count of email addresses we have for a domain, broken down by department and seniority. FREE endpoint.
 
 Parameters:
@@ -53,7 +53,7 @@ Parameters:
 orth api run hunter /v2/email-count --query 'domain=google.com'
 ```
 
-### Discover Companies ($0.01)
+### Discover Companies
 Find companies matching criteria using filters or natural language. Returns up to 100 companies per request. FREE endpoint.
 
 Parameters:
@@ -68,7 +68,7 @@ Parameters:
 orth api run hunter /v2/discover --body '{"query": "AI startups in San Francisco"}'
 ```
 
-### Company Enrichment ($0.01)
+### Company Enrichment
 Get detailed company information from a domain - industry, description, location, size, tech stack, funding.
 
 Parameters:
@@ -78,7 +78,7 @@ Parameters:
 orth api run hunter /v2/companies/find --query 'domain=anthropic.com'
 ```
 
-### Domain Search ($0.01)
+### Domain Search
 Find all email addresses for a domain. Returns emails with sources, confidence scores, and verification status.
 
 Parameters:
@@ -93,7 +93,7 @@ Parameters:
 orth api run hunter /v2/domain-search --query 'domain=stripe.com'
 ```
 
-### Email Finder ($0.01)
+### Email Finder
 Find the most likely email address for a person given their name and company domain.
 
 Parameters:
@@ -108,7 +108,7 @@ Parameters:
 orth api run hunter /v2/email-finder --query domain=openai.com first_name=Sam last_name=Altman
 ```
 
-### Email Verifier ($0.01)
+### Email Verifier
 Verify if an email address is deliverable. Returns status (valid, invalid, accept_all, webmail, disposable, unknown).
 
 Parameters:

--- a/skills/orthogonal-jina-s/SKILL.md
+++ b/skills/orthogonal-jina-s/SKILL.md
@@ -9,11 +9,11 @@ Simple, fast web search using Jina's search foundation.
 
 ## Capabilities
 
-- **Search**: Use s ($0.01)
+- **Search**: Use s
 
 ## Usage
 
-### Search ($0.01)
+### Search
 Use s.jina.ai to search the web and get SERP
 
 Parameters:

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -9,12 +9,12 @@ Search the web and fetch content from any URL.
 
 ## Capabilities
 
-- **Search**: The /search endpoint allows you to retrieve web content ($0.01)
-- **Fetch**: The /fetch endpoint allows you to fetch a single webpage from a given URL ($0.01)
+- **Search**: The /search endpoint allows you to retrieve web content
+- **Fetch**: The /fetch endpoint allows you to fetch a single webpage from a given URL
 
 ## Usage
 
-### Search ($0.01)
+### Search
 The /search endpoint allows you to retrieve web content.
 
 Parameters:
@@ -39,7 +39,7 @@ orth api run linkup /search --body '{
 }'
 ```
 
-### Fetch ($0.01)
+### Fetch
 The /fetch endpoint allows you to fetch a single webpage from a given URL.
 
 Parameters:

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -9,11 +9,11 @@ Find company domains by searching brand names.
 
 ## Capabilities
 
-- **Brand Search**: Search for company domains by brand name ($0.01)
+- **Brand Search**: Search for company domains by brand name
 
 ## Usage
 
-### Brand Search ($0.01)
+### Brand Search
 Search for company domains by brand name
 
 Parameters:

--- a/skills/orthogonal-notte/SKILL.md
+++ b/skills/orthogonal-notte/SKILL.md
@@ -9,25 +9,25 @@ Control browser sessions, scrape web pages, and run autonomous AI agents.
 
 ## Capabilities
 
-- **Take Screenshot**: Take a screenshot of the current page ($0.001)
+- **Take Screenshot**: Take a screenshot of the current page
 - **Get Session**: Get session status and details (free)
 - **Stop Session**: Stop and clean up a browser session (free)
 - **Get Session Cookies**: Get all cookies from the browser session (free)
 - **Get Network Logs**: Get network request/response logs from the session (free)
 - **Get Agent Status**: Get agent execution status and results (free)
-- **Observe Page**: Observe the current page state and get available actions ($0.005)
+- **Observe Page**: Observe the current page state and get available actions
 - **Stop Agent**: Stop a running agent (free)
-- **Scrape Webpage**: Scrape content from a URL without managing sessions ($0.01)
-- **Execute Page Action**: Execute an action on the page (click, type, navigate, etc ($0.002)
-- **Set Session Cookies**: Set cookies in the browser session ($0.001)
-- **Start Session**: Start a new browser session ($0.015)
-- **Scrape from HTML**: Extract structured content from raw HTML without using a browser ($0.002)
-- **Start Agent**: Start an AI agent to autonomously complete a browser task ($0.07)
-- **Scrape Page**: Scrape content from the current page in the session ($0.003)
+- **Scrape Webpage**: Scrape content from a URL without managing sessions
+- **Execute Page Action**: Execute an action on the page (click, type, navigate, etc
+- **Set Session Cookies**: Set cookies in the browser session
+- **Start Session**: Start a new browser session
+- **Scrape from HTML**: Extract structured content from raw HTML without using a browser
+- **Start Agent**: Start an AI agent to autonomously complete a browser task
+- **Scrape Page**: Scrape content from the current page in the session
 
 ## Usage
 
-### Take Screenshot ($0.001)
+### Take Screenshot
 Take a screenshot of the current page.
 
 Parameters:
@@ -88,7 +88,7 @@ Parameters:
 orth api run notte /agents/{agent_id}
 ```
 
-### Observe Page ($0.005)
+### Observe Page
 Observe the current page state and get available actions.
 
 Parameters:
@@ -111,7 +111,7 @@ Parameters:
 orth api run notte /agents/{agent_id}/stop
 ```
 
-### Scrape Webpage ($0.01)
+### Scrape Webpage
 Scrape content from a URL without managing sessions.
 
 Parameters:
@@ -122,7 +122,7 @@ Parameters:
 orth api run notte /scrape --body '{"url": "https://example.com"}'
 ```
 
-### Execute Page Action ($0.002)
+### Execute Page Action
 Execute an action on the page (click, type, navigate, etc.).
 
 Parameters:
@@ -140,7 +140,7 @@ Parameters:
 orth api run notte /sessions/{session_id}/page/execute --body '{"instruction": "Click the search button"}'
 ```
 
-### Set Session Cookies ($0.001)
+### Set Session Cookies
 Set cookies in the browser session.
 
 Parameters:
@@ -151,7 +151,7 @@ Parameters:
 orth api run notte /sessions/{session_id}/cookies
 ```
 
-### Start Session ($0.015)
+### Start Session
 Start a new browser session. Configure browser type, proxies, viewport, and session timeout.
 
 Parameters:
@@ -172,7 +172,7 @@ orth api run notte /sessions/start --body '{
 }'
 ```
 
-### Scrape from HTML ($0.002)
+### Scrape from HTML
 Extract structured content from raw HTML without using a browser
 
 Parameters:
@@ -182,7 +182,7 @@ Parameters:
 orth api run notte /scrape_from_html --body '{"html": "<html><body>Hello</body></html>"}'
 ```
 
-### Start Agent ($0.07)
+### Start Agent
 Start an AI agent to autonomously complete a browser task.
 
 Parameters:
@@ -199,7 +199,7 @@ orth api run notte /agents/start --body '{
 }'
 ```
 
-### Scrape Page ($0.003)
+### Scrape Page
 Scrape content from the current page in the session.
 
 Parameters:

--- a/skills/orthogonal-nyne/SKILL.md
+++ b/skills/orthogonal-nyne/SKILL.md
@@ -9,24 +9,24 @@ Enrich person and company data with social profiles, events, interests, funding,
 
 ## Capabilities
 
-- **Person Search**: Search people by company, role, geography, and name ($0.075)
-- **Person Enrichment**: Enrich person data from email, phone, or social URL ($0.075)
-- **Person Events**: Find life events and career milestones ($0.219)
-- **Person Social Profiles**: Get all social media profiles for a person ($0.363)
-- **Person Single Social Lookup**: Look up a specific social media profile ($0.148)
-- **Person Interactions**: Get social media interactions ($0.219)
-- **Person Interests**: Get interests, skills, and topics a person engages with ($0.363)
-- **Person Newsfeed**: Get social media newsfeed data ($0.435)
-- **Company Search**: Search companies by industry and keywords ($0.363)
-- **Company Enrichment**: Enrich company data from email, phone, or social URL ($0.076)
-- **Company Check Seller**: Check if a company sells a specific product/service ($0.148)
-- **Company Needs**: Analyze company needs from SEC filings and content ($0.219)
-- **Company Funding**: Get company funding history and investment details ($0.578)
-- **Company Funders**: Get investors and funders associated with a company ($1.44)
+- **Person Search**: Search people by company, role, geography, and name
+- **Person Enrichment**: Enrich person data from email, phone, or social URL
+- **Person Events**: Find life events and career milestones
+- **Person Social Profiles**: Get all social media profiles for a person
+- **Person Single Social Lookup**: Look up a specific social media profile
+- **Person Interactions**: Get social media interactions
+- **Person Interests**: Get interests, skills, and topics a person engages with
+- **Person Newsfeed**: Get social media newsfeed data
+- **Company Search**: Search companies by industry and keywords
+- **Company Enrichment**: Enrich company data from email, phone, or social URL
+- **Company Check Seller**: Check if a company sells a specific product/service
+- **Company Needs**: Analyze company needs from SEC filings and content
+- **Company Funding**: Get company funding history and investment details
+- **Company Funders**: Get investors and funders associated with a company
 
 ## Usage
 
-### Person Search ($0.075)
+### Person Search
 Search people by company name, role, geography, and person name. Returns requestId for polling.
 
 Parameters:
@@ -52,7 +52,7 @@ Parameters:
 orth api run nyne /person/search --body '{"query": "Software engineers at OpenAI"}'
 ```
 
-### Person Enrichment ($0.075)
+### Person Enrichment
 Enrich a person's profile from email, phone, or social media URL. Returns comprehensive data including work history, education, and social profiles.
 
 Parameters:
@@ -72,7 +72,7 @@ Parameters:
 orth api run nyne /person/enrichment --body '{"email": "john@openai.com"}'
 ```
 
-### Person Events ($0.219)
+### Person Events
 Find life events and career milestones for people at specific events.
 
 Parameters:
@@ -87,7 +87,7 @@ Parameters:
 orth api run nyne /person/events --body '{"event": "YC Demo Day"}'
 ```
 
-### Person Social Profiles ($0.363)
+### Person Social Profiles
 Get all social media profiles associated with a person.
 
 Parameters:
@@ -100,7 +100,7 @@ Parameters:
 orth api run nyne /person/social-profiles --body '{"email": "john@openai.com"}'
 ```
 
-### Person Single Social Lookup ($0.148)
+### Person Single Social Lookup
 Look up a single social media profile for a person on a specific platform.
 
 Parameters:
@@ -113,7 +113,7 @@ Parameters:
 orth api run nyne /person/single-social-lookup --body '{"email": "john@openai.com", "site": "linkedin"}'
 ```
 
-### Person Interactions ($0.219)
+### Person Interactions
 Get social media interactions (replies, followers, following) from a profile.
 
 Parameters:
@@ -126,7 +126,7 @@ Parameters:
 orth api run nyne /person/interactions --body '{"type": "followers", "social_media_url": "https://twitter.com/openai"}'
 ```
 
-### Person Interests ($0.363)
+### Person Interests
 Get interests, skills, and topics a person engages with.
 
 Parameters:
@@ -139,7 +139,7 @@ Parameters:
 orth api run nyne /person/interests --body '{"email": "john@openai.com"}'
 ```
 
-### Person Newsfeed ($0.435)
+### Person Newsfeed
 Get social media newsfeed data from LinkedIn, Twitter, Instagram, GitHub, or Facebook profiles.
 
 Parameters:
@@ -150,7 +150,7 @@ Parameters:
 orth api run nyne /person/newsfeed --body '{"social_media_url": "https://linkedin.com/in/johndoe"}'
 ```
 
-### Company Search ($0.363)
+### Company Search
 Search for companies by industry focus and website keywords.
 
 Parameters:
@@ -165,7 +165,7 @@ Parameters:
 orth api run nyne /company/search --body '{"industry": "AI", "location": "San Francisco"}'
 ```
 
-### Company Enrichment ($0.076)
+### Company Enrichment
 Enrich company data from email, phone, or LinkedIn company URL.
 
 Parameters:
@@ -178,7 +178,7 @@ Parameters:
 orth api run nyne /company/enrichment --body '{"social_media_url": "https://linkedin.com/company/openai"}'
 ```
 
-### Company Check Seller ($0.148)
+### Company Check Seller
 Check if a company sells a specific product or service.
 
 Parameters:
@@ -190,7 +190,7 @@ Parameters:
 orth api run nyne /company/checkseller --body '{"company_name": "Vanta", "product_service": "SOC 2 automation"}'
 ```
 
-### Company Needs ($0.219)
+### Company Needs
 Analyze company needs based on SEC filings and provided content.
 
 Parameters:
@@ -203,7 +203,7 @@ Parameters:
 orth api run nyne /company/needs --body '{"company_name": "Uber Technologies", "content": "Regulatory challenges"}'
 ```
 
-### Company Funding ($0.578)
+### Company Funding
 Get company funding history and investment details.
 
 Parameters:
@@ -215,7 +215,7 @@ Parameters:
 orth api run nyne /company/funding --body '{"company_name": "OpenAI"}'
 ```
 
-### Company Funders ($1.44)
+### Company Funders
 Get investors and funders associated with a company.
 
 Parameters:

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -9,22 +9,22 @@ Powerful web scraping, crawling, and AI-powered content extraction.
 
 ## Capabilities
 
-- **Create Scrape**: Initiate a web page scrape ($0.01)
-- **Create Answer**: The AI will perform actions like searching and browsing web pages to find the answer to the provided task ($0.05)
-- **Maps**: This endpoint allows users to get all the urls on a certain website ($0.01)
-- **Start Crawl**: Starts a new crawl ($0.05)
-- **Start Batch**: Starts a new batch ($0.01)
-- **Batch Items**: Retrieves the list of items processed for a batch ($0.01)
-- **Crawl Info**: Fetches information about a specific crawl ($0.01)
-- **Crawl Pages**: Fetches the list of pages for a specific crawl ($0.01)
-- **Get Answer**: This endpoint retrieves a previously completed answer by its ID ($0.01)
-- **Get Scrape**: Can be used to retrieve response for a scrape ($0.01)
-- **Batch Info**: Retrieves the status and progress information about a batch ($0.01)
-- **Retrieve Content**: Retrieve page content of processed batches and crawls urls ($0.01)
+- **Create Scrape**: Initiate a web page scrape
+- **Create Answer**: The AI will perform actions like searching and browsing web pages to find the answer to the provided task
+- **Maps**: This endpoint allows users to get all the urls on a certain website
+- **Start Crawl**: Starts a new crawl
+- **Start Batch**: Starts a new batch
+- **Batch Items**: Retrieves the list of items processed for a batch
+- **Crawl Info**: Fetches information about a specific crawl
+- **Crawl Pages**: Fetches the list of pages for a specific crawl
+- **Get Answer**: This endpoint retrieves a previously completed answer by its ID
+- **Get Scrape**: Can be used to retrieve response for a scrape
+- **Batch Info**: Retrieves the status and progress information about a batch
+- **Retrieve Content**: Retrieve page content of processed batches and crawls urls
 
 ## Usage
 
-### Create Scrape ($0.01)
+### Create Scrape
 Initiate a web page scrape
 
 Parameters:
@@ -47,7 +47,7 @@ Parameters:
 orth api run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
 ```
 
-### Create Answer ($0.05)
+### Create Answer
 The AI will perform actions like searching and browsing web pages to find the answer to the provided task. Execution time is 3-30s depending upon complexity. For longer tasks, use the agent endpoint instead.
 
 Parameters:
@@ -58,7 +58,7 @@ Parameters:
 orth api run olostep /v1/answers --body '{"task": "What are the latest AI developments?"}'
 ```
 
-### Maps ($0.01)
+### Maps
 This endpoint allows users to get all the urls on a certain website. It can take up to 120 seconds for complex websites. For large websites, results are paginated using cursor-based pagination
 
 Parameters:
@@ -74,7 +74,7 @@ Parameters:
 orth api run olostep /v1/maps --body '{"url": "https://example.com"}'
 ```
 
-### Start Crawl ($0.05)
+### Start Crawl
 Starts a new crawl. You receive a `id` to track the progress. The operation may take 1-10 mins depending upon the site and depth and pages parameters.
 
 Parameters:
@@ -97,7 +97,7 @@ orth api run olostep /v1/crawls --body '{
 }'
 ```
 
-### Start Batch ($0.01)
+### Start Batch
 Starts a new batch. You receive an `id` that you can use to track the progress of the batch as shown [here](/api-reference/batches/info). Note: Processing time is constant regardless of batch size
 
 Parameters:
@@ -115,49 +115,49 @@ orth api run olostep /v1/batches --body '{
 }'
 ```
 
-### Batch Items ($0.01)
+### Batch Items
 Retrieves the list of items processed for a batch. You can then use the `retrieve_id` to get the content with the Retrieve Endpoint
 
 ```bash
 orth api run olostep /v1/batches/{batch_id}/items
 ```
 
-### Crawl Info ($0.01)
+### Crawl Info
 Fetches information about a specific crawl.
 
 ```bash
 orth api run olostep /v1/crawls/{crawl_id}
 ```
 
-### Crawl Pages ($0.01)
+### Crawl Pages
 Fetches the list of pages for a specific crawl.
 
 ```bash
 orth api run olostep /v1/crawls/{crawl_id}/pages
 ```
 
-### Get Answer ($0.01)
+### Get Answer
 This endpoint retrieves a previously completed answer by its ID.
 
 ```bash
 orth api run olostep /v1/answers/{answer_id}
 ```
 
-### Get Scrape ($0.01)
+### Get Scrape
 Can be used to retrieve response for a scrape.
 
 ```bash
 orth api run olostep /v1/scrapes/{scrape_id}
 ```
 
-### Batch Info ($0.01)
+### Batch Info
 Retrieves the status and progress information about a batch. To retrieve the content for a batch, see here
 
 ```bash
 orth api run olostep /v1/batches/{batch_id}
 ```
 
-### Retrieve Content ($0.01)
+### Retrieve Content
 Retrieve page content of processed batches and crawls urls.
 
 Parameters:

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -14,13 +14,13 @@ Web research API that returns OpenAI ChatCompletions-compatible responses.
 - **Cancel FindAll Run**: Cancel a FindAll run (free)
 - **Retrieve Task Run Input**: Retrieves the input of a run by run_id (free)
 - **Retrieve Task Run**: Retrieves run status by run_id (free)
-- **Ingest FindAll Run**: Transforms a natural language search objective into a structured FindAll spec ($0.01)
+- **Ingest FindAll Run**: Transforms a natural language search objective into a structured FindAll spec
 - **Retrieve Task Run Result**: Retrieves a run result by run_id, blocking until the run is completed (free)
-- **Create FindAll Run**: Starts a FindAll run ($0.01)
-- **Search**: Searches the web ($0.01)
-- **Chat API**: Parallel Chat is a web research API that returns OpenAI ChatCompletions compatible streaming text and JSON ($0.01)
-- **Extract**: Extracts relevant content from specific web URLs ($0.01)
-- **Create Task Run**: Initiates a task run ($0.01)
+- **Create FindAll Run**: Starts a FindAll run
+- **Search**: Searches the web
+- **Chat API**: Parallel Chat is a web research API that returns OpenAI ChatCompletions compatible streaming text and JSON
+- **Extract**: Extracts relevant content from specific web URLs
+- **Create Task Run**: Initiates a task run
 
 ## Usage
 
@@ -59,7 +59,7 @@ Retrieves run status by run_id.The run result is available from the /result endp
 orth api run parallel /v1/tasks/runs/{run_id}
 ```
 
-### Ingest FindAll Run ($0.01)
+### Ingest FindAll Run
 Transforms a natural language search objective into a structured FindAll spec.Note: Access to this endpoint requires the parallel-beta header.The generated specification serves as a suggested starting point and can be furthercustomized by the user.
 
 Parameters:
@@ -79,7 +79,7 @@ Parameters:
 orth api run parallel /v1/tasks/runs/{run_id}/result
 ```
 
-### Create FindAll Run ($0.01)
+### Create FindAll Run
 Starts a FindAll run.This endpoint immediately returns a FindAll run object with status set to ‘queued’.You can get the run result snapshot using the GET /v1beta/findall/runs//result endpoint.You can track the progress of the run by:Polling the status using the GET /v1beta/findall/runs/ endpoint,Subscribing to real-time updates via the /v1beta/findall/runs//eventsendpoint,Or specifying a webhook with relevant event types during run creation to receivenotifications.
 
 Parameters:
@@ -98,7 +98,7 @@ orth api run parallel /v1beta/findall/runs --body '{
 }'
 ```
 
-### Search ($0.01)
+### Search
 Searches the web.To access this endpoint, pass the parallel-beta header with the valuesearch-extract-2025-10-10.
 
 Parameters:
@@ -116,7 +116,7 @@ Parameters:
 orth api run parallel /v1beta/search --body '{"objective": "AI agent frameworks comparison 2024"}'
 ```
 
-### Chat API ($0.01)
+### Chat API
 Parallel Chat is a web research API that returns OpenAI ChatCompletions compatible streaming text and JSON.
 
 Parameters:
@@ -134,7 +134,7 @@ orth api run parallel /chat/completions --body '{
 }'
 ```
 
-### Extract ($0.01)
+### Extract
 Extracts relevant content from specific web URLs.To access this endpoint, pass the parallel-beta header with the valuesearch-extract-2025-10-10.
 
 Parameters:
@@ -149,7 +149,7 @@ Parameters:
 orth api run parallel /v1beta/extract --body '{"urls": ["https://example.com/article"]}'
 ```
 
-### Create Task Run ($0.01)
+### Create Task Run
 Initiates a task run.Returns immediately with a run object in status ‘queued’.Beta features can be enabled by setting the ‘parallel-beta’ header.
 
 Parameters:

--- a/skills/orthogonal-perplexity/SKILL.md
+++ b/skills/orthogonal-perplexity/SKILL.md
@@ -9,15 +9,15 @@ AI-powered search and chat completions with real-time web data.
 
 ## Capabilities
 
-- **Chat Completions**: Generates a model’s response for the given chat conversation ($0.01)
-- **Search**: Get ranked search results from Perplexity’s continuously refreshed index with advanced filtering and customization options ($0.01)
-- **Sonar Chat Completions API**: Creates an asynchronous chat completion job ($0.01)
-- **Get Async Chat Completion Response**: Retrieves the status and result of a specific asynchronous chat completion job ($0.01)
-- **List Async Chat Completions**: Lists all asynchronous chat completion requests for the authenticated user ($0.01)
+- **Chat Completions**: Generates a model’s response for the given chat conversation
+- **Search**: Get ranked search results from Perplexity’s continuously refreshed index with advanced filtering and customization options
+- **Sonar Chat Completions API**: Creates an asynchronous chat completion job
+- **Get Async Chat Completion Response**: Retrieves the status and result of a specific asynchronous chat completion job
+- **List Async Chat Completions**: Lists all asynchronous chat completion requests for the authenticated user
 
 ## Usage
 
-### Chat Completions ($0.01)
+### Chat Completions
 Generates a model’s response for the given chat conversation.
 
 Parameters:
@@ -56,7 +56,7 @@ orth api run perplexity /chat/completions --body '{
 }'
 ```
 
-### Search ($0.01)
+### Search
 Get ranked search results from Perplexity’s continuously refreshed index with advanced filtering and customization options.
 
 Parameters:
@@ -77,7 +77,7 @@ Parameters:
 orth api run perplexity /search --body '{"query": "latest AI developments February 2024"}'
 ```
 
-### Sonar Chat Completions API ($0.01)
+### Sonar Chat Completions API
 Creates an asynchronous chat completion job.
 
 Parameters:
@@ -92,14 +92,14 @@ orth api run perplexity /async/chat/completions --body '{
 }'
 ```
 
-### Get Async Chat Completion Response ($0.01)
+### Get Async Chat Completion Response
 Retrieves the status and result of a specific asynchronous chat completion job.
 
 ```bash
 orth api run perplexity /async/chat/completions/{request_id}
 ```
 
-### List Async Chat Completions ($0.01)
+### List Async Chat Completions
 Lists all asynchronous chat completion requests for the authenticated user.
 
 Parameters:

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -9,27 +9,27 @@ Access hyperlocal weather data including precipitation, temperature, wind, soil 
 
 ## Capabilities
 
-- **Last 48 Hours Precipitation Data**: Total precipitation in the last 48 hours for the given location(s) ($0.01)
-- **Air Temperature**: Hourly near-surface air temperature in Celsius (°C) ($0.01)
-- **Hourly Soil Moisture**: Hourly soil moisture percentage relative to holding capacity at 0-10cm depth ($0.01)
-- **Wind Direction**: Hourly wind direction in compass degrees (0-360) ($0.01)
-- **Daily Precipitation Data**: Returns comprehensive daily precipitation data for the given time range and location(s) ($0.01)
-- **Wind Gusts**: Hourly wind gust speed in meters per second (m/s) ($0.01)
-- **Recent Rain Event**: Returns detailed information about the most recent precipitation event for the given location(s), including total amounts, precipitation type (rain/snow), timing, and how long ago it occurred ($0.01)
-- **Map Layer Tiles**: Map tiles compatible with most web mapping or GIS tools ($0.01)
-- **Wind Speed**: Hourly near-surface wind speed in meters per second (m/s) ($0.01)
-- **Cloud Cover**: Hourly cloud cover fraction (0-1, where 0 is clear and 1 is overcast) ($0.01)
-- **Soil Temperature**: Hourly soil temperature data at 0-10cm depth in Celsius (°C) ($0.01)
-- **Specific Humidity**: Hourly specific humidity (kg/kg) ($0.01)
-- **Hourly Precipitation Data**: Returns comprehensive hourly precipitation data for the given time range and location(s) ($0.01)
-- **Daily Soil Moisture**: Daily soil moisture percentage relative to holding capacity at 0-10cm depth ($0.01)
-- **Embeddable HTML UI**: Returns a complete, HTML page displaying comprehensive weather data for a specific location ($0.10)
-- **Solar Radiation**: Hourly downward short-wave radiation flux in watts per square meter (W/m²) ($0.01)
-- **Relative Humidity**: Hourly relative humidity as a percentage (0-100%) ($0.01)
+- **Last 48 Hours Precipitation Data**: Total precipitation in the last 48 hours for the given location(s)
+- **Air Temperature**: Hourly near-surface air temperature in Celsius (°C)
+- **Hourly Soil Moisture**: Hourly soil moisture percentage relative to holding capacity at 0-10cm depth
+- **Wind Direction**: Hourly wind direction in compass degrees (0-360)
+- **Daily Precipitation Data**: Returns comprehensive daily precipitation data for the given time range and location(s)
+- **Wind Gusts**: Hourly wind gust speed in meters per second (m/s)
+- **Recent Rain Event**: Returns detailed information about the most recent precipitation event for the given location(s), including total amounts, precipitation type (rain/snow), timing, and how long ago it occurred
+- **Map Layer Tiles**: Map tiles compatible with most web mapping or GIS tools
+- **Wind Speed**: Hourly near-surface wind speed in meters per second (m/s)
+- **Cloud Cover**: Hourly cloud cover fraction (0-1, where 0 is clear and 1 is overcast)
+- **Soil Temperature**: Hourly soil temperature data at 0-10cm depth in Celsius (°C)
+- **Specific Humidity**: Hourly specific humidity (kg/kg)
+- **Hourly Precipitation Data**: Returns comprehensive hourly precipitation data for the given time range and location(s)
+- **Daily Soil Moisture**: Daily soil moisture percentage relative to holding capacity at 0-10cm depth
+- **Embeddable HTML UI**: Returns a complete, HTML page displaying comprehensive weather data for a specific location
+- **Solar Radiation**: Hourly downward short-wave radiation flux in watts per square meter (W/m²)
+- **Relative Humidity**: Hourly relative humidity as a percentage (0-100%)
 
 ## Usage
 
-### Last 48 Hours Precipitation Data ($0.01)
+### Last 48 Hours Precipitation Data
 Total precipitation in the last 48 hours for the given location(s).
 
 Parameters:
@@ -42,7 +42,7 @@ Parameters:
 orth api run precip /api/v1/last-48 --query latitude=37.7749 longitude=-122.4194
 ```
 
-### Air Temperature ($0.01)
+### Air Temperature
 Hourly near-surface air temperature in Celsius (°C)
 
 Parameters:
@@ -57,7 +57,7 @@ Parameters:
 orth api run precip /api/v1/temperature-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Hourly Soil Moisture ($0.01)
+### Hourly Soil Moisture
 Hourly soil moisture percentage relative to holding capacity at 0-10cm depth
 
 Parameters:
@@ -72,7 +72,7 @@ Parameters:
 orth api run precip /api/v1/soil-moisture-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Wind Direction ($0.01)
+### Wind Direction
 Hourly wind direction in compass degrees (0-360)
 
 Parameters:
@@ -87,7 +87,7 @@ Parameters:
 orth api run precip /api/v1/wind-direction-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Daily Precipitation Data ($0.01)
+### Daily Precipitation Data
 Returns comprehensive daily precipitation data for the given time range and location(s). Each day includes precipitation amount, type (rain/snow/mixed), probability (for forecasts), and data source. Seamlessly combines historical observations with forecast data depending on the requested time range.
 
 Parameters:
@@ -102,7 +102,7 @@ Parameters:
 orth api run precip /api/v1/daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
 ```
 
-### Wind Gusts ($0.01)
+### Wind Gusts
 Hourly wind gust speed in meters per second (m/s)
 
 Parameters:
@@ -117,7 +117,7 @@ Parameters:
 orth api run precip /api/v1/wind-speed-gust-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Recent Rain Event ($0.01)
+### Recent Rain Event
 Returns detailed information about the most recent precipitation event for the given location(s), including total amounts, precipitation type (rain/snow), timing, and how long ago it occurred.
 
 Parameters:
@@ -130,7 +130,7 @@ Parameters:
 orth api run precip /api/v1/recent-rain --query latitude=37.7749 longitude=-122.4194
 ```
 
-### Map Layer Tiles ($0.01)
+### Map Layer Tiles
 Map tiles compatible with most web mapping or GIS tools. Software such as Mapbox, Google Maps, ArcGIS, Leaflet, OpenLayers or QGIS will require an `x/y/z` url eg `https://api.precip.ai/api/v1/map/last-48/ImageServer/tile/{z}/{y}/{x}`. See the examples for more details.
 
 Parameters:
@@ -140,7 +140,7 @@ Parameters:
 orth api run precip /api/v1/map/precipitation/ImageServer/tile/5/12/10
 ```
 
-### Wind Speed ($0.01)
+### Wind Speed
 Hourly near-surface wind speed in meters per second (m/s)
 
 Parameters:
@@ -155,7 +155,7 @@ Parameters:
 orth api run precip /api/v1/wind-speed-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Cloud Cover ($0.01)
+### Cloud Cover
 Hourly cloud cover fraction (0-1, where 0 is clear and 1 is overcast)
 
 Parameters:
@@ -170,7 +170,7 @@ Parameters:
 orth api run precip /api/v1/cloud-cover-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Soil Temperature ($0.01)
+### Soil Temperature
 Hourly soil temperature data at 0-10cm depth in Celsius (°C)
 
 Parameters:
@@ -185,7 +185,7 @@ Parameters:
 orth api run precip /api/v1/temp-0-10cm-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Specific Humidity ($0.01)
+### Specific Humidity
 Hourly specific humidity (kg/kg)
 
 Parameters:
@@ -200,7 +200,7 @@ Parameters:
 orth api run precip /api/v1/specific-humidity-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Hourly Precipitation Data ($0.01)
+### Hourly Precipitation Data
 Returns comprehensive hourly precipitation data for the given time range and location(s). Each hour includes precipitation amount, type (rain/snow/mixed), probability (for forecasts), and data source.
 
 Parameters:
@@ -215,7 +215,7 @@ Parameters:
 orth api run precip /api/v1/hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-07
 ```
 
-### Daily Soil Moisture ($0.01)
+### Daily Soil Moisture
 Daily soil moisture percentage relative to holding capacity at 0-10cm depth
 
 Parameters:
@@ -230,7 +230,7 @@ Parameters:
 orth api run precip /api/v1/soil-moisture-daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
 ```
 
-### Embeddable HTML UI ($0.10)
+### Embeddable HTML UI
 Returns a complete, HTML page displaying comprehensive weather data for a specific location. See the examples page for more details. 
 
  Authorization headers set automatically from query parameters on this endpoint.
@@ -251,7 +251,7 @@ When not provided, shows all widgets.
 orth api run precip /embed/location --query lat=37.7749 lon=-122.4194
 ```
 
-### Solar Radiation ($0.01)
+### Solar Radiation
 Hourly downward short-wave radiation flux in watts per square meter (W/m²)
 
 Parameters:
@@ -266,7 +266,7 @@ Parameters:
 orth api run precip /api/v1/solar-radiation-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
-### Relative Humidity ($0.01)
+### Relative Humidity
 Hourly relative humidity as a percentage (0-100%)
 
 Parameters:

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -9,15 +9,15 @@ Scrape web pages and extract data into your defined structure.
 
 ## Capabilities
 
-- **Scrape**: Scrape a webpage and return the text content ($0.01)
-- **Run**: Copy link Define the structure of your output directly in the API request ($0.01)
+- **Scrape**: Scrape a webpage and return the text content
+- **Run**: Copy link Define the structure of your output directly in the API request
 - **Run data**: Retrieve the processed data from a completed project run (free)
 - **Run status**: Check the current status of a project run (free)
 - **Stop run**: Stop a currently running project (free)
 
 ## Usage
 
-### Scrape ($0.01)
+### Scrape
 Scrape a webpage and return the text content. This endpoint allows you to extract text content from any public webpage.
 
 Parameters:
@@ -29,7 +29,7 @@ Parameters:
 orth api run riveter /v1/scrape --body '{"url": "https://example.com/article"}'
 ```
 
-### Run ($0.01)
+### Run
 Copy link Define the structure of your output directly in the API request. This endpoint allows you to define both your input data and output configuration in a single request.
 
 Parameters:

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -9,12 +9,12 @@ Extract web content using AI with natural language prompts.
 
 ## Capabilities
 
-- **Start SmartScraper**: Extract content from a webpage using AI by providing a natural language prompt and a URL ($0.04)
-- **Start SearchScraper**: Start a new AI-powered web search request ($0.12)
-- **Scrape**: Extract raw HTML content from web pages with JavaScript rendering support ($0.03)
-- **Start SmartCrawler**: Start a new web crawl request with AI extraction or markdown conversion ($0.04)
-- **Start Sitemap**: Extract all URLs from a website sitemap automatically ($0.01)
-- **Start Markdownify**: Convert any webpage into clean, readable Markdown format ($0.03)
+- **Start SmartScraper**: Extract content from a webpage using AI by providing a natural language prompt and a URL
+- **Start SearchScraper**: Start a new AI-powered web search request
+- **Scrape**: Extract raw HTML content from web pages with JavaScript rendering support
+- **Start SmartCrawler**: Start a new web crawl request with AI extraction or markdown conversion
+- **Start Sitemap**: Extract all URLs from a website sitemap automatically
+- **Start Markdownify**: Convert any webpage into clean, readable Markdown format
 - **Get SearchScraper Status**: Get the status and results of a previous search request (free)
 - **Get Markdownify Status**: Check the status and retrieve results of a Markdownify request (free)
 - **Get Sitemap Status**: Check the status and retrieve results of a Sitemap request (free)
@@ -23,7 +23,7 @@ Extract web content using AI with natural language prompts.
 
 ## Usage
 
-### Start SmartScraper ($0.04)
+### Start SmartScraper
 Extract content from a webpage using AI by providing a natural language prompt and a URL.
 
 Parameters:
@@ -48,7 +48,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 }'
 ```
 
-### Start SearchScraper ($0.12)
+### Start SearchScraper
 Start a new AI-powered web search request
 
 Parameters:
@@ -62,7 +62,7 @@ Parameters:
 orth api run scrapegraph /v1/searchscraper --body '{"user_prompt": "Find the latest iPhone prices from major retailers"}'
 ```
 
-### Scrape ($0.03)
+### Scrape
 Extract raw HTML content from web pages with JavaScript rendering support
 
 Parameters:
@@ -75,7 +75,7 @@ Parameters:
 orth api run scrapegraph /v1/scrape --body '{"website_url": "https://example.com"}'
 ```
 
-### Start SmartCrawler ($0.04)
+### Start SmartCrawler
 Start a new web crawl request with AI extraction or markdown conversion
 
 Parameters:
@@ -100,7 +100,7 @@ orth api run scrapegraph /v1/crawl --body '{
 }'
 ```
 
-### Start Sitemap ($0.01)
+### Start Sitemap
 Extract all URLs from a website sitemap automatically.
 
 Parameters:
@@ -113,7 +113,7 @@ Parameters:
 orth api run scrapegraph /v1/sitemap --body '{"website_url": "https://example.com"}'
 ```
 
-### Start Markdownify ($0.03)
+### Start Markdownify
 Convert any webpage into clean, readable Markdown format.
 
 Parameters:

--- a/skills/orthogonal-searchapi/SKILL.md
+++ b/skills/orthogonal-searchapi/SKILL.md
@@ -9,28 +9,28 @@ Search across YouTube, Amazon, eBay, Walmart, TikTok, Instagram, Airbnb, and ad 
 
 ## Capabilities
 
-- **TripAdvisor Search**: Search TripAdvisor listings ($0.01)
-- **YouTube Comments**: Get comments on a YouTube video ($0.01)
-- **YouTube Channel**: Get YouTube channel info ($0.01)
-- **Reddit Ad Library**: Search Reddit ads library ($0.01)
-- **Meta Ad Library**: Search Meta/Facebook ads library ($0.01)
-- **YouTube Transcripts**: Get video transcript/captions ($0.01)
-- **Amazon Search**: Search Amazon products ($0.01)
-- **eBay Search**: Search eBay listings ($0.01)
-- **YouTube Video Details**: Get detailed info about a YouTube video ($0.01)
-- **YouTube Channel Videos**: Get videos from a YouTube channel ($0.01)
-- **Apple App Store Search**: Search Apple App Store apps ($0.01)
-- **Airbnb Search**: Search Airbnb listings ($0.01)
-- **TikTok Profile**: Get TikTok user profile info ($0.01)
-- **Instagram Profile**: Get Instagram profile info ($0.01)
-- **Walmart Search**: Search Walmart products ($0.01)
-- **TikTok Ads Library**: Search TikTok ads library ($0.01)
-- **LinkedIn Ad Library**: Search LinkedIn ads library ($0.01)
-- **YouTube Search**: Search YouTube videos by query ($0.01)
+- **TripAdvisor Search**: Search TripAdvisor listings
+- **YouTube Comments**: Get comments on a YouTube video
+- **YouTube Channel**: Get YouTube channel info
+- **Reddit Ad Library**: Search Reddit ads library
+- **Meta Ad Library**: Search Meta/Facebook ads library
+- **YouTube Transcripts**: Get video transcript/captions
+- **Amazon Search**: Search Amazon products
+- **eBay Search**: Search eBay listings
+- **YouTube Video Details**: Get detailed info about a YouTube video
+- **YouTube Channel Videos**: Get videos from a YouTube channel
+- **Apple App Store Search**: Search Apple App Store apps
+- **Airbnb Search**: Search Airbnb listings
+- **TikTok Profile**: Get TikTok user profile info
+- **Instagram Profile**: Get Instagram profile info
+- **Walmart Search**: Search Walmart products
+- **TikTok Ads Library**: Search TikTok ads library
+- **LinkedIn Ad Library**: Search LinkedIn ads library
+- **YouTube Search**: Search YouTube videos by query
 
 ## Usage
 
-### TripAdvisor Search ($0.01)
+### TripAdvisor Search
 Search TripAdvisor listings
 
 Parameters:
@@ -48,7 +48,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=tripadvisor q=best%20restaurants%20NYC
 ```
 
-### YouTube Comments ($0.01)
+### YouTube Comments
 Get comments on a YouTube video
 
 Parameters:
@@ -62,7 +62,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=youtube_comments video_id=dQw4w9WgXcQ
 ```
 
-### YouTube Channel ($0.01)
+### YouTube Channel
 Get YouTube channel info
 
 Parameters:
@@ -75,7 +75,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=youtube_channel channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw
 ```
 
-### Reddit Ad Library ($0.01)
+### Reddit Ad Library
 Search Reddit ads library
 
 Parameters:
@@ -91,7 +91,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=reddit_ad_library q=software
 ```
 
-### Meta Ad Library ($0.01)
+### Meta Ad Library
 Search Meta/Facebook ads library
 
 Parameters:
@@ -114,7 +114,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=meta_ad_library q=AI%20tools
 ```
 
-### YouTube Transcripts ($0.01)
+### YouTube Transcripts
 Get video transcript/captions
 
 Parameters:
@@ -129,7 +129,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=youtube_transcripts video_id=dQw4w9WgXcQ
 ```
 
-### Amazon Search ($0.01)
+### Amazon Search
 Search Amazon products
 
 Parameters:
@@ -148,7 +148,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=amazon_search q=wireless%20headphones
 ```
 
-### eBay Search ($0.01)
+### eBay Search
 Search eBay listings
 
 Parameters:
@@ -173,7 +173,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=ebay_search q=vintage%20watch
 ```
 
-### YouTube Video Details ($0.01)
+### YouTube Video Details
 Get detailed info about a YouTube video
 
 Parameters:
@@ -186,7 +186,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=youtube_video video_id=dQw4w9WgXcQ
 ```
 
-### YouTube Channel Videos ($0.01)
+### YouTube Channel Videos
 Get videos from a YouTube channel
 
 Parameters:
@@ -199,7 +199,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=youtube_channel_videos channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw
 ```
 
-### Apple App Store Search ($0.01)
+### Apple App Store Search
 Search Apple App Store apps
 
 Parameters:
@@ -217,7 +217,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=apple_app_store term=productivity
 ```
 
-### Airbnb Search ($0.01)
+### Airbnb Search
 Search Airbnb listings
 
 Parameters:
@@ -245,7 +245,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=airbnb q=Paris
 ```
 
-### TikTok Profile ($0.01)
+### TikTok Profile
 Get TikTok user profile info
 
 Parameters:
@@ -256,7 +256,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=tiktok_profile username=openai
 ```
 
-### Instagram Profile ($0.01)
+### Instagram Profile
 Get Instagram profile info
 
 Parameters:
@@ -267,7 +267,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=instagram_profile username=openai
 ```
 
-### Walmart Search ($0.01)
+### Walmart Search
 Search Walmart products
 
 Parameters:
@@ -285,7 +285,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=walmart_search q=laptop
 ```
 
-### TikTok Ads Library ($0.01)
+### TikTok Ads Library
 Search TikTok ads library
 
 Parameters:
@@ -301,7 +301,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=tiktok_ads_library q=AI
 ```
 
-### LinkedIn Ad Library ($0.01)
+### LinkedIn Ad Library
 Search LinkedIn ads library
 
 Parameters:
@@ -316,7 +316,7 @@ Parameters:
 orth api run searchapi /api/v1/search --query engine=linkedin_ad_library q=hiring
 ```
 
-### YouTube Search ($0.01)
+### YouTube Search
 Search YouTube videos by query
 
 Parameters:

--- a/skills/orthogonal-shofo/SKILL.md
+++ b/skills/orthogonal-shofo/SKILL.md
@@ -9,28 +9,28 @@ Scrape profiles, posts, and comments from Instagram, TikTok, LinkedIn, and X/Twi
 
 ## Capabilities
 
-- **Instagram Hashtag**: Get posts for an Instagram hashtag ($0.01)
-- **X/Twitter Tweet Comments**: Get comments/replies from an X tweet ($0.01)
-- **LinkedIn Company Posts**: Get recent posts from a LinkedIn company page ($0.01)
-- **TikTok Hashtag Videos**: Get videos for a specific hashtag ($0.01)
-- **X/Twitter User Profile**: Get X/Twitter profile data including bio, follower counts, and profile info ($0.01)
-- **TikTok Feed Videos**: Get videos from TikTok's recommendation feed ($0.01)
-- **Instagram User Profile**: Get Instagram profile data with optional followers and following lists ($0.01)
-- **TikTok User Profile Videos**: Get videos from a specific TikTok user's profile ($0.01)
-- **TikTok Video Comments**: Get comments from a TikTok video ($0.01)
-- **Linkedin User Profile**: Get comprehensive LinkedIn profile data including work experience, education, skills, and contact info ($0.01)
-- **Linkedin User Posts**: Get recent posts and activity from a LinkedIn user ($0.01)
-- **Linkedin Company Profile**: Get company information including size, industry, locations, and specialties ($0.01)
-- **Linkedin Search Employees**: Search LinkedIn people by company or school ($0.01)
-- **Instagram User Posts**: Get posts or reels from an Instagram user's profile ($0.01)
-- **Instagram Individual Post**: Get detailed data for a specific Instagram post by shortcode or URL ($0.01)
-- **Instagram Post Comments**: Get comments from an Instagram post ($0.01)
-- **X/Twitter User Posts**: Get tweets from a user's profile ($0.01)
-- **X/Twitter Individual Post**: Get detailed data for a specific tweet by ID or URL ($0.01)
+- **Instagram Hashtag**: Get posts for an Instagram hashtag
+- **X/Twitter Tweet Comments**: Get comments/replies from an X tweet
+- **LinkedIn Company Posts**: Get recent posts from a LinkedIn company page
+- **TikTok Hashtag Videos**: Get videos for a specific hashtag
+- **X/Twitter User Profile**: Get X/Twitter profile data including bio, follower counts, and profile info
+- **TikTok Feed Videos**: Get videos from TikTok's recommendation feed
+- **Instagram User Profile**: Get Instagram profile data with optional followers and following lists
+- **TikTok User Profile Videos**: Get videos from a specific TikTok user's profile
+- **TikTok Video Comments**: Get comments from a TikTok video
+- **Linkedin User Profile**: Get comprehensive LinkedIn profile data including work experience, education, skills, and contact info
+- **Linkedin User Posts**: Get recent posts and activity from a LinkedIn user
+- **Linkedin Company Profile**: Get company information including size, industry, locations, and specialties
+- **Linkedin Search Employees**: Search LinkedIn people by company or school
+- **Instagram User Posts**: Get posts or reels from an Instagram user's profile
+- **Instagram Individual Post**: Get detailed data for a specific Instagram post by shortcode or URL
+- **Instagram Post Comments**: Get comments from an Instagram post
+- **X/Twitter User Posts**: Get tweets from a user's profile
+- **X/Twitter Individual Post**: Get detailed data for a specific tweet by ID or URL
 
 ## Usage
 
-### Instagram Hashtag ($0.01)
+### Instagram Hashtag
 Get posts for an Instagram hashtag.
 
 Parameters:
@@ -42,7 +42,7 @@ Parameters:
 orth api run shofo /instagram/hashtag --query 'hashtag=artificialintelligence'
 ```
 
-### X/Twitter Tweet Comments ($0.01)
+### X/Twitter Tweet Comments
 Get comments/replies from an X tweet.
 
 Parameters:
@@ -54,7 +54,7 @@ Parameters:
 orth api run shofo /x/comments --query 'tweet_url=https://x.com/OpenAI/status/123456'
 ```
 
-### LinkedIn Company Posts ($0.01)
+### LinkedIn Company Posts
 Get recent posts from a LinkedIn company page.
 
 Parameters:
@@ -67,7 +67,7 @@ Parameters:
 orth api run shofo /linkedin/company-posts --query 'url=https://linkedin.com/company/openai'
 ```
 
-### TikTok Hashtag Videos ($0.01)
+### TikTok Hashtag Videos
 Get videos for a specific hashtag. Great for campaign tracking and trend monitoring.
 
 Parameters:
@@ -80,7 +80,7 @@ Parameters:
 orth api run shofo /tiktok/hashtag --query 'hashtag=ai'
 ```
 
-### X/Twitter User Profile ($0.01)
+### X/Twitter User Profile
 Get X/Twitter profile data including bio, follower counts, and profile info.
 
 Parameters:
@@ -90,7 +90,7 @@ Parameters:
 orth api run shofo /x/user-profile --query 'username=OpenAI'
 ```
 
-### TikTok Feed Videos ($0.01)
+### TikTok Feed Videos
 Get videos from TikTok's recommendation feed. Perfect for trend analysis and content discovery.
 
 Parameters:
@@ -100,7 +100,7 @@ Parameters:
 orth api run shofo /tiktok/feed --query 'keyword=artificial%20intelligence'
 ```
 
-### Instagram User Profile ($0.01)
+### Instagram User Profile
 Get Instagram profile data with optional followers and following lists.
 
 Parameters:
@@ -112,7 +112,7 @@ Parameters:
 orth api run shofo /instagram/user-profile --query 'username=openai'
 ```
 
-### TikTok User Profile Videos ($0.01)
+### TikTok User Profile Videos
 Get videos from a specific TikTok user's profile.
 
 Parameters:
@@ -125,7 +125,7 @@ Parameters:
 orth api run shofo /tiktok/profile --query 'username=openai'
 ```
 
-### TikTok Video Comments ($0.01)
+### TikTok Video Comments
 Get comments from a TikTok video.
 
 Parameters:
@@ -137,7 +137,7 @@ Parameters:
 orth api run shofo /tiktok/comments --query 'video_url=https://tiktok.com/@user/video/123'
 ```
 
-### Linkedin User Profile ($0.01)
+### Linkedin User Profile
 Get comprehensive LinkedIn profile data including work experience, education, skills, and contact info.
 
 Parameters:
@@ -147,7 +147,7 @@ Parameters:
 orth api run shofo /linkedin/user-profile --query 'url=https://linkedin.com/in/johndoe'
 ```
 
-### Linkedin User Posts ($0.01)
+### Linkedin User Posts
 Get recent posts and activity from a LinkedIn user.
 
 Parameters:
@@ -158,7 +158,7 @@ Parameters:
 orth api run shofo /linkedin/user-posts --query 'url=https://linkedin.com/in/johndoe'
 ```
 
-### Linkedin Company Profile ($0.01)
+### Linkedin Company Profile
 Get company information including size, industry, locations, and specialties.
 
 Parameters:
@@ -170,7 +170,7 @@ Parameters:
 orth api run shofo /linkedin/company-profile --query 'url=https://linkedin.com/company/openai'
 ```
 
-### Linkedin Search Employees ($0.01)
+### Linkedin Search Employees
 Search LinkedIn people by company or school.
 
 Parameters:
@@ -183,7 +183,7 @@ Parameters:
 orth api run shofo /linkedin/search-employees --query 'company_url=https://linkedin.com/company/openai'
 ```
 
-### Instagram User Posts ($0.01)
+### Instagram User Posts
 Get posts or reels from an Instagram user's profile.
 
 Parameters:
@@ -195,7 +195,7 @@ Parameters:
 orth api run shofo /instagram/user-posts --query 'username=openai'
 ```
 
-### Instagram Individual Post ($0.01)
+### Instagram Individual Post
 Get detailed data for a specific Instagram post by shortcode or URL.
 
 Parameters:
@@ -205,7 +205,7 @@ Parameters:
 orth api run shofo /instagram/post --query 'url=https://instagram.com/p/abc123'
 ```
 
-### Instagram Post Comments ($0.01)
+### Instagram Post Comments
 Get comments from an Instagram post.
 
 Parameters:
@@ -218,7 +218,7 @@ Parameters:
 orth api run shofo /instagram/comments --query 'post_url=https://instagram.com/p/abc123'
 ```
 
-### X/Twitter User Posts ($0.01)
+### X/Twitter User Posts
 Get tweets from a user's profile.
 
 Parameters:
@@ -229,7 +229,7 @@ Parameters:
 orth api run shofo /x/user-posts --query 'username=OpenAI'
 ```
 
-### X/Twitter Individual Post ($0.01)
+### X/Twitter Individual Post
 Get detailed data for a specific tweet by ID or URL.
 
 Parameters:

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -9,14 +9,14 @@ Find contact information and enrich lead data using AI-powered discovery.
 
 ## Capabilities
 
-- **Find email**: Find email address for a lead ($0.05)
-- **Enrich lead**: Enrich lead information with additional details such as contact information, social profiles, and company details ($0.10)
-- **Find Phone API**: The Find Phone API uses Sixtyfour AI to discover phone numbers for leads ($0.30)
-- **Enrich company**: Enrich company data with additional information and find associated people ($0.10)
+- **Find email**: Find email address for a lead
+- **Enrich lead**: Enrich lead information with additional details such as contact information, social profiles, and company details
+- **Find Phone API**: The Find Phone API uses Sixtyfour AI to discover phone numbers for leads
+- **Enrich company**: Enrich company data with additional information and find associated people
 
 ## Usage
 
-### Find email ($0.05)
+### Find email
 Find email address for a lead.
 
 Parameters:
@@ -34,7 +34,7 @@ orth api run sixtyfour /find-email --body '{
 }'
 ```
 
-### Enrich lead ($0.10)
+### Enrich lead
 Enrich lead information with additional details such as contact information, social profiles, and company details.
 
 Parameters:
@@ -54,7 +54,7 @@ orth api run sixtyfour /enrich-lead --body '{
 }'
 ```
 
-### Find Phone API ($0.30)
+### Find Phone API
 The Find Phone API uses Sixtyfour AI to discover phone numbers for leads. It extracts contact information from lead data and returns enriched results with phone numbers.
 
 Parameters:
@@ -75,7 +75,7 @@ orth api run sixtyfour /find-phone --body '{
 }'
 ```
 
-### Enrich company ($0.10)
+### Enrich company
 Enrich company data with additional information and find associated people.
 
 Parameters:

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -9,16 +9,16 @@ Comprehensive web search, crawling, content extraction, and deep research.
 
 ## Capabilities
 
-- **Tavily Search**: Execute a search query using Tavily Search ($0.016)
+- **Tavily Search**: Execute a search query using Tavily Search
 - **Get Research Task Status**: Retrieve the status and results of a research task using its request ID (free)
-- **Create Research Task**: Tavily Research performs comprehensive research on a given topic by conducting multiple searches, analyzing sources, and generating a detailed research report ($0.50)
-- **Tavily Extract**: Extract web page content from one or more specified URLs using Tavily Extract ($0.01)
-- **Tavily Map**: Tavily Map traverses websites like a graph and can explore hundreds of paths in parallel with intelligent discovery to generate comprehensive site maps ($0.01)
-- **Tavily Crawl**: Tavily Crawl is a graph-based website traversal tool that can explore hundreds of paths in parallel with built-in extraction and intelligent discovery ($0.01)
+- **Create Research Task**: Tavily Research performs comprehensive research on a given topic by conducting multiple searches, analyzing sources, and generating a detailed research report
+- **Tavily Extract**: Extract web page content from one or more specified URLs using Tavily Extract
+- **Tavily Map**: Tavily Map traverses websites like a graph and can explore hundreds of paths in parallel with intelligent discovery to generate comprehensive site maps
+- **Tavily Crawl**: Tavily Crawl is a graph-based website traversal tool that can explore hundreds of paths in parallel with built-in extraction and intelligent discovery
 
 ## Usage
 
-### Tavily Search ($0.016)
+### Tavily Search
 Execute a search query using Tavily Search.
 
 Parameters:
@@ -55,7 +55,7 @@ Retrieve the status and results of a research task using its request ID.
 orth api run tavily /research/{request_id}
 ```
 
-### Create Research Task ($0.50)
+### Create Research Task
 Tavily Research performs comprehensive research on a given topic by conducting multiple searches, analyzing sources, and generating a detailed research report.
 
 Parameters:
@@ -69,7 +69,7 @@ Parameters:
 orth api run tavily /research --body '{"input": "Compare different AI agent frameworks for production use"}'
 ```
 
-### Tavily Extract ($0.01)
+### Tavily Extract
 Extract web page content from one or more specified URLs using Tavily Extract.
 
 Parameters:
@@ -86,7 +86,7 @@ Parameters:
 orth api run tavily /extract --body '{"urls": ["https://example.com/article1", "https://example.com/article2"]}'
 ```
 
-### Tavily Map ($0.01)
+### Tavily Map
 Tavily Map traverses websites like a graph and can explore hundreds of paths in parallel with intelligent discovery to generate comprehensive site maps.
 
 Parameters:
@@ -106,7 +106,7 @@ Parameters:
 orth api run tavily /map --body '{"url": "https://example.com"}'
 ```
 
-### Tavily Crawl ($0.01)
+### Tavily Crawl
 Tavily Crawl is a graph-based website traversal tool that can explore hundreds of paths in parallel with built-in extraction and intelligent discovery.
 
 Parameters:

--- a/skills/orthogonal-tavus/SKILL.md
+++ b/skills/orthogonal-tavus/SKILL.md
@@ -9,19 +9,19 @@ Create real-time video conversations with AI-powered digital personas.
 
 ## Capabilities
 
-- **List Personas**: This endpoint returns a list of all Personas ($0.01)
-- **Create Conversation**: This endpoint starts a real-time video conversation with your AI replica, powered by a persona that allows it to see, hear, and respond like a human ($0.02)
+- **List Personas**: This endpoint returns a list of all Personas
+- **Create Conversation**: This endpoint starts a real-time video conversation with your AI replica, powered by a persona that allows it to see, hear, and respond like a human
 
 ## Usage
 
-### List Personas ($0.01)
+### List Personas
 This endpoint returns a list of all Personas. You can first list the Personas to choose which one you'd like to create a conversation with. Then, using the Create Conversation endpoint, you can start a conversation with that persona providing the persona ID.
 
 ```bash
 orth api run tavus /v2/personas
 ```
 
-### Create Conversation ($0.02)
+### Create Conversation
 This endpoint starts a real-time video conversation with your AI replica, powered by a persona that allows it to see, hear, and respond like a human. Provide the most relevant persona_id obtained from the List Personas endpoint.
 
 Parameters:

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -10,7 +10,7 @@ Send SMS messages via simple HTTP API.
 ## Capabilities
 
 - **Status**: Checking SMS delivery status (free)
-- **Send an SMS**: Send an SMS using HTTP POST ($0.025)
+- **Send an SMS**: Send an SMS using HTTP POST
 
 ## Usage
 
@@ -21,7 +21,7 @@ Checking SMS delivery status
 orth api run textbelt /status/{message_id}
 ```
 
-### Send an SMS ($0.025)
+### Send an SMS
 Send an SMS using HTTP POST.
 Note: No Urls in text message.
 Max 800 characters

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -9,30 +9,30 @@ Find and verify email addresses from domains, LinkedIn profiles, or natural lang
 
 ## Capabilities
 
-- **Validate Phone**: Validate a phone number and get carrier information ($0.01)
-- **Domain Status**: Check the status and availability of a domain ($0.01)
-- **Email Format**: Get the email format patterns used by a domain (e ($0.01)
-- **Find Person**: Get person information from an email address ($0.01)
-- **Combined Enrichment**: Get combined person and company information from an email ($0.01)
-- **Domain Suggestions**: Get domain suggestions for a company name ($0.01)
-- **Email Count**: Get the count of email addresses for a domain, broken down by department and seniority ($0.01)
-- **Author Finder**: Find the email address of a blog post author from the article URL ($0.01)
-- **LinkedIn Finder**: Find the email address from a LinkedIn profile URL ($0.01)
-- **Technology Stack**: Discover technologies used by a website ($0.01)
-- **Verify Email**: Verify the deliverability of an email address ($0.01)
-- **Find Company**: Get company information from a domain ($0.01)
-- **Location**: Get employee location distribution for a domain ($0.01)
-- **Domain Search**: Search emails based on a website domain ($0.01)
-- **Email Enrichment**: Enrich an email address with person and company data (name, location, social handles) ($0.01)
-- **Find Phone**: Find phone numbers associated with an email, domain, or LinkedIn profile ($0.01)
-- **Similar Domains**: Find domains similar to a given domain ($0.01)
-- **Email Finder**: Find the most likely email address from a domain name, first name, and last name ($0.01)
-- **Email Sources**: Find the sources where an email was found on the web ($0.01)
-- **Search Companies**: Search for companies using natural language queries or structured filters ($0.01)
+- **Validate Phone**: Validate a phone number and get carrier information
+- **Domain Status**: Check the status and availability of a domain
+- **Email Format**: Get the email format patterns used by a domain (e
+- **Find Person**: Get person information from an email address
+- **Combined Enrichment**: Get combined person and company information from an email
+- **Domain Suggestions**: Get domain suggestions for a company name
+- **Email Count**: Get the count of email addresses for a domain, broken down by department and seniority
+- **Author Finder**: Find the email address of a blog post author from the article URL
+- **LinkedIn Finder**: Find the email address from a LinkedIn profile URL
+- **Technology Stack**: Discover technologies used by a website
+- **Verify Email**: Verify the deliverability of an email address
+- **Find Company**: Get company information from a domain
+- **Location**: Get employee location distribution for a domain
+- **Domain Search**: Search emails based on a website domain
+- **Email Enrichment**: Enrich an email address with person and company data (name, location, social handles)
+- **Find Phone**: Find phone numbers associated with an email, domain, or LinkedIn profile
+- **Similar Domains**: Find domains similar to a given domain
+- **Email Finder**: Find the most likely email address from a domain name, first name, and last name
+- **Email Sources**: Find the sources where an email was found on the web
+- **Search Companies**: Search for companies using natural language queries or structured filters
 
 ## Usage
 
-### Validate Phone ($0.01)
+### Validate Phone
 Validate a phone number and get carrier information.
 
 Parameters:
@@ -43,7 +43,7 @@ Parameters:
 orth api run tomba /v1/phone-validator --query 'phone=+14155552671'
 ```
 
-### Domain Status ($0.01)
+### Domain Status
 Check the status and availability of a domain.
 
 Parameters:
@@ -53,7 +53,7 @@ Parameters:
 orth api run tomba /v1/domain-status --query 'domain=stripe.com'
 ```
 
-### Email Format ($0.01)
+### Email Format
 Get the email format patterns used by a domain (e.g. first.last, firstlast).
 
 Parameters:
@@ -63,7 +63,7 @@ Parameters:
 orth api run tomba /v1/email-format --query 'domain=stripe.com'
 ```
 
-### Find Person ($0.01)
+### Find Person
 Get person information from an email address.
 
 Parameters:
@@ -73,7 +73,7 @@ Parameters:
 orth api run tomba /v1/people/find --query 'email=john@stripe.com'
 ```
 
-### Combined Enrichment ($0.01)
+### Combined Enrichment
 Get combined person and company information from an email.
 
 Parameters:
@@ -83,7 +83,7 @@ Parameters:
 orth api run tomba /v1/combined/find --query 'email=john@stripe.com'
 ```
 
-### Domain Suggestions ($0.01)
+### Domain Suggestions
 Get domain suggestions for a company name
 
 Parameters:
@@ -93,7 +93,7 @@ Parameters:
 orth api run tomba /v1/domain-suggestions --query 'query=Google'
 ```
 
-### Email Count ($0.01)
+### Email Count
 Get the count of email addresses for a domain, broken down by department and seniority.
 
 Parameters:
@@ -103,7 +103,7 @@ Parameters:
 orth api run tomba /v1/email-count --query 'domain=openai.com'
 ```
 
-### Author Finder ($0.01)
+### Author Finder
 Find the email address of a blog post author from the article URL.
 
 Parameters:
@@ -113,7 +113,7 @@ Parameters:
 orth api run tomba /v1/author-finder --query 'url=https://example.com/blog/post'
 ```
 
-### LinkedIn Finder ($0.01)
+### LinkedIn Finder
 Find the email address from a LinkedIn profile URL.
 
 Parameters:
@@ -124,7 +124,7 @@ Parameters:
 orth api run tomba /v1/linkedin --query 'url=https://linkedin.com/in/johndoe'
 ```
 
-### Technology Stack ($0.01)
+### Technology Stack
 Discover technologies used by a website.
 
 Parameters:
@@ -134,7 +134,7 @@ Parameters:
 orth api run tomba /v1/technology --query 'domain=stripe.com'
 ```
 
-### Verify Email ($0.01)
+### Verify Email
 Verify the deliverability of an email address.
 
 Parameters:
@@ -144,7 +144,7 @@ Parameters:
 orth api run tomba /v1/email-verifier --query 'email=john@example.com'
 ```
 
-### Find Company ($0.01)
+### Find Company
 Get company information from a domain.
 
 Parameters:
@@ -154,7 +154,7 @@ Parameters:
 orth api run tomba /v1/companies/find --query 'domain=anthropic.com'
 ```
 
-### Location ($0.01)
+### Location
 Get employee location distribution for a domain.
 
 Parameters:
@@ -164,7 +164,7 @@ Parameters:
 orth api run tomba /v1/location --query 'ip=8.8.8.8'
 ```
 
-### Domain Search ($0.01)
+### Domain Search
 Search emails based on a website domain. Returns all email addresses found on the internet for a given domain, with organization info and employee details.
 
 Parameters:
@@ -179,7 +179,7 @@ Parameters:
 orth api run tomba /v1/domain-search --query 'domain=stripe.com'
 ```
 
-### Email Enrichment ($0.01)
+### Email Enrichment
 Enrich an email address with person and company data (name, location, social handles).
 
 Parameters:
@@ -190,7 +190,7 @@ Parameters:
 orth api run tomba /v1/enrich --query 'email=john@stripe.com'
 ```
 
-### Find Phone ($0.01)
+### Find Phone
 Find phone numbers associated with an email, domain, or LinkedIn profile.
 
 Parameters:
@@ -203,7 +203,7 @@ Parameters:
 orth api run tomba /v1/phone-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
-### Similar Domains ($0.01)
+### Similar Domains
 Find domains similar to a given domain.
 
 Parameters:
@@ -213,7 +213,7 @@ Parameters:
 orth api run tomba /v1/similar --query 'domain=stripe.com'
 ```
 
-### Email Finder ($0.01)
+### Email Finder
 Find the most likely email address from a domain name, first name, and last name.
 
 Parameters:
@@ -228,7 +228,7 @@ Parameters:
 orth api run tomba /v1/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
-### Email Sources ($0.01)
+### Email Sources
 Find the sources where an email was found on the web.
 
 Parameters:
@@ -238,7 +238,7 @@ Parameters:
 orth api run tomba /v1/email-sources --query 'email=john@stripe.com'
 ```
 
-### Search Companies ($0.01)
+### Search Companies
 Search for companies using natural language queries or structured filters. AI assistant generates appropriate filters from your query.
 
 Parameters:

--- a/skills/orthogonal-valyu/SKILL.md
+++ b/skills/orthogonal-valyu/SKILL.md
@@ -9,30 +9,30 @@ Search the web, get AI answers, extract content, and run deep research tasks.
 
 ## Capabilities
 
-- **Get Status**: Reference for getting deep research task status via GET /v1/deepresearch/tasks/{id}/status ($0.01)
-- **Update Task**: Reference for adding follow-up instructions to a running task via POST /v1/deepresearch/tasks/{id}/update ($0.01)
-- **Cancel Task**: Reference for cancelling a running task via POST /v1/deepresearch/tasks/{id}/cancel ($0.01)
-- **Delete Task**: Reference for deleting a task via DELETE /v1/deepresearch/tasks/{id}/delete ($0.01)
-- **Get Batch Status**: Reference for getting batch status via GET /v1/deepresearch/batches/ ($0.01)
-- **List Batch Tasks**: Reference for listing tasks in a batch via GET /v1/deepresearch/batches//tasks ($0.01)
-- **Cancel Batch**: Reference for cancelling a batch via POST /v1/deepresearch/batches//cancel ($0.01)
-- **Search**: Reference for the Valyu Search endpoint to search the web, research, and proprietary datasets via POST /v1/search ($0.01)
-- **Answer**: Reference for the Valyu Answer endpoint that blends search results into AI-generated answers via POST /v1/answer ($0.01)
-- **Contents**: Reference for the Valyu Contents endpoint that extracts clean, structured content from any URL via POST /v1/contents ($0.01)
-- **Create Batch**: Reference for creating a new batch via POST /v1/deepresearch/batches ($0.01)
-- **Create Task**: Reference for creating a new deep research task via POST /v1/deepresearch/tasks ($0.01)
-- **Add Tasks to Batch**: Reference for adding tasks to a batch via POST /v1/deepresearch/batches//tasks ($0.01)
+- **Get Status**: Reference for getting deep research task status via GET /v1/deepresearch/tasks/{id}/status
+- **Update Task**: Reference for adding follow-up instructions to a running task via POST /v1/deepresearch/tasks/{id}/update
+- **Cancel Task**: Reference for cancelling a running task via POST /v1/deepresearch/tasks/{id}/cancel
+- **Delete Task**: Reference for deleting a task via DELETE /v1/deepresearch/tasks/{id}/delete
+- **Get Batch Status**: Reference for getting batch status via GET /v1/deepresearch/batches/
+- **List Batch Tasks**: Reference for listing tasks in a batch via GET /v1/deepresearch/batches//tasks
+- **Cancel Batch**: Reference for cancelling a batch via POST /v1/deepresearch/batches//cancel
+- **Search**: Reference for the Valyu Search endpoint to search the web, research, and proprietary datasets via POST /v1/search
+- **Answer**: Reference for the Valyu Answer endpoint that blends search results into AI-generated answers via POST /v1/answer
+- **Contents**: Reference for the Valyu Contents endpoint that extracts clean, structured content from any URL via POST /v1/contents
+- **Create Batch**: Reference for creating a new batch via POST /v1/deepresearch/batches
+- **Create Task**: Reference for creating a new deep research task via POST /v1/deepresearch/tasks
+- **Add Tasks to Batch**: Reference for adding tasks to a batch via POST /v1/deepresearch/batches//tasks
 
 ## Usage
 
-### Get Status ($0.01)
+### Get Status
 Reference for getting deep research task status via GET /v1/deepresearch/tasks/{id}/status.
 
 ```bash
 orth api run valyu /v1/deepresearch/tasks/{id}/status
 ```
 
-### Update Task ($0.01)
+### Update Task
 Reference for adding follow-up instructions to a running task via POST /v1/deepresearch/tasks/{id}/update.
 
 Parameters:
@@ -42,42 +42,42 @@ Parameters:
 orth api run valyu /v1/deepresearch/tasks/{id}/update --body '{"query": "Updated research query"}'
 ```
 
-### Cancel Task ($0.01)
+### Cancel Task
 Reference for cancelling a running task via POST /v1/deepresearch/tasks/{id}/cancel.
 
 ```bash
 orth api run valyu /v1/deepresearch/tasks/{id}/cancel
 ```
 
-### Delete Task ($0.01)
+### Delete Task
 Reference for deleting a task via DELETE /v1/deepresearch/tasks/{id}/delete.
 
 ```bash
 orth api run valyu /v1/deepresearch/tasks/{id}/delete
 ```
 
-### Get Batch Status ($0.01)
+### Get Batch Status
 Reference for getting batch status via GET /v1/deepresearch/batches/.
 
 ```bash
 orth api run valyu /v1/deepresearch/batches/{id}
 ```
 
-### List Batch Tasks ($0.01)
+### List Batch Tasks
 Reference for listing tasks in a batch via GET /v1/deepresearch/batches//tasks.
 
 ```bash
 orth api run valyu /v1/deepresearch/batches/{id}/tasks
 ```
 
-### Cancel Batch ($0.01)
+### Cancel Batch
 Reference for cancelling a batch via POST /v1/deepresearch/batches//cancel.
 
 ```bash
 orth api run valyu /v1/deepresearch/batches/{id}/cancel
 ```
 
-### Search ($0.01)
+### Search
 Reference for the Valyu Search endpoint to search the web, research, and proprietary datasets via POST /v1/search.
 
 Parameters:
@@ -101,7 +101,7 @@ Parameters:
 orth api run valyu /v1/search --body '{"query": "AI agent frameworks comparison"}'
 ```
 
-### Answer ($0.01)
+### Answer
 Reference for the Valyu Answer endpoint that blends search results into AI-generated answers via POST /v1/answer.
 
 Parameters:
@@ -122,7 +122,7 @@ Parameters:
 orth api run valyu /v1/answer --body '{"query": "What are the best practices for building AI agents?"}'
 ```
 
-### Contents ($0.01)
+### Contents
 Reference for the Valyu Contents endpoint that extracts clean, structured content from any URL via POST /v1/contents.
 
 Parameters:
@@ -137,7 +137,7 @@ Parameters:
 orth api run valyu /v1/contents --body '{"urls": ["https://example.com/article"]}'
 ```
 
-### Create Batch ($0.01)
+### Create Batch
 Reference for creating a new batch via POST /v1/deepresearch/batches.
 
 Parameters:
@@ -152,7 +152,7 @@ Parameters:
 orth api run valyu /v1/deepresearch/batches --body '{"name": "Competitor Research"}'
 ```
 
-### Create Task ($0.01)
+### Create Task
 Reference for creating a new deep research task via POST /v1/deepresearch/tasks.
 
 Parameters:
@@ -175,7 +175,7 @@ Parameters:
 orth api run valyu /v1/deepresearch/tasks --body '{"query": "Comprehensive analysis of vector databases market"}'
 ```
 
-### Add Tasks to Batch ($0.01)
+### Add Tasks to Batch
 Reference for adding tasks to a batch via POST /v1/deepresearch/batches//tasks.
 
 Parameters:


### PR DESCRIPTION
Prices can change, so they shouldn't be hardcoded in skill files.

Removed all `($X.XX)` price annotations from 26 SKILL.md files:
- andi, brand-dev, didit, dome, exa, fiber, hunter, jina-s
- linkup, logo, notte, nyne, olostep, parallel, perplexity, precip
- riveter, scrapegraph, searchapi, shofo, sixtyfour, tavily
- tavus, textbelt, tomba, valyu