### PR TITLE
fix: update CLI syntax from 'orth api run' to 'orth run'

### DIFF
--- a/skills/orthogonal-andi/SKILL.md
+++ b/skills/orthogonal-andi/SKILL.md
@@ -37,7 +37,7 @@ Parameters:
 - parseOperators (string) - Extract operators from query string
 
 ```bash
-orth api run andi /v1/search --query 'q=how%20does%20RAG%20work'
+orth run andi /v1/search --query 'q=how%20does%20RAG%20work'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-api-tester/SKILL.md
+++ b/skills/orthogonal-api-tester/SKILL.md
@@ -13,14 +13,14 @@ Test API endpoints, validate responses, and generate documentation examples.
 Make GET requests to test endpoints:
 
 ```bash
-orth api run linkup /fetch --body '{"url": "https://api.example.com/health"}'
+orth run linkup /fetch --body '{"url": "https://api.example.com/health"}'
 ```
 
 ### Step 2: Test POST Endpoints
 Test POST requests by fetching API docs:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://api.example.com/docs",
   "user_prompt": "Extract all API endpoints, methods, parameters, and example responses"
 }'
@@ -30,14 +30,14 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Fetch and parse API docs:
 
 ```bash
-orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://api.example.com/docs"}'
+orth run scrapegraph /v1/markdownify --body '{"website_url": "https://api.example.com/docs"}'
 ```
 
 ### Step 4: Validate Response Schema
 Check response structure:
 
 ```bash
-orth api run riveter /v1/run --body '{
+orth run riveter /v1/run --body '{
   "url": "https://api.example.com/endpoint",
   "schema": {
     "id": "string",
@@ -51,13 +51,13 @@ orth api run riveter /v1/run --body '{
 
 ```bash
 # Extract API spec from docs
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://stripe.com/docs/api",
   "user_prompt": "Extract API authentication methods and example curl commands"
 }'
 
 # Fetch API page
-orth api run linkup /fetch --body '{"url": "https://api.openai.com/v1/models"}'
+orth run linkup /fetch --body '{"url": "https://api.openai.com/v1/models"}'
 ```
 
 ## Tips

--- a/skills/orthogonal-brand-dev/SKILL.md
+++ b/skills/orthogonal-brand-dev/SKILL.md
@@ -33,7 +33,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/fonts --query 'domain=vercel.com'
+orth run brand-dev /v1/brand/fonts --query 'domain=vercel.com'
 ```
 
 ### Identify brand from transaction data
@@ -50,7 +50,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/transaction_identifier --query 'transaction_title=STRIPE%20PAYMENT'
+orth run brand-dev /v1/brand/transaction_identifier --query 'transaction_title=STRIPE%20PAYMENT'
 ```
 
 ### Retrieve NAICS code for any brand
@@ -63,7 +63,7 @@ Parameters:
 - maxResults (integer) - Maximum number of NAICS codes to return. Must be between 1 and 10. Defaults to 5.
 
 ```bash
-orth api run brand-dev /v1/brand/naics --query 'input=openai.com'
+orth run brand-dev /v1/brand/naics --query 'input=openai.com'
 ```
 
 ### Retrieve brand data by email address
@@ -76,7 +76,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve-by-email --query 'email=john@stripe.com'
+orth run brand-dev /v1/brand/retrieve-by-email --query 'email=john@stripe.com'
 ```
 
 ### Retrieve simplified brand data by domain
@@ -87,7 +87,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve-simplified --query 'domain=notion.so'
+orth run brand-dev /v1/brand/retrieve-simplified --query 'domain=notion.so'
 ```
 
 ### Retrieve brand data by ISIN
@@ -100,7 +100,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve-by-isin --query 'isin=US0378331005'
+orth run brand-dev /v1/brand/retrieve-by-isin --query 'isin=US0378331005'
 ```
 
 ### Extract products from a brand's website
@@ -112,7 +112,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/ai/products --body '{"domain": "stripe.com"}'
+orth run brand-dev /v1/brand/ai/products --body '{"domain": "stripe.com"}'
 ```
 
 ### Retrieve brand data by domain
@@ -125,7 +125,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
+orth run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ### Retrieve brand data by company name
@@ -138,7 +138,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve-by-name --query 'name=Stripe'
+orth run brand-dev /v1/brand/retrieve-by-name --query 'name=Stripe'
 ```
 
 ### Retrieve brand data by stock ticker
@@ -152,7 +152,7 @@ Parameters:
 - timeoutMS (integer) - Optional timeout in milliseconds for the request. If the request takes longer than this value, it will be aborted with a 408 status code. Maximum allowed value is 300000ms (5 minutes).
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve-by-ticker --query 'ticker=AAPL'
+orth run brand-dev /v1/brand/retrieve-by-ticker --query 'ticker=AAPL'
 ```
 
 ### Extract design system and styleguide from website
@@ -164,7 +164,7 @@ Parameters:
 - prioritize (string) - Optional parameter to prioritize screenshot capture for styleguide extraction. If 'speed', optimizes for faster capture with basic quality. If 'quality', optimizes for higher quality with longer wait times. Defaults to 'quality' if not provided.
 
 ```bash
-orth api run brand-dev /v1/brand/styleguide --query 'domain=linear.app'
+orth run brand-dev /v1/brand/styleguide --query 'domain=linear.app'
 ```
 
 ### Take screenshot of website
@@ -177,7 +177,7 @@ Parameters:
 - prioritize (string) - Optional parameter to prioritize screenshot capture. If 'speed', optimizes for faster capture with basic quality. If 'quality', optimizes for higher quality with longer wait times. Defaults to 'quality' if not provided.
 
 ```bash
-orth api run brand-dev /v1/brand/screenshot --query 'domain=github.com'
+orth run brand-dev /v1/brand/screenshot --query 'domain=github.com'
 ```
 
 ### Query website data using AI
@@ -190,7 +190,7 @@ Parameters:
 - specific_pages (object) - Optional object specifying which pages to analyze
 
 ```bash
-orth api run brand-dev /v1/brand/ai/query --body '{
+orth run brand-dev /v1/brand/ai/query --body '{
   "domain": "anthropic.com",
   "data_to_extract": [{"name": "products", "description": "What products does this company offer?"}]
 }'

--- a/skills/orthogonal-company-intel/SKILL.md
+++ b/skills/orthogonal-company-intel/SKILL.md
@@ -13,14 +13,14 @@ Generate full intelligence reports on any company including overview, team, fund
 Get basic company information:
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
+orth run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ### Step 2: Find Leadership Team
 Get info on key executives:
 
 ```bash
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "company_names": ["Stripe"],
     "job_titles": ["CEO", "CTO", "CFO", "COO", "VP", "Head of"]
@@ -32,7 +32,7 @@ orth api run fiber /v1/people-search --body '{
 Analyze products and pricing:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://stripe.com/pricing",
   "user_prompt": "Extract all products, pricing tiers, and features"
 }'
@@ -42,7 +42,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Track company growth:
 
 ```bash
-orth api run fiber /v1/company-search --body '{
+orth run fiber /v1/company-search --body '{
   "searchParams": {
     "company_names": ["Stripe"]
   }
@@ -57,16 +57,16 @@ DOMAIN="stripe.com"
 COMPANY="Stripe"
 
 # 1. Basic info
-orth api run brand-dev /v1/brand/retrieve --query "domain=$DOMAIN"
+orth run brand-dev /v1/brand/retrieve --query "domain=$DOMAIN"
 
 # 2. Leadership team
-orth api run fiber /v1/people-search --body "{\"searchParams\": {\"company_names\": [\"$COMPANY\"], \"job_titles\": [\"CEO\", \"CTO\", \"CFO\"]}}"
+orth run fiber /v1/people-search --body "{\"searchParams\": {\"company_names\": [\"$COMPANY\"], \"job_titles\": [\"CEO\", \"CTO\", \"CFO\"]}}"
 
 # 3. Products & pricing
-orth api run scrapegraph /v1/smartscraper --body "{\"website_url\": \"https://$DOMAIN/pricing\", \"user_prompt\": \"Extract all products, pricing tiers, and features\"}"
+orth run scrapegraph /v1/smartscraper --body "{\"website_url\": \"https://$DOMAIN/pricing\", \"user_prompt\": \"Extract all products, pricing tiers, and features\"}"
 
 # 4. Company data
-orth api run fiber /v1/company-search --body "{\"searchParams\": {\"company_names\": [\"$COMPANY\"]}}"
+orth run fiber /v1/company-search --body "{\"searchParams\": {\"company_names\": [\"$COMPANY\"]}}"
 ```
 
 ## Tips

--- a/skills/orthogonal-competitor-research/SKILL.md
+++ b/skills/orthogonal-competitor-research/SKILL.md
@@ -13,14 +13,14 @@ Gather comprehensive intelligence on competitors including products, pricing, te
 Get basic company information:
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=competitor.com'
+orth run brand-dev /v1/brand/retrieve --query 'domain=competitor.com'
 ```
 
 ### Step 2: Find Similar Companies
 Use Exa to find related competitors:
 
 ```bash
-orth api run exa /findSimilar --body '{
+orth run exa /findSimilar --body '{
   "url": "https://notion.so",
   "num_results": 10
 }'
@@ -30,7 +30,7 @@ orth api run exa /findSimilar --body '{
 Scrape pricing and features:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://notion.so/pricing",
   "user_prompt": "Extract all pricing tiers, features per tier, and any enterprise options"
 }'
@@ -40,7 +40,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Find key people at the company:
 
 ```bash
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "company_names": ["Notion"],
     "job_titles": ["CEO", "CTO", "VP Product", "VP Engineering"]
@@ -52,7 +52,7 @@ orth api run fiber /v1/people-search --body '{
 
 ```bash
 # Find competitor customers
-orth api run exa /search --body '{
+orth run exa /search --body '{
   "query": "companies using Notion for documentation case studies",
   "num_results": 20
 }'

--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -28,7 +28,7 @@ Parameters:
 - vendor_data (string) - Unique identifier for vendor/user (UUID or email) for session tracking
 
 ```bash
-orth api run didit /v3/email/send --body '{"email": "user@example.com"}'
+orth run didit /v3/email/send --body '{"email": "user@example.com"}'
 ```
 
 ### Check Phone Code (free)
@@ -42,7 +42,7 @@ Parameters:
 - voip_number_action (string) - Action for VoIP numbers: NO_ACTION (default) or DECLINE
 
 ```bash
-orth api run didit /v3/phone/check --body '{"phone_number": "+1234567890", "code": "123456"}'
+orth run didit /v3/phone/check --body '{"phone_number": "+1234567890", "code": "123456"}'
 ```
 
 ### Send Phone Code
@@ -55,7 +55,7 @@ Parameters:
 - vendor_data (string) - Unique identifier for vendor/user (UUID or email) for session tracking
 
 ```bash
-orth api run didit /v3/phone/send --body '{"phone_number": "+1234567890"}'
+orth run didit /v3/phone/send --body '{"phone_number": "+1234567890"}'
 ```
 
 ### AML Screening
@@ -79,7 +79,7 @@ Parameters:
 - vendor_data (string) - A unique identifier for the vendor or user, such as a UUID or email. This field enables proper session tracking and user data aggregation across multiple verification sessions.
 
 ```bash
-orth api run didit /v3/aml --body '{"full_name": "John Doe"}'
+orth run didit /v3/aml --body '{"full_name": "John Doe"}'
 ```
 
 ### Check Email Code (free)
@@ -94,7 +94,7 @@ Parameters:
 - undeliverable_email_action (string) - Action for undeliverable emails: NO_ACTION (default) or DECLINE
 
 ```bash
-orth api run didit /v3/email/check --body '{"email": "user@example.com", "code": "123456"}'
+orth run didit /v3/email/check --body '{"email": "user@example.com", "code": "123456"}'
 ```
 
 ### Database Validation API
@@ -113,7 +113,7 @@ Parameters:
 - address (string) - Residential address
 
 ```bash
-orth api run didit /v3/database-validation --body '{"issuing_state": "ESP", "validation_type": "one_by_one", "identification_number": "12345678A"}'
+orth run didit /v3/database-validation --body '{"issuing_state": "ESP", "validation_type": "one_by_one", "identification_number": "12345678A"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-dome/SKILL.md
+++ b/skills/orthogonal-dome/SKILL.md
@@ -39,7 +39,7 @@ Parameters:
 - limit (integer) - Maximum number of snapshots to return (default: 100, max: 200). Ignored when fetching the latest orderbook without start_time and end_time.
 
 ```bash
-orth api run dome /kalshi/orderbooks --query 'ticker={ticker}'
+orth run dome /kalshi/orderbooks --query 'ticker={ticker}'
 ```
 
 ### Market Price
@@ -49,7 +49,7 @@ Parameters:
 - at_time (integer) - Optional Unix timestamp (in seconds) to fetch a historical market price. If not provided, returns the most real-time price available.
 
 ```bash
-orth api run dome /polymarket/market-price/{token_id}
+orth run dome /polymarket/market-price/{token_id}
 ```
 
 ### Market Price
@@ -59,7 +59,7 @@ Parameters:
 - at_time (integer) - Optional Unix timestamp (in seconds) to fetch a historical market price. If not provided, returns the most real-time price available.
 
 ```bash
-orth api run dome /kalshi/market-price/{market_ticker}
+orth run dome /kalshi/market-price/{market_ticker}
 ```
 
 ### Trade History
@@ -73,7 +73,7 @@ Parameters:
 - offset (integer) - Number of trades to skip for pagination
 
 ```bash
-orth api run dome /kalshi/trades --query 'ticker={ticker}'
+orth run dome /kalshi/trades --query 'ticker={ticker}'
 ```
 
 ### Sport by Date
@@ -83,7 +83,7 @@ Parameters:
 - date* (string) - The date to find matching markets for in YYYY-MM-DD format
 
 ```bash
-orth api run dome /matching-markets/sports/nba --query 'date=2024-03-01'
+orth run dome /matching-markets/sports/nba --query 'date=2024-03-01'
 ```
 
 ### Sports
@@ -94,7 +94,7 @@ Parameters:
 - kalshi_event_ticker (string[]) - The Kalshi event ticker(s) to find matching markets for. To get multiple markets at once, provide the query param multiple times with different tickers. Can not be combined with polymarket_market_slug.
 
 ```bash
-orth api run dome /matching-markets/sports
+orth run dome /matching-markets/sports
 ```
 
 ### Positions
@@ -105,7 +105,7 @@ Parameters:
 - pagination_key (string) - Pagination key returned from previous request to fetch next page of results
 
 ```bash
-orth api run dome /polymarket/positions/wallet/{wallet_address}
+orth run dome /polymarket/positions/wallet/{wallet_address}
 ```
 
 ### Binance Prices
@@ -119,7 +119,7 @@ Parameters:
 - pagination_key (string) - Pagination key (base64-encoded) to fetch the next page of results. Returned in the response when more data is available.
 
 ```bash
-orth api run dome /crypto-prices/binance --query 'currency=btcusdt'
+orth run dome /crypto-prices/binance --query 'currency=btcusdt'
 ```
 
 ### Activity
@@ -135,7 +135,7 @@ Parameters:
 - offset (integer) - Number of activities to skip for pagination
 
 ```bash
-orth api run dome /polymarket/activity --query 'user={wallet_address}'
+orth run dome /polymarket/activity --query 'user={wallet_address}'
 ```
 
 ### Markets
@@ -155,7 +155,7 @@ Parameters:
 - end_time (integer) - Filter markets until this Unix timestamp in seconds (inclusive)
 
 ```bash
-orth api run dome /polymarket/markets --query 'search=election' 'status=open'
+orth run dome /polymarket/markets --query 'search=election' 'status=open'
 ```
 
 ### Orderbook History
@@ -169,7 +169,7 @@ Parameters:
 - pagination_key (string) - Pagination key to get the next chunk of data. Ignored when fetching the latest orderbook without start_time and end_time.
 
 ```bash
-orth api run dome /polymarket/orderbooks --query 'token_id={token_id}'
+orth run dome /polymarket/orderbooks --query 'token_id={token_id}'
 ```
 
 ### Wallet
@@ -183,7 +183,7 @@ Parameters:
 - end_time (integer) - Optional end date for metrics calculation (Unix timestamp in seconds). Only used when with_metrics=true.
 
 ```bash
-orth api run dome /polymarket/wallet --query 'address={wallet_address}'
+orth run dome /polymarket/wallet --query 'address={wallet_address}'
 ```
 
 ### Candlesticks
@@ -195,7 +195,7 @@ Parameters:
 - interval (enum<integer>) - Interval length: 1 = 1m, 60 = 1h, 1440 = 1d. Defaults to 1m. ⚠️ Note: There are range limits for interval — specifically: 1 (1m): max range 1 week 60 (1h): max range 1 month 1440 (1d): max range 1 year
 
 ```bash
-orth api run dome /polymarket/candlesticks/{condition_id} --query 'interval=1h'
+orth run dome /polymarket/candlesticks/{condition_id} --query 'interval=1h'
 ```
 
 ### Chainlink Prices
@@ -209,7 +209,7 @@ Parameters:
 - pagination_key (string) - Pagination key (base64-encoded) to fetch the next page of results. Returned in the response when more data is available.
 
 ```bash
-orth api run dome /crypto-prices/chainlink --query 'currency=btc/usd'
+orth run dome /crypto-prices/chainlink --query 'currency=btc/usd'
 ```
 
 ### Wallet Profit-and-Loss
@@ -221,7 +221,7 @@ Parameters:
 - end_time (integer) - Defaults to the current date if not provided.
 
 ```bash
-orth api run dome /polymarket/wallet/pnl/{wallet_address}
+orth run dome /polymarket/wallet/pnl/{wallet_address}
 ```
 
 ### Trade History
@@ -238,7 +238,7 @@ Parameters:
 - user (string) - Filter orders by user (wallet address)
 
 ```bash
-orth api run dome /polymarket/orders --query 'market={market_id}'
+orth run dome /polymarket/orders --query 'market={market_id}'
 ```
 
 ### Markets
@@ -254,7 +254,7 @@ Parameters:
 - offset (integer) - Number of markets to skip for pagination
 
 ```bash
-orth api run dome /kalshi/markets --query 'search=fed%20rate'
+orth run dome /kalshi/markets --query 'search=fed%20rate'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-email-campaign/SKILL.md
+++ b/skills/orthogonal-email-campaign/SKILL.md
@@ -13,35 +13,35 @@ Build targeted email campaigns with verified email addresses and personalized ou
 Get all emails for target companies:
 
 ```bash
-orth api run hunter /v2/domain-search --query 'domain=stripe.com'
+orth run hunter /v2/domain-search --query 'domain=stripe.com'
 ```
 
 ### Step 2: Find Specific Person's Email
 Find email for specific contacts:
 
 ```bash
-orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
+orth run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ### Step 3: Verify Emails
 Check deliverability before sending:
 
 ```bash
-orth api run hunter /v2/email-verifier --query 'email=john@stripe.com'
+orth run hunter /v2/email-verifier --query 'email=john@stripe.com'
 ```
 
 ### Step 4: Batch Verification with Fiber
 Validate multiple emails:
 
 ```bash
-orth api run fiber /v1/validate-email/single --body '{"email": "john@stripe.com"}'
+orth run fiber /v1/validate-email/single --body '{"email": "john@stripe.com"}'
 ```
 
 ### Step 5: Enrich for Personalization
 Get info for personalized outreach:
 
 ```bash
-orth api run sixtyfour /enrich-lead --body '{
+orth run sixtyfour /enrich-lead --body '{
   "lead_info": {
     "first_name": "John",
     "last_name": "Doe",
@@ -55,14 +55,14 @@ orth api run sixtyfour /enrich-lead --body '{
 Research company for personalization:
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
+orth run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ## Campaign Building Pipeline
 
 ```bash
 # 1. Find target companies
-orth api run fiber /v1/company-search --body '{
+orth run fiber /v1/company-search --body '{
   "searchParams": {
     "industries": ["SaaS"],
     "employee_count_min": 50,
@@ -71,13 +71,13 @@ orth api run fiber /v1/company-search --body '{
 }'
 
 # 2. Get emails for each company
-orth api run hunter /v2/domain-search --query 'domain=company.com'
+orth run hunter /v2/domain-search --query 'domain=company.com'
 
 # 3. Verify each email
-orth api run hunter /v2/email-verifier --query 'email=person@company.com'
+orth run hunter /v2/email-verifier --query 'email=person@company.com'
 
 # 4. Enrich for personalization
-orth api run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John", "last_name": "Doe", "company": "Company"}, "struct": {"email": "Work email"}}'
+orth run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John", "last_name": "Doe", "company": "Company"}, "struct": {"email": "Work email"}}'
 ```
 
 ## Tips

--- a/skills/orthogonal-exa/SKILL.md
+++ b/skills/orthogonal-exa/SKILL.md
@@ -27,7 +27,7 @@ Parameters:
 - limit (number) - Number of results per page (1-50) Required range: `1 <= x <= 50`
 
 ```bash
-orth api run exa /research/v1
+orth run exa /research/v1
 ```
 
 ### Answer
@@ -41,7 +41,7 @@ Parameters:
 - text (boolean) - If true, the response includes full text content in the search results
 
 ```bash
-orth api run exa /answer --body '{"query": "What are the best practices for prompt engineering?"}'
+orth run exa /answer --body '{"query": "What are the best practices for prompt engineering?"}'
 ```
 
 ### Search
@@ -67,7 +67,7 @@ Parameters:
 - contents (object)
 
 ```bash
-orth api run exa /search --body '{
+orth run exa /search --body '{
   "query": "startups building AI coding assistants",
   "num_results": 10,
   "contents": {"text": true}
@@ -82,7 +82,7 @@ Parameters:
 - events (string) - Set to "true" to include the detailed event log of all operations performed
 
 ```bash
-orth api run exa /research/v1/{researchId}
+orth run exa /research/v1/{researchId}
 ```
 
 ### Find similar links
@@ -104,7 +104,7 @@ Parameters:
 - contents (object)
 
 ```bash
-orth api run exa /findSimilar --body '{
+orth run exa /findSimilar --body '{
   "url": "https://example.com/article",
   "num_results": 10
 }'
@@ -119,7 +119,7 @@ Parameters:
 - outputSchema (object) - JSON Schema to enforce structured output. When provided, the research output will be validated against this schema and returned as parsed JSON.
 
 ```bash
-orth api run exa /research/v1 --body '{"instructions": "Research the current state of AI coding assistants"}'
+orth run exa /research/v1 --body '{"instructions": "Research the current state of AI coding assistants"}'
 ```
 
 ### Get contents
@@ -139,7 +139,7 @@ Parameters:
 - context (string) - Return page contents as a context string for LLM. When true, combines all result contents into one string. We recommend using 10000+ characters for best results, though no limit works best. Context strings often perform better than highlights for RAG applications.
 
 ```bash
-orth api run exa /contents --body '{
+orth run exa /contents --body '{
   "ids": ["https://example.com"],
   "text": true,
   "summary": true

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -40,7 +40,7 @@ Parameters:
 - cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
 
 ```bash
-orth api run fiber /v1/natural-language-search/profiles --body '{"query": "Software engineers in San Francisco with 5+ years experience"}'
+orth run fiber /v1/natural-language-search/profiles --body '{"query": "Software engineers in San Francisco with 5+ years experience"}'
 ```
 
 ### Search companies from text
@@ -52,7 +52,7 @@ Parameters:
 - cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
 
 ```bash
-orth api run fiber /v1/natural-language-search/companies --body '{"query": "Series A startups in fintech with 50-200 employees"}'
+orth run fiber /v1/natural-language-search/companies --body '{"query": "Series A startups in fintech with 50-200 employees"}'
 ```
 
 ### Find person by email
@@ -63,7 +63,7 @@ Parameters:
 - num_profiles (['number', 'null']) - Number of profiles to return. Maximum 10 profiles can be returned for given query. The returned profiles will be sorted by best match first.
 
 ```bash
-orth api run fiber /v1/email-to-person/single --body '{"email": "john@company.com"}'
+orth run fiber /v1/email-to-person/single --body '{"email": "john@company.com"}'
 ```
 
 ### Live fetch LinkedIn profile
@@ -75,7 +75,7 @@ Parameters:
 - getDetailedWorkExperience (['boolean', 'null']) - Whether to include deep details about each work experience item, like the company's LinkedIn URL, website, location, etc. That'll be put in the detailedWorkExperience array. This slows down the API call, so only enable this if you need it.
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
+orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
 ### Validate a single email
@@ -85,7 +85,7 @@ Parameters:
 - email* (string) - The email to validate
 
 ```bash
-orth api run fiber /v1/validate-email/single --body '{"email": "john@example.com"}'
+orth run fiber /v1/validate-email/single --body '{"email": "john@example.com"}'
 ```
 
 ### Kitchen sink person lookup
@@ -107,7 +107,7 @@ Parameters:
 - getDetailedWorkExperience (['boolean', 'null']) - Whether to include deep details about each work experience item, like the company's LinkedIn URL, website, location, etc. That'll be put in the detailedWorkExperience array. This slows down the API call, so only enable this if you need it.
 
 ```bash
-orth api run fiber /v1/kitchen-sink/person --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
+orth run fiber /v1/kitchen-sink/person --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
 ```
 
 ### Kitchen sink company lookup
@@ -120,7 +120,7 @@ Parameters:
 - numCompanies (integer) - The number of companies you want to fetch. Companies are sorted by best match first.
 
 ```bash
-orth api run fiber /v1/kitchen-sink/company --body '{"domain": "openai.com"}'
+orth run fiber /v1/kitchen-sink/company --body '{"domain": "openai.com"}'
 ```
 
 ### Investor search
@@ -132,7 +132,7 @@ Parameters:
 - cursor (['string', 'null']) - Pagination cursor returned from a previous search response. Use this to fetch the next page of results. Null for the first page.
 
 ```bash
-orth api run fiber /v1/investor-search --body '{
+orth run fiber /v1/investor-search --body '{
   "searchParams": {
     "investment_stages": ["Seed", "Series A"],
     "industries": ["AI", "SaaS"]
@@ -148,7 +148,7 @@ Parameters:
 - cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "https://linkedin.com/in/johndoe"}'
+orth run fiber /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
 ### Live fetch LinkedIn company
@@ -159,7 +159,7 @@ Parameters:
 - value* (string) - The company's LinkedIn slug (e.g., 'microsoft'), LinkedIn URL (e.g., 'https://www.linkedin.com/company/microsoft' or 'https://www.linkedin.com/company/1441'), LinkedIn organization ID (e.g., '1441' for Google), or Fiber company ID (e.g., 'comp_1441')
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/company/single --body '{"identifier": "https://linkedin.com/company/openai"}'
+orth run fiber /v1/linkedin-live-fetch/company/single --body '{"identifier": "https://linkedin.com/company/openai"}'
 ```
 
 ### People search
@@ -174,7 +174,7 @@ Parameters:
 - companyExclusionListIDs (['array', 'null']) - Filter out people who work at companies which belong to the given company exclusion lists
 
 ```bash
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "job_titles": ["CTO", "VP Engineering"],
     "locations": ["San Francisco", "New York"]
@@ -190,7 +190,7 @@ Parameters:
 - cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/post-comments --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
+orth run fiber /v1/linkedin-live-fetch/post-comments --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
 ```
 
 ### Company search
@@ -203,7 +203,7 @@ Parameters:
 - companyExclusionListIDs (['array', 'null']) - Filter out companies which belong to the given company exclusion lists. You can create company exclusion lists via /v1/exclusions/companies/create-list
 
 ```bash
-orth api run fiber /v1/company-search --body '{
+orth run fiber /v1/company-search --body '{
   "searchParams": {
     "industries": ["Software", "AI"],
     "employee_count_min": 50,
@@ -219,7 +219,7 @@ Parameters:
 - query* (string)
 
 ```bash
-orth api run fiber /v1/text-to-search-params/companies --body '{"query": "AI startups in healthcare"}'
+orth run fiber /v1/text-to-search-params/companies --body '{"query": "AI startups in healthcare"}'
 ```
 
 ### Convert text into profile search filters
@@ -229,7 +229,7 @@ Parameters:
 - query* (string)
 
 ```bash
-orth api run fiber /v1/text-to-search-params/profiles --body '{"query": "Senior engineers at FAANG companies"}'
+orth run fiber /v1/text-to-search-params/profiles --body '{"query": "Senior engineers at FAANG companies"}'
 ```
 
 ### Job postings search
@@ -241,7 +241,7 @@ Parameters:
 - cursor (['string', 'null']) - Pagination cursor for fetching next page of results
 
 ```bash
-orth api run fiber /v1/job-search --body '{
+orth run fiber /v1/job-search --body '{
   "searchParams": {
     "job_titles": ["Software Engineer"],
     "locations": ["Remote"]
@@ -258,7 +258,7 @@ Parameters:
 - cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
+orth run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-hunter/SKILL.md
+++ b/skills/orthogonal-hunter/SKILL.md
@@ -27,7 +27,7 @@ Parameters:
 - email* (string) - Email address to enrich
 
 ```bash
-orth api run hunter /v2/combined/find --query 'email=jane@company.com'
+orth run hunter /v2/combined/find --query 'email=jane@company.com'
 ```
 
 ### Email Enrichment
@@ -38,7 +38,7 @@ Parameters:
 - linkedin_handle (string) - LinkedIn handle to enrich
 
 ```bash
-orth api run hunter /v2/people/find --query 'email=john@company.com'
+orth run hunter /v2/people/find --query 'email=john@company.com'
 ```
 
 ### Email Count
@@ -50,7 +50,7 @@ Parameters:
 - type (string) - Filter: personal or generic
 
 ```bash
-orth api run hunter /v2/email-count --query 'domain=google.com'
+orth run hunter /v2/email-count --query 'domain=google.com'
 ```
 
 ### Discover Companies
@@ -65,7 +65,7 @@ Parameters:
 - offset (integer) - Skip N results for pagination
 
 ```bash
-orth api run hunter /v2/discover --body '{"query": "AI startups in San Francisco"}'
+orth run hunter /v2/discover --body '{"query": "AI startups in San Francisco"}'
 ```
 
 ### Company Enrichment
@@ -75,7 +75,7 @@ Parameters:
 - domain* (string) - Company domain to enrich (e.g. hunter.io)
 
 ```bash
-orth api run hunter /v2/companies/find --query 'domain=anthropic.com'
+orth run hunter /v2/companies/find --query 'domain=anthropic.com'
 ```
 
 ### Domain Search
@@ -90,7 +90,7 @@ Parameters:
 - department (string) - Filter by department (sales, marketing, etc)
 
 ```bash
-orth api run hunter /v2/domain-search --query 'domain=stripe.com'
+orth run hunter /v2/domain-search --query 'domain=stripe.com'
 ```
 
 ### Email Finder
@@ -105,7 +105,7 @@ Parameters:
 - linkedin_handle (string) - LinkedIn profile handle
 
 ```bash
-orth api run hunter /v2/email-finder --query domain=openai.com first_name=Sam last_name=Altman
+orth run hunter /v2/email-finder --query domain=openai.com first_name=Sam last_name=Altman
 ```
 
 ### Email Verifier
@@ -115,7 +115,7 @@ Parameters:
 - email* (string) - Email address to verify
 
 ```bash
-orth api run hunter /v2/email-verifier --query 'email=john@example.com'
+orth run hunter /v2/email-verifier --query 'email=john@example.com'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-image-analyzer/SKILL.md
+++ b/skills/orthogonal-image-analyzer/SKILL.md
@@ -13,14 +13,14 @@ Analyze images to extract text, describe content, and detect objects using AI.
 Fetch image content:
 
 ```bash
-orth api run linkup /fetch --body '{"url": "https://example.com/image.jpg"}'
+orth run linkup /fetch --body '{"url": "https://example.com/image.jpg"}'
 ```
 
 ### Step 2: Extract Text (OCR)
 Use AI to extract text from images:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com/screenshot.png",
   "user_prompt": "Extract all visible text from this image"
 }'
@@ -30,7 +30,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Get specific data from images:
 
 ```bash
-orth api run riveter /v1/run --body '{
+orth run riveter /v1/run --body '{
   "url": "https://example.com/receipt.jpg",
   "schema": {
     "store_name": "string",
@@ -45,20 +45,20 @@ orth api run riveter /v1/run --body '{
 Get screenshots of web pages:
 
 ```bash
-orth api run brand-dev /v1/brand/screenshot --query 'domain=stripe.com'
+orth run brand-dev /v1/brand/screenshot --query 'domain=stripe.com'
 ```
 
 ## Example Usage
 
 ```bash
 # Extract receipt data
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com/receipt.jpg",
   "user_prompt": "Extract store name, date, all items with prices, and total amount"
 }'
 
 # Get website screenshot
-orth api run brand-dev /v1/brand/screenshot --query 'domain=openai.com'
+orth run brand-dev /v1/brand/screenshot --query 'domain=openai.com'
 ```
 
 ## Tips

--- a/skills/orthogonal-investor-research/SKILL.md
+++ b/skills/orthogonal-investor-research/SKILL.md
@@ -13,7 +13,7 @@ Research venture capitalists, angel investors, and their investment patterns.
 Find investors in your space:
 
 ```bash
-orth api run fiber /v1/investor-search --body '{
+orth run fiber /v1/investor-search --body '{
   "searchParams": {
     "investment_stages": ["Seed", "Series A"],
     "industries": ["AI", "SaaS", "Developer Tools"]
@@ -25,7 +25,7 @@ orth api run fiber /v1/investor-search --body '{
 See their existing investments:
 
 ```bash
-orth api run exa /search --body '{
+orth run exa /search --body '{
   "query": "Sequoia Capital portfolio companies AI 2023 2024",
   "num_results": 30
 }'
@@ -35,7 +35,7 @@ orth api run exa /search --body '{
 Get contact info for partners:
 
 ```bash
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "company_names": ["Sequoia Capital"],
     "job_titles": ["Partner", "General Partner", "Principal"]
@@ -47,7 +47,7 @@ orth api run fiber /v1/people-search --body '{
 Find email for outreach:
 
 ```bash
-orth api run sixtyfour /find-email --body '{
+orth run sixtyfour /find-email --body '{
   "lead": {
     "first_name": "Alfred",
     "last_name": "Lin",
@@ -60,7 +60,7 @@ orth api run sixtyfour /find-email --body '{
 
 ```bash
 # Find AI-focused investors
-orth api run fiber /v1/investor-search --body '{
+orth run fiber /v1/investor-search --body '{
   "searchParams": {
     "industries": ["AI", "Machine Learning"],
     "investment_stages": ["Seed"],
@@ -69,7 +69,7 @@ orth api run fiber /v1/investor-search --body '{
 }'
 
 # Find angels in your space
-orth api run exa /search --body '{
+orth run exa /search --body '{
   "query": "angel investors who invest in developer tools startups",
   "num_results": 25
 }'

--- a/skills/orthogonal-jina-s/SKILL.md
+++ b/skills/orthogonal-jina-s/SKILL.md
@@ -20,7 +20,7 @@ Parameters:
 - q (string) - Search query
 
 ```bash
-orth api run jina-s / --query 'q=latest%20AI%20news'
+orth run jina-s / --query 'q=latest%20AI%20news'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-job-search/SKILL.md
+++ b/skills/orthogonal-job-search/SKILL.md
@@ -13,7 +13,7 @@ Search for jobs matching your skills, experience level, and location preferences
 Use Fiber to search for jobs:
 
 ```bash
-orth api run fiber /v1/job-search --body '{
+orth run fiber /v1/job-search --body '{
   "searchParams": {
     "job_titles": ["Software Engineer", "Full Stack Developer"],
     "locations": ["San Francisco", "Remote"],
@@ -26,7 +26,7 @@ orth api run fiber /v1/job-search --body '{
 Get company information for interesting roles:
 
 ```bash
-orth api run fiber /v1/company-search --body '{
+orth run fiber /v1/company-search --body '{
   "searchParams": {
     "company_names": ["Stripe", "Figma", "Notion"]
   }
@@ -37,14 +37,14 @@ orth api run fiber /v1/company-search --body '{
 Use Brand.dev for detailed company info:
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
+orth run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ### Step 4: Find Hiring Managers
 Find people at the company to network with:
 
 ```bash
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "company_names": ["Stripe"],
     "job_titles": ["Engineering Manager", "VP Engineering", "CTO"]
@@ -56,14 +56,14 @@ orth api run fiber /v1/people-search --body '{
 Find email for outreach:
 
 ```bash
-orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
+orth run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ## Example Usage
 
 ```bash
 # Search for remote AI jobs
-orth api run fiber /v1/job-search --body '{
+orth run fiber /v1/job-search --body '{
   "searchParams": {
     "job_titles": ["Machine Learning Engineer", "AI Engineer"],
     "locations": ["Remote"],
@@ -72,7 +72,7 @@ orth api run fiber /v1/job-search --body '{
 }'
 
 # Research a company
-orth api run fiber /v1/natural-language-search/companies --body '{
+orth run fiber /v1/natural-language-search/companies --body '{
   "query": "Tell me about Anthropic - funding, team size, culture"
 }'
 ```

--- a/skills/orthogonal-lead-enrichment/SKILL.md
+++ b/skills/orthogonal-lead-enrichment/SKILL.md
@@ -13,21 +13,21 @@ Enrich partial lead data with emails, phone numbers, and company information usi
 Use Hunter to find email:
 
 ```bash
-orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
+orth run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ### Step 2: Verify Email
 Verify the email is deliverable:
 
 ```bash
-orth api run hunter /v2/email-verifier --query 'email=john@stripe.com'
+orth run hunter /v2/email-verifier --query 'email=john@stripe.com'
 ```
 
 ### Step 3: Get More Contact Info
 Use Sixtyfour for additional enrichment:
 
 ```bash
-orth api run sixtyfour /enrich-lead --body '{
+orth run sixtyfour /enrich-lead --body '{
   "lead_info": {
     "first_name": "John",
     "last_name": "Doe",
@@ -42,7 +42,7 @@ orth api run sixtyfour /enrich-lead --body '{
 Use Sixtyfour to find phone:
 
 ```bash
-orth api run sixtyfour /find-phone --body '{
+orth run sixtyfour /find-phone --body '{
   "lead": {
     "first_name": "John",
     "last_name": "Doe",
@@ -55,14 +55,14 @@ orth api run sixtyfour /find-phone --body '{
 Get detailed company information:
 
 ```bash
-orth api run hunter /v2/companies/find --query 'domain=stripe.com'
+orth run hunter /v2/companies/find --query 'domain=stripe.com'
 ```
 
 ### Step 6: Get LinkedIn Data
 Fetch real-time LinkedIn profile:
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
+orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
 ## Full Enrichment Pipeline
@@ -74,19 +74,19 @@ export COMPANY="Stripe"
 export DOMAIN="stripe.com"
 
 # 2. Find email (Hunter)
-orth api run hunter /v2/email-finder --query domain=$DOMAIN first_name=John last_name=Doe
+orth run hunter /v2/email-finder --query domain=$DOMAIN first_name=John last_name=Doe
 
 # 3. Verify email
-orth api run hunter /v2/email-verifier --query "email=john@stripe.com"
+orth run hunter /v2/email-verifier --query "email=john@stripe.com"
 
 # 4. Get full lead profile (Sixtyfour)
-orth api run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John", "last_name": "Doe", "company": "Stripe"}, "struct": {"email": "Work email"}}'
+orth run sixtyfour /enrich-lead --body '{"lead_info": {"first_name": "John", "last_name": "Doe", "company": "Stripe"}, "struct": {"email": "Work email"}}'
 
 # 5. Find phone
-orth api run sixtyfour /find-phone --body '{"lead": {"first_name": "John", "last_name": "Doe", "company": "Stripe"}}'
+orth run sixtyfour /find-phone --body '{"lead": {"first_name": "John", "last_name": "Doe", "company": "Stripe"}}'
 
 # 6. Get company details
-orth api run hunter /v2/companies/find --query "domain=stripe.com"
+orth run hunter /v2/companies/find --query "domain=stripe.com"
 ```
 
 ## Tips

--- a/skills/orthogonal-linkup/SKILL.md
+++ b/skills/orthogonal-linkup/SKILL.md
@@ -32,7 +32,7 @@ Parameters:
 - maxResults (number) - The maximum number of results to return.
 
 ```bash
-orth api run linkup /search --body '{
+orth run linkup /search --body '{
   "q": "latest AI developments 2024",
   "depth": "standard",
   "outputType": "sourcedAnswer"
@@ -49,7 +49,7 @@ Parameters:
 - extractImages (boolean) - Defines whether the API should extract the images from the webpage in its response.
 
 ```bash
-orth api run linkup /fetch --body '{"url": "https://example.com/article"}'
+orth run linkup /fetch --body '{"url": "https://example.com/article"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-logo/SKILL.md
+++ b/skills/orthogonal-logo/SKILL.md
@@ -21,7 +21,7 @@ Parameters:
 - strategy (string)
 
 ```bash
-orth api run logo /search --query 'q=Stripe'
+orth run logo /search --query 'q=Stripe'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-market-research/SKILL.md
+++ b/skills/orthogonal-market-research/SKILL.md
@@ -13,7 +13,7 @@ Research market size, trends, competitors, and growth opportunities for any indu
 Find companies in the market:
 
 ```bash
-orth api run fiber /v1/natural-language-search/companies --body '{
+orth run fiber /v1/natural-language-search/companies --body '{
   "query": "AI software companies with over 100 employees, Series B or later funding"
 }'
 ```
@@ -22,7 +22,7 @@ orth api run fiber /v1/natural-language-search/companies --body '{
 Get detailed info on key players:
 
 ```bash
-orth api run fiber /v1/company-search --body '{
+orth run fiber /v1/company-search --body '{
   "searchParams": {
     "company_names": ["OpenAI", "Anthropic", "Cohere"],
     "include_financials": true
@@ -34,7 +34,7 @@ orth api run fiber /v1/company-search --body '{
 Identify leadership at key companies:
 
 ```bash
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "company_names": ["OpenAI", "Anthropic"],
     "job_titles": ["CEO", "CTO", "VP Product", "Head of Sales"]
@@ -46,12 +46,12 @@ orth api run fiber /v1/people-search --body '{
 
 ```bash
 # Find companies by industry and size
-orth api run fiber /v1/natural-language-search/companies --body '{
+orth run fiber /v1/natural-language-search/companies --body '{
   "query": "EdTech companies with 50-500 employees founded after 2018"
 }'
 
 # Search by specific criteria
-orth api run fiber /v1/company-search --body '{
+orth run fiber /v1/company-search --body '{
   "searchParams": {
     "industries": ["Enterprise Software"],
     "employee_count_min": 100,

--- a/skills/orthogonal-notte/SKILL.md
+++ b/skills/orthogonal-notte/SKILL.md
@@ -35,7 +35,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}/page/screenshot --body '{}'
+orth run notte /sessions/{session_id}/page/screenshot --body '{}'
 ```
 
 ### Get Session (free)
@@ -45,7 +45,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}
+orth run notte /sessions/{session_id}
 ```
 
 ### Stop Session (free)
@@ -55,7 +55,7 @@ Parameters:
 - session_id* (string) - Session ID
 
 ```bash
-orth api run notte /sessions/{session_id}/stop
+orth run notte /sessions/{session_id}/stop
 ```
 
 ### Get Session Cookies (free)
@@ -65,7 +65,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}/cookies
+orth run notte /sessions/{session_id}/cookies
 ```
 
 ### Get Network Logs (free)
@@ -75,7 +75,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}/network/logs --query session_id=example
+orth run notte /sessions/{session_id}/network/logs --query session_id=example
 ```
 
 ### Get Agent Status (free)
@@ -85,7 +85,7 @@ Parameters:
 - agent_id* (string)
 
 ```bash
-orth api run notte /agents/{agent_id}
+orth run notte /agents/{agent_id}
 ```
 
 ### Observe Page
@@ -98,7 +98,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}/page/observe --body '{"instruction": "Find the search box"}'
+orth run notte /sessions/{session_id}/page/observe --body '{"instruction": "Find the search box"}'
 ```
 
 ### Stop Agent (free)
@@ -108,7 +108,7 @@ Parameters:
 - session_id* (string) - Session ID the agent is running on
 
 ```bash
-orth api run notte /agents/{agent_id}/stop
+orth run notte /agents/{agent_id}/stop
 ```
 
 ### Scrape Webpage
@@ -119,7 +119,7 @@ Parameters:
 - schema (object) - Structured extraction schema
 
 ```bash
-orth api run notte /scrape --body '{"url": "https://example.com"}'
+orth run notte /scrape --body '{"url": "https://example.com"}'
 ```
 
 ### Execute Page Action
@@ -137,7 +137,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}/page/execute --body '{"instruction": "Click the search button"}'
+orth run notte /sessions/{session_id}/page/execute --body '{"instruction": "Click the search button"}'
 ```
 
 ### Set Session Cookies
@@ -148,7 +148,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}/cookies
+orth run notte /sessions/{session_id}/cookies
 ```
 
 ### Start Session
@@ -166,7 +166,7 @@ Parameters:
 - user_agent (string)
 
 ```bash
-orth api run notte /sessions/start --body '{
+orth run notte /sessions/start --body '{
   "url": "https://example.com",
   "timeout_minutes": 5
 }'
@@ -179,7 +179,7 @@ Parameters:
 - frames* (array) - Array of HTML frames to parse
 
 ```bash
-orth api run notte /scrape_from_html --body '{"html": "<html><body>Hello</body></html>"}'
+orth run notte /scrape_from_html --body '{"html": "<html><body>Hello</body></html>"}'
 ```
 
 ### Start Agent
@@ -193,7 +193,7 @@ Parameters:
 - use_vision (boolean) - Use vision model (default: true)
 
 ```bash
-orth api run notte /agents/start --body '{
+orth run notte /agents/start --body '{
   "task": "Search for AI news on Google and summarize the top results",
   "url": "https://google.com"
 }'
@@ -212,7 +212,7 @@ Parameters:
 - session_id* (string)
 
 ```bash
-orth api run notte /sessions/{session_id}/page/scrape --body '{}'
+orth run notte /sessions/{session_id}/page/scrape --body '{}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-nyne/SKILL.md
+++ b/skills/orthogonal-nyne/SKILL.md
@@ -49,7 +49,7 @@ Parameters:
 - custom_filters (object) - Structured filters (locations, industries, titles, etc.)
 
 ```bash
-orth api run nyne /person/search --body '{"query": "Software engineers at OpenAI"}'
+orth run nyne /person/search --body '{"query": "Software engineers at OpenAI"}'
 ```
 
 ### Person Enrichment
@@ -69,7 +69,7 @@ Parameters:
 - probability_score (boolean) - Include confidence score in results
 
 ```bash
-orth api run nyne /person/enrichment --body '{"email": "john@openai.com"}'
+orth run nyne /person/enrichment --body '{"email": "john@openai.com"}'
 ```
 
 ### Person Events
@@ -84,7 +84,7 @@ Parameters:
 - callback_url (string) - HTTPS endpoint for automatic delivery
 
 ```bash
-orth api run nyne /person/events --body '{"event": "YC Demo Day"}'
+orth run nyne /person/events --body '{"event": "YC Demo Day"}'
 ```
 
 ### Person Social Profiles
@@ -97,7 +97,7 @@ Parameters:
 - callback_url (string) - URL to receive results via webhook
 
 ```bash
-orth api run nyne /person/social-profiles --body '{"email": "john@openai.com"}'
+orth run nyne /person/social-profiles --body '{"email": "john@openai.com"}'
 ```
 
 ### Person Single Social Lookup
@@ -110,7 +110,7 @@ Parameters:
 - callback_url (string) - URL to receive results via webhook
 
 ```bash
-orth api run nyne /person/single-social-lookup --body '{"email": "john@openai.com", "site": "linkedin"}'
+orth run nyne /person/single-social-lookup --body '{"email": "john@openai.com", "site": "linkedin"}'
 ```
 
 ### Person Interactions
@@ -123,7 +123,7 @@ Parameters:
 - callback_url (string) - URL to receive results via webhook
 
 ```bash
-orth api run nyne /person/interactions --body '{"type": "followers", "social_media_url": "https://twitter.com/openai"}'
+orth run nyne /person/interactions --body '{"type": "followers", "social_media_url": "https://twitter.com/openai"}'
 ```
 
 ### Person Interests
@@ -136,7 +136,7 @@ Parameters:
 - callback_url (string) - URL to receive results via webhook
 
 ```bash
-orth api run nyne /person/interests --body '{"email": "john@openai.com"}'
+orth run nyne /person/interests --body '{"email": "john@openai.com"}'
 ```
 
 ### Person Newsfeed
@@ -147,7 +147,7 @@ Parameters:
 - callback_url (string) - URL to receive results via webhook
 
 ```bash
-orth api run nyne /person/newsfeed --body '{"social_media_url": "https://linkedin.com/in/johndoe"}'
+orth run nyne /person/newsfeed --body '{"social_media_url": "https://linkedin.com/in/johndoe"}'
 ```
 
 ### Company Search
@@ -162,7 +162,7 @@ Parameters:
 - callback_url (string) - HTTPS endpoint for automatic delivery
 
 ```bash
-orth api run nyne /company/search --body '{"industry": "AI", "location": "San Francisco"}'
+orth run nyne /company/search --body '{"industry": "AI", "location": "San Francisco"}'
 ```
 
 ### Company Enrichment
@@ -175,7 +175,7 @@ Parameters:
 - callback_url (string) - HTTPS endpoint for automatic delivery
 
 ```bash
-orth api run nyne /company/enrichment --body '{"social_media_url": "https://linkedin.com/company/openai"}'
+orth run nyne /company/enrichment --body '{"social_media_url": "https://linkedin.com/company/openai"}'
 ```
 
 ### Company Check Seller
@@ -187,7 +187,7 @@ Parameters:
 - callback_url (string) - HTTPS endpoint for automatic delivery
 
 ```bash
-orth api run nyne /company/checkseller --body '{"company_name": "Vanta", "product_service": "SOC 2 automation"}'
+orth run nyne /company/checkseller --body '{"company_name": "Vanta", "product_service": "SOC 2 automation"}'
 ```
 
 ### Company Needs
@@ -200,7 +200,7 @@ Parameters:
 - callback_url (string) - HTTPS endpoint for automatic delivery
 
 ```bash
-orth api run nyne /company/needs --body '{"company_name": "Uber Technologies", "content": "Regulatory challenges"}'
+orth run nyne /company/needs --body '{"company_name": "Uber Technologies", "content": "Regulatory challenges"}'
 ```
 
 ### Company Funding
@@ -212,7 +212,7 @@ Parameters:
 - callback_url (string) - HTTPS endpoint for automatic delivery
 
 ```bash
-orth api run nyne /company/funding --body '{"company_name": "OpenAI"}'
+orth run nyne /company/funding --body '{"company_name": "OpenAI"}'
 ```
 
 ### Company Funders
@@ -224,7 +224,7 @@ Parameters:
 - callback_url (string) - HTTPS endpoint for automatic delivery
 
 ```bash
-orth api run nyne /company/funders --body '{"company_name": "OpenAI"}'
+orth run nyne /company/funders --body '{"company_name": "OpenAI"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-olostep/SKILL.md
+++ b/skills/orthogonal-olostep/SKILL.md
@@ -44,7 +44,7 @@ Parameters:
 - metadata (object) - User-defined metadata. Not supported yet
 
 ```bash
-orth api run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
+orth run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
 ```
 
 ### Create Answer
@@ -55,7 +55,7 @@ Parameters:
 - json_format (object) - The desired output JSON object with empty values as a schema, or simply describe the data you want as a string.
 
 ```bash
-orth api run olostep /v1/answers --body '{"task": "What are the latest AI developments?"}'
+orth run olostep /v1/answers --body '{"task": "What are the latest AI developments?"}'
 ```
 
 ### Maps
@@ -71,7 +71,7 @@ Parameters:
 - cursor (string) - OPTIONAL: Pagination cursor from a previous response. When provided, returns the next set of URLs from where the previous request left off due to response size limit.
 
 ```bash
-orth api run olostep /v1/maps --body '{"url": "https://example.com"}'
+orth run olostep /v1/maps --body '{"url": "https://example.com"}'
 ```
 
 ### Start Crawl
@@ -91,7 +91,7 @@ Parameters:
 - timeout (number) - End the crawl after n seconds with the pages completed until then. May take ~10s extra from provided timeout.
 
 ```bash
-orth api run olostep /v1/crawls --body '{
+orth run olostep /v1/crawls --body '{
   "start_url": "https://example.com",
   "max_pages": 100
 }'
@@ -107,7 +107,7 @@ Parameters:
 - links_on_page (object) - Get all the links present on each page in the batch.
 
 ```bash
-orth api run olostep /v1/batches --body '{
+orth run olostep /v1/batches --body '{
   "items": [
     {"url_to_scrape": "https://example.com/page1"},
     {"url_to_scrape": "https://example.com/page2"}
@@ -119,42 +119,42 @@ orth api run olostep /v1/batches --body '{
 Retrieves the list of items processed for a batch. You can then use the `retrieve_id` to get the content with the Retrieve Endpoint
 
 ```bash
-orth api run olostep /v1/batches/{batch_id}/items
+orth run olostep /v1/batches/{batch_id}/items
 ```
 
 ### Crawl Info
 Fetches information about a specific crawl.
 
 ```bash
-orth api run olostep /v1/crawls/{crawl_id}
+orth run olostep /v1/crawls/{crawl_id}
 ```
 
 ### Crawl Pages
 Fetches the list of pages for a specific crawl.
 
 ```bash
-orth api run olostep /v1/crawls/{crawl_id}/pages
+orth run olostep /v1/crawls/{crawl_id}/pages
 ```
 
 ### Get Answer
 This endpoint retrieves a previously completed answer by its ID.
 
 ```bash
-orth api run olostep /v1/answers/{answer_id}
+orth run olostep /v1/answers/{answer_id}
 ```
 
 ### Get Scrape
 Can be used to retrieve response for a scrape.
 
 ```bash
-orth api run olostep /v1/scrapes/{scrape_id}
+orth run olostep /v1/scrapes/{scrape_id}
 ```
 
 ### Batch Info
 Retrieves the status and progress information about a batch. To retrieve the content for a batch, see here
 
 ```bash
-orth api run olostep /v1/batches/{batch_id}
+orth run olostep /v1/batches/{batch_id}
 ```
 
 ### Retrieve Content
@@ -165,7 +165,7 @@ Parameters:
 - formats (string[]) - Optional array to retrieve only specific formats in production. If not provided, all formats will be returned.
 
 ```bash
-orth api run olostep /v1/retrieve --body '{"retrieve_id": "abc123"}'
+orth run olostep /v1/retrieve --body '{"retrieve_id": "abc123"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -28,35 +28,35 @@ Web research API that returns OpenAI ChatCompletions-compatible responses.
 Retrieve a FindAll run.
 
 ```bash
-orth api run parallel /v1beta/findall/runs/{findall_id}
+orth run parallel /v1beta/findall/runs/{findall_id}
 ```
 
 ### FindAll Run Result (free)
 Retrieve the FindAll run result at the time of the request.
 
 ```bash
-orth api run parallel /v1beta/findall/runs/{findall_id}/result
+orth run parallel /v1beta/findall/runs/{findall_id}/result
 ```
 
 ### Cancel FindAll Run (free)
 Cancel a FindAll run.
 
 ```bash
-orth api run parallel /v1beta/findall/runs/{findall_id}/cancel
+orth run parallel /v1beta/findall/runs/{findall_id}/cancel
 ```
 
 ### Retrieve Task Run Input (free)
 Retrieves the input of a run by run_id.
 
 ```bash
-orth api run parallel /v1/tasks/runs/{run_id}/input
+orth run parallel /v1/tasks/runs/{run_id}/input
 ```
 
 ### Retrieve Task Run (free)
 Retrieves run status by run_id.The run result is available from the /result endpoint.
 
 ```bash
-orth api run parallel /v1/tasks/runs/{run_id}
+orth run parallel /v1/tasks/runs/{run_id}
 ```
 
 ### Ingest FindAll Run
@@ -66,7 +66,7 @@ Parameters:
 - objective* (string) - Input model for FindAll ingest.
 
 ```bash
-orth api run parallel /v1beta/findall/ingest --body '{"objective": "Find all AI startups in San Francisco"}'
+orth run parallel /v1beta/findall/ingest --body '{"objective": "Find all AI startups in San Francisco"}'
 ```
 
 ### Retrieve Task Run Result (free)
@@ -76,7 +76,7 @@ Parameters:
 - timeout (integer)
 
 ```bash
-orth api run parallel /v1/tasks/runs/{run_id}/result
+orth run parallel /v1/tasks/runs/{run_id}/result
 ```
 
 ### Create FindAll Run
@@ -93,7 +93,7 @@ Parameters:
 - webhook (Webhook · object) - Webhook for the FindAll run.
 
 ```bash
-orth api run parallel /v1beta/findall/runs --body '{
+orth run parallel /v1beta/findall/runs --body '{
   "goal": "Find all AI startups in San Francisco"
 }'
 ```
@@ -113,7 +113,7 @@ Parameters:
 - fetch_policy (object) - Fetch policy: determines when to return cached content from the index (faster) vs fetching live content (fresher). Default is to disable live fetch and return cached content from the index.
 
 ```bash
-orth api run parallel /v1beta/search --body '{"objective": "AI agent frameworks comparison 2024"}'
+orth run parallel /v1beta/search --body '{"objective": "AI agent frameworks comparison 2024"}'
 ```
 
 ### Chat API
@@ -126,7 +126,7 @@ Parameters:
 - response_format (object)
 
 ```bash
-orth api run parallel /chat/completions --body '{
+orth run parallel /chat/completions --body '{
   "model": "parallel",
   "messages": [
     {"role": "user", "content": "What are the latest developments in quantum computing?"}
@@ -146,7 +146,7 @@ Parameters:
 - full_content (boolean) - Include full content from each URL. Note that if neither objective nor search_queries is provided, excerpts are redundant with full content. default:false
 
 ```bash
-orth api run parallel /v1beta/extract --body '{"urls": ["https://example.com/article"]}'
+orth run parallel /v1beta/extract --body '{"urls": ["https://example.com/article"]}'
 ```
 
 ### Create Task Run
@@ -163,7 +163,7 @@ Parameters:
 - webhook (object) - Callback URL (webhook endpoint) that will receive an HTTP POST when the run completes.This feature is not available via the Python SDK. To enable this feature in your API requests, specify the parallel-beta header with webhook-2025-08-12 value.
 
 ```bash
-orth api run parallel /v1/tasks/runs --body '{
+orth run parallel /v1/tasks/runs --body '{
   "processor": "base",
   "input": "Research the competitive landscape of AI coding assistants"
 }'

--- a/skills/orthogonal-pdf-processor/SKILL.md
+++ b/skills/orthogonal-pdf-processor/SKILL.md
@@ -13,14 +13,14 @@ Extract text, tables, and structured data from PDF documents.
 Use Linkup to fetch PDF URLs:
 
 ```bash
-orth api run linkup /fetch --body '{"url": "https://example.com/document.pdf"}'
+orth run linkup /fetch --body '{"url": "https://example.com/document.pdf"}'
 ```
 
 ### Step 2: Extract with AI
 Use ScrapeGraph to extract specific content:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com/report.pdf",
   "user_prompt": "Extract all financial figures, tables, and key metrics from this document"
 }'
@@ -30,7 +30,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Get structured table data:
 
 ```bash
-orth api run riveter /v1/run --body '{
+orth run riveter /v1/run --body '{
   "input": {
     "urls": ["https://example.com/report.pdf"]
   },
@@ -44,20 +44,20 @@ orth api run riveter /v1/run --body '{
 Get readable markdown output:
 
 ```bash
-orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/document.pdf"}'
+orth run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/document.pdf"}'
 ```
 
 ## Example Usage
 
 ```bash
 # Extract data from financial report
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com/annual-report.pdf",
   "user_prompt": "Extract revenue, profit, and key business metrics with their values"
 }'
 
 # Extract invoice data
-orth api run riveter /v1/run --body '{
+orth run riveter /v1/run --body '{
   "input": {"urls": ["https://example.com/invoice.pdf"]},
   "output": {
     "vendor": {"prompt": "Vendor name", "contexts": ["urls"]},

--- a/skills/orthogonal-perplexity/SKILL.md
+++ b/skills/orthogonal-perplexity/SKILL.md
@@ -48,7 +48,7 @@ Parameters:
 - media_response (object) - Perplexity-Specific: Configuration for controlling media content in responses, such as videos and images. Use the overrides property to enable specific media types.
 
 ```bash
-orth api run perplexity /chat/completions --body '{
+orth run perplexity /chat/completions --body '{
   "model": "sonar",
   "messages": [
     {"role": "user", "content": "What are the latest developments in AI agents?"}
@@ -74,7 +74,7 @@ Parameters:
 - search_language_filter (string[]) - Perplexity-Specific: Filters search results to only include content in the specified languages. Accepts an array of ISO 639-1 language codes (2 lowercase letters). Maximum 10 language codes per request.
 
 ```bash
-orth api run perplexity /search --body '{"query": "latest AI developments February 2024"}'
+orth run perplexity /search --body '{"query": "latest AI developments February 2024"}'
 ```
 
 ### Sonar Chat Completions API
@@ -84,7 +84,7 @@ Parameters:
 - request (object) - required Show child attributes
 
 ```bash
-orth api run perplexity /async/chat/completions --body '{
+orth run perplexity /async/chat/completions --body '{
   "model": "sonar",
   "messages": [
     {"role": "user", "content": "Write a comprehensive analysis of vector databases"}
@@ -96,7 +96,7 @@ orth api run perplexity /async/chat/completions --body '{
 Retrieves the status and result of a specific asynchronous chat completion job.
 
 ```bash
-orth api run perplexity /async/chat/completions/{request_id}
+orth run perplexity /async/chat/completions/{request_id}
 ```
 
 ### List Async Chat Completions
@@ -107,7 +107,7 @@ Parameters:
 - next_token (string) - Token for fetching the next page of results. Ensure this token is URL-encoded when passed as a query parameter.
 
 ```bash
-orth api run perplexity /async/chat/completions
+orth run perplexity /async/chat/completions
 ```
 
 ## Use Cases

--- a/skills/orthogonal-precip/SKILL.md
+++ b/skills/orthogonal-precip/SKILL.md
@@ -39,7 +39,7 @@ Parameters:
 - format (string)
 
 ```bash
-orth api run precip /api/v1/last-48 --query latitude=37.7749 longitude=-122.4194
+orth run precip /api/v1/last-48 --query latitude=37.7749 longitude=-122.4194
 ```
 
 ### Air Temperature
@@ -54,7 +54,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/temperature-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/temperature-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Hourly Soil Moisture
@@ -69,7 +69,7 @@ Parameters:
 - format (string)
 
 ```bash
-orth api run precip /api/v1/soil-moisture-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/soil-moisture-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Wind Direction
@@ -84,7 +84,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/wind-direction-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/wind-direction-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Daily Precipitation Data
@@ -99,7 +99,7 @@ Parameters:
 - format (string)
 
 ```bash
-orth api run precip /api/v1/daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
+orth run precip /api/v1/daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
 ```
 
 ### Wind Gusts
@@ -114,7 +114,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/wind-speed-gust-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/wind-speed-gust-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Recent Rain Event
@@ -127,7 +127,7 @@ Parameters:
 - format (string)
 
 ```bash
-orth api run precip /api/v1/recent-rain --query latitude=37.7749 longitude=-122.4194
+orth run precip /api/v1/recent-rain --query latitude=37.7749 longitude=-122.4194
 ```
 
 ### Map Layer Tiles
@@ -137,7 +137,7 @@ Parameters:
 - time (string)
 
 ```bash
-orth api run precip /api/v1/map/precipitation/ImageServer/tile/5/12/10
+orth run precip /api/v1/map/precipitation/ImageServer/tile/5/12/10
 ```
 
 ### Wind Speed
@@ -152,7 +152,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/wind-speed-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/wind-speed-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Cloud Cover
@@ -167,7 +167,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/cloud-cover-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/cloud-cover-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Soil Temperature
@@ -182,7 +182,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/temp-0-10cm-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/temp-0-10cm-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Specific Humidity
@@ -197,7 +197,7 @@ Parameters:
 - format (string)
 
 ```bash
-orth api run precip /api/v1/specific-humidity-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/specific-humidity-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Hourly Precipitation Data
@@ -212,7 +212,7 @@ Parameters:
 - format (string)
 
 ```bash
-orth api run precip /api/v1/hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-07
+orth run precip /api/v1/hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-07
 ```
 
 ### Daily Soil Moisture
@@ -227,7 +227,7 @@ Parameters:
 - format (string)
 
 ```bash
-orth api run precip /api/v1/soil-moisture-daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
+orth run precip /api/v1/soil-moisture-daily --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-31
 ```
 
 ### Embeddable HTML UI
@@ -248,7 +248,7 @@ Available options:
 When not provided, shows all widgets.
 
 ```bash
-orth api run precip /embed/location --query lat=37.7749 lon=-122.4194
+orth run precip /embed/location --query lat=37.7749 lon=-122.4194
 ```
 
 ### Solar Radiation
@@ -263,7 +263,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/solar-radiation-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/solar-radiation-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ### Relative Humidity
@@ -278,7 +278,7 @@ Parameters:
 - format (string) - Output format: `geojson`, `json` or `csv`
 
 ```bash
-orth api run precip /api/v1/relative-humidity-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
+orth run precip /api/v1/relative-humidity-hourly --query latitude=37.7749 longitude=-122.4194 start=2024-01-01 end=2024-01-02
 ```
 
 ## Use Cases

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -26,7 +26,7 @@ Parameters:
 - skip_cache (boolean) - Default: false. Set to true to bypass cache and always fetch fresh content
 
 ```bash
-orth api run riveter /v1/scrape --body '{"url": "https://example.com/article"}'
+orth run riveter /v1/scrape --body '{"url": "https://example.com/article"}'
 ```
 
 ### Run
@@ -38,7 +38,7 @@ Parameters:
 - run_key (string) - Custom identifier for this run (optional, will be generated if not provided)
 
 ```bash
-orth api run riveter /v1/run --body '{
+orth run riveter /v1/run --body '{
   "input": {
     "urls": ["https://example.com/products"]
   },
@@ -56,7 +56,7 @@ Parameters:
 - run_key* (string) - The run key (UUID) of the project run to retrieve data for
 
 ```bash
-orth api run riveter /v1/run_data --query 'run_key=abc123'
+orth run riveter /v1/run_data --query 'run_key=abc123'
 ```
 
 ### Run status (free)
@@ -66,7 +66,7 @@ Parameters:
 - run_key* (string) - The run key (UUID) of the project run to check
 
 ```bash
-orth api run riveter /v1/run_status --query 'run_key=abc123'
+orth run riveter /v1/run_status --query 'run_key=abc123'
 ```
 
 ### Stop run (free)
@@ -76,7 +76,7 @@ Parameters:
 - run_key* (string) - The run key (UUID) of the project run to stop
 
 ```bash
-orth api run riveter /v1/stop_run --query 'run_key=abc123'
+orth run riveter /v1/stop_run --query 'run_key=abc123'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-sales-prospecting/SKILL.md
+++ b/skills/orthogonal-sales-prospecting/SKILL.md
@@ -13,7 +13,7 @@ Build targeted prospect lists with verified emails and contact information.
 Search for companies matching your ICP:
 
 ```bash
-orth api run fiber /v1/natural-language-search/companies --body '{
+orth run fiber /v1/natural-language-search/companies --body '{
   "query": "B2B SaaS startups in San Francisco with 50-200 employees Series A or B funded"
 }'
 ```
@@ -22,7 +22,7 @@ orth api run fiber /v1/natural-language-search/companies --body '{
 Search for people at target companies:
 
 ```bash
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "job_titles": ["CTO", "VP Engineering", "Head of Engineering"],
     "company_names": ["Stripe", "Figma", "Notion"],
@@ -35,14 +35,14 @@ orth api run fiber /v1/people-search --body '{
 Find all contacts at a domain:
 
 ```bash
-orth api run hunter /v2/domain-search --query 'domain=stripe.com'
+orth run hunter /v2/domain-search --query 'domain=stripe.com'
 ```
 
 ### Step 4: Find Specific Contact's Email
 Find email for a specific person:
 
 ```bash
-orth api run sixtyfour /find-email --body '{
+orth run sixtyfour /find-email --body '{
   "lead": {
     "first_name": "Sarah",
     "last_name": "Chen",
@@ -55,21 +55,21 @@ orth api run sixtyfour /find-email --body '{
 Check deliverability before outreach:
 
 ```bash
-orth api run fiber /v1/validate-email/single --body '{"email": "sarah@stripe.com"}'
+orth run fiber /v1/validate-email/single --body '{"email": "sarah@stripe.com"}'
 ```
 
 ### Step 6: Enrich with Company Data
 Get company context for personalization:
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
+orth run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
 ```
 
 ## Prospecting Pipeline
 
 ```bash
 # 1. Find companies (Fiber)
-orth api run fiber /v1/company-search --body '{
+orth run fiber /v1/company-search --body '{
   "searchParams": {
     "industries": ["Software", "SaaS"],
     "employee_count_min": 50,
@@ -79,7 +79,7 @@ orth api run fiber /v1/company-search --body '{
 }'
 
 # 2. Find decision makers (Fiber)
-orth api run fiber /v1/people-search --body '{
+orth run fiber /v1/people-search --body '{
   "searchParams": {
     "job_titles": ["VP Sales", "Head of Sales", "CRO"],
     "company_domains": ["company1.com", "company2.com"]
@@ -87,10 +87,10 @@ orth api run fiber /v1/people-search --body '{
 }'
 
 # 3. Get emails (Hunter)
-orth api run hunter /v2/domain-search --query 'domain=company1.com'
+orth run hunter /v2/domain-search --query 'domain=company1.com'
 
 # 4. Verify emails (Fiber)
-orth api run fiber /v1/validate-email/single --body '{"email": "lead@company.com"}'
+orth run fiber /v1/validate-email/single --body '{"email": "lead@company.com"}'
 ```
 
 ## Tips

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -42,7 +42,7 @@ Parameters:
 -  steps (array) - Optional array of interaction steps to perform on the webpage before extraction. Each step is a string describing the action to take (e.g., “click on filter button”, “wait for results to load”). Example: ["click on search button", "type query in search box", "wait for results"]
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com/products",
   "user_prompt": "Extract all product names and prices"
 }'
@@ -59,7 +59,7 @@ Parameters:
 - stealth (boolean) - Optional parameter to enable stealth mode. When set to true, the scraper will use advanced anti-detection techniques to bypass bot protection and access protected websites. Adds +4 credits to the request cost. Default: false
 
 ```bash
-orth api run scrapegraph /v1/searchscraper --body '{"user_prompt": "Find the latest iPhone prices from major retailers"}'
+orth run scrapegraph /v1/searchscraper --body '{"user_prompt": "Find the latest iPhone prices from major retailers"}'
 ```
 
 ### Scrape
@@ -72,7 +72,7 @@ Parameters:
 - stealth (string) - Enable stealth mode for anti-bot protection. Adds additional credits. Default: false
 
 ```bash
-orth api run scrapegraph /v1/scrape --body '{"website_url": "https://example.com"}'
+orth run scrapegraph /v1/scrape --body '{"website_url": "https://example.com"}'
 ```
 
 ### Start SmartCrawler
@@ -94,7 +94,7 @@ Parameters:
 - stealth (string)
 
 ```bash
-orth api run scrapegraph /v1/crawl --body '{
+orth run scrapegraph /v1/crawl --body '{
   "url": "https://docs.example.com",
   "prompt": "Extract all API endpoints and their descriptions"
 }'
@@ -110,7 +110,7 @@ Parameters:
 - stealth (boolean) - Optional parameter to enable stealth mode. When set to true, the scraper will use advanced anti-detection techniques to bypass bot protection and access protected websites. Adds +4 credits to the request cost.
 
 ```bash
-orth api run scrapegraph /v1/sitemap --body '{"website_url": "https://example.com"}'
+orth run scrapegraph /v1/sitemap --body '{"website_url": "https://example.com"}'
 ```
 
 ### Start Markdownify
@@ -122,42 +122,42 @@ Parameters:
 - stealth (boolean) - Enable stealth mode to bypass bot protection using advanced anti-detection techniques. Adds +4 credits to the request cost
 
 ```bash
-orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
+orth run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
 ```
 
 ### Get SearchScraper Status (free)
 Get the status and results of a previous search request
 
 ```bash
-orth api run scrapegraph /v1/searchscraper/{request_id}
+orth run scrapegraph /v1/searchscraper/{request_id}
 ```
 
 ### Get Markdownify Status (free)
 Check the status and retrieve results of a Markdownify request.
 
 ```bash
-orth api run scrapegraph /v1/markdownify/{request_id}
+orth run scrapegraph /v1/markdownify/{request_id}
 ```
 
 ### Get Sitemap Status (free)
 Check the status and retrieve results of a Sitemap request.
 
 ```bash
-orth api run scrapegraph /v1/sitemap/{request_id}
+orth run scrapegraph /v1/sitemap/{request_id}
 ```
 
 ### Get SmartCrawler Status (free)
 Get the status and results of a previous smartcrawl request
 
 ```bash
-orth api run scrapegraph /v1/crawl/{task_id}
+orth run scrapegraph /v1/crawl/{task_id}
 ```
 
 ### Get SmartScraper Status (free)
 Check the status and retrieve results of a SmartScraper request.
 
 ```bash
-orth api run scrapegraph /v1/smartscraper/{request_id}
+orth run scrapegraph /v1/smartscraper/{request_id}
 ```
 
 ## Use Cases

--- a/skills/orthogonal-searchapi/SKILL.md
+++ b/skills/orthogonal-searchapi/SKILL.md
@@ -45,7 +45,7 @@ Parameters:
 - num (integer) - Number of results
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=tripadvisor q=best%20restaurants%20NYC
+orth run searchapi /api/v1/search -q 'engine=tripadvisor&q=best restaurants NYC'
 ```
 
 ### YouTube Comments
@@ -59,7 +59,7 @@ Parameters:
 - next_page_token (string) - Pagination token
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=youtube_comments video_id=dQw4w9WgXcQ
+orth run searchapi /api/v1/search -q 'engine=youtube_comments&video_id=dQw4w9WgXcQ'
 ```
 
 ### YouTube Channel
@@ -72,7 +72,7 @@ Parameters:
 - hl (string) - Language code
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=youtube_channel channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw
+orth run searchapi /api/v1/search -q 'engine=youtube_channel&channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw'
 ```
 
 ### Reddit Ad Library
@@ -88,7 +88,7 @@ Parameters:
 - post_type (string) - Post type filter
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=reddit_ad_library q=software
+orth run searchapi /api/v1/search -q 'engine=reddit_ad_library&q=software'
 ```
 
 ### Meta Ad Library
@@ -111,7 +111,7 @@ Parameters:
 - next_page_token (string) - Pagination token
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=meta_ad_library q=AI%20tools
+orth run searchapi /api/v1/search -q 'engine=meta_ad_library&q=AI tools'
 ```
 
 ### YouTube Transcripts
@@ -126,7 +126,7 @@ Parameters:
 - only_available (boolean) - Only return available transcripts
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=youtube_transcripts video_id=dQw4w9WgXcQ
+orth run searchapi /api/v1/search -q 'engine=youtube_transcripts&video_id=dQw4w9WgXcQ'
 ```
 
 ### Amazon Search
@@ -145,7 +145,7 @@ Parameters:
 - rh (string) - Refinement filters
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=amazon_search q=wireless%20headphones
+orth run searchapi /api/v1/search -q 'engine=amazon_search&q=wireless headphones'
 ```
 
 ### eBay Search
@@ -170,7 +170,7 @@ Parameters:
 - distance_radius (integer) - Distance radius in miles
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=ebay_search q=vintage%20watch
+orth run searchapi /api/v1/search -q 'engine=ebay_search&q=vintage watch'
 ```
 
 ### YouTube Video Details
@@ -183,7 +183,7 @@ Parameters:
 - hl (string) - Language code
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=youtube_video video_id=dQw4w9WgXcQ
+orth run searchapi /api/v1/search -q 'engine=youtube_video&video_id=dQw4w9WgXcQ'
 ```
 
 ### YouTube Channel Videos
@@ -196,7 +196,7 @@ Parameters:
 - hl (string) - Language code
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=youtube_channel_videos channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw
+orth run searchapi /api/v1/search -q 'engine=youtube_channel_videos&channel_id=UC_x5XG1OV2P6uZZ5FSM9Ttw'
 ```
 
 ### Apple App Store Search
@@ -214,7 +214,7 @@ Parameters:
 - include_explicit (boolean) - Include explicit content
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=apple_app_store term=productivity
+orth run searchapi /api/v1/search -q 'engine=apple_app_store&term=productivity'
 ```
 
 ### Airbnb Search
@@ -242,7 +242,7 @@ Parameters:
 - amenities (string) - Amenities filter
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=airbnb q=Paris
+orth run searchapi /api/v1/search -q 'engine=airbnb&q=Paris'
 ```
 
 ### TikTok Profile
@@ -253,7 +253,7 @@ Parameters:
 - username* (string) - TikTok username
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=tiktok_profile username=openai
+orth run searchapi /api/v1/search -q 'engine=tiktok_profile&username=openai'
 ```
 
 ### Instagram Profile
@@ -264,7 +264,7 @@ Parameters:
 - username* (string) - Instagram username
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=instagram_profile username=openai
+orth run searchapi /api/v1/search -q 'engine=instagram_profile&username=openai'
 ```
 
 ### Walmart Search
@@ -282,7 +282,7 @@ Parameters:
 - filters (string) - Additional filters
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=walmart_search q=laptop
+orth run searchapi /api/v1/search -q 'engine=walmart_search&q=laptop'
 ```
 
 ### TikTok Ads Library
@@ -298,7 +298,7 @@ Parameters:
 - next_page_token (string) - Pagination token
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=tiktok_ads_library q=AI
+orth run searchapi /api/v1/search -q 'engine=tiktok_ads_library&q=AI'
 ```
 
 ### LinkedIn Ad Library
@@ -313,7 +313,7 @@ Parameters:
 - next_page_token (string) - Pagination token
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=linkedin_ad_library q=hiring
+orth run searchapi /api/v1/search -q 'engine=linkedin_ad_library&q=hiring'
 ```
 
 ### YouTube Search
@@ -327,7 +327,7 @@ Parameters:
 - hl (string) - Language code (e.g. en, de, fr)
 
 ```bash
-orth api run searchapi /api/v1/search --query engine=youtube q=AI%20agents
+orth run searchapi /api/v1/search -q 'engine=youtube&q=AI agents'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-seo-analyzer/SKILL.md
+++ b/skills/orthogonal-seo-analyzer/SKILL.md
@@ -13,14 +13,14 @@ Analyze websites for SEO performance, keywords, content quality, and competitor 
 Map the website structure:
 
 ```bash
-orth api run tavily /map --body '{"url": "https://example.com"}'
+orth run tavily /map --body '{"url": "https://example.com"}'
 ```
 
 ### Step 2: Extract Page Content
 Get content for analysis:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com",
   "user_prompt": "Extract page title, meta description, headings (H1, H2, H3), main content, and internal links"
 }'
@@ -30,7 +30,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Find linking opportunities:
 
 ```bash
-orth api run exa /search --body '{
+orth run exa /search --body '{
   "query": "blogs and websites that accept guest posts about productivity software",
   "num_results": 20
 }'
@@ -40,7 +40,7 @@ orth api run exa /search --body '{
 
 ```bash
 # Quick site analysis
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://mysite.com",
   "user_prompt": "Analyze this page for SEO: title tag, meta description, heading structure, keyword usage, content length"
 }'

--- a/skills/orthogonal-shofo/SKILL.md
+++ b/skills/orthogonal-shofo/SKILL.md
@@ -39,7 +39,7 @@ Parameters:
 - feed_type (string) - Feed type: "top", "recent", or "reels"
 
 ```bash
-orth api run shofo /instagram/hashtag --query 'hashtag=artificialintelligence'
+orth run shofo /instagram/hashtag --query 'hashtag=artificialintelligence'
 ```
 
 ### X/Twitter Tweet Comments
@@ -51,7 +51,7 @@ Parameters:
 - cursor (string) - Pagination cursor from previous response
 
 ```bash
-orth api run shofo /x/comments --query 'tweet_url=https://x.com/OpenAI/status/123456'
+orth run shofo /x/comments --query 'tweet_url=https://x.com/OpenAI/status/123456'
 ```
 
 ### LinkedIn Company Posts
@@ -64,7 +64,7 @@ Parameters:
 - sort_by (string) - "top" for popular, "recent" for newest (default: top)
 
 ```bash
-orth api run shofo /linkedin/company-posts --query 'url=https://linkedin.com/company/openai'
+orth run shofo /linkedin/company-posts --query 'url=https://linkedin.com/company/openai'
 ```
 
 ### TikTok Hashtag Videos
@@ -77,7 +77,7 @@ Parameters:
 - cursor (string) - Pagination cursor from previous response
 
 ```bash
-orth api run shofo /tiktok/hashtag --query 'hashtag=ai'
+orth run shofo /tiktok/hashtag --query 'hashtag=ai'
 ```
 
 ### X/Twitter User Profile
@@ -87,7 +87,7 @@ Parameters:
 - username* (string) - X/Twitter username (without @)
 
 ```bash
-orth api run shofo /x/user-profile --query 'username=OpenAI'
+orth run shofo /x/user-profile --query 'username=OpenAI'
 ```
 
 ### TikTok Feed Videos
@@ -97,7 +97,7 @@ Parameters:
 - count* (integer) - Number of videos to retrieve (1-100)
 
 ```bash
-orth api run shofo /tiktok/feed --query 'keyword=artificial%20intelligence'
+orth run shofo /tiktok/feed --query 'keyword=artificial%20intelligence'
 ```
 
 ### Instagram User Profile
@@ -109,7 +109,7 @@ Parameters:
 - max_following (integer) - Number of following to fetch (0 = skip)
 
 ```bash
-orth api run shofo /instagram/user-profile --query 'username=openai'
+orth run shofo /instagram/user-profile --query 'username=openai'
 ```
 
 ### TikTok User Profile Videos
@@ -122,7 +122,7 @@ Parameters:
 - cursor (string) - Pagination cursor from previous response
 
 ```bash
-orth api run shofo /tiktok/profile --query 'username=openai'
+orth run shofo /tiktok/profile --query 'username=openai'
 ```
 
 ### TikTok Video Comments
@@ -134,7 +134,7 @@ Parameters:
 - cursor (integer) - Pagination cursor from previous response
 
 ```bash
-orth api run shofo /tiktok/comments --query 'video_url=https://tiktok.com/@user/video/123'
+orth run shofo /tiktok/comments --query 'video_url=https://tiktok.com/@user/video/123'
 ```
 
 ### Linkedin User Profile
@@ -144,7 +144,7 @@ Parameters:
 - username* (string) - LinkedIn username (from URL: linkedin.com/in/username). Provide either profile_url or username.
 
 ```bash
-orth api run shofo /linkedin/user-profile --query 'url=https://linkedin.com/in/johndoe'
+orth run shofo /linkedin/user-profile --query 'url=https://linkedin.com/in/johndoe'
 ```
 
 ### Linkedin User Posts
@@ -155,7 +155,7 @@ Parameters:
 - count* (integer) - Number of posts to retrieve
 
 ```bash
-orth api run shofo /linkedin/user-posts --query 'url=https://linkedin.com/in/johndoe'
+orth run shofo /linkedin/user-posts --query 'url=https://linkedin.com/in/johndoe'
 ```
 
 ### Linkedin Company Profile
@@ -167,7 +167,7 @@ Parameters:
 - employee_count (string) - Number of employees to fetch (default: 0)
 
 ```bash
-orth api run shofo /linkedin/company-profile --query 'url=https://linkedin.com/company/openai'
+orth run shofo /linkedin/company-profile --query 'url=https://linkedin.com/company/openai'
 ```
 
 ### Linkedin Search Employees
@@ -180,7 +180,7 @@ Parameters:
 - count* (integer) - Number of people to retrieve
 
 ```bash
-orth api run shofo /linkedin/search-employees --query 'company_url=https://linkedin.com/company/openai'
+orth run shofo /linkedin/search-employees --query 'company_url=https://linkedin.com/company/openai'
 ```
 
 ### Instagram User Posts
@@ -192,7 +192,7 @@ Parameters:
 - reels_only (boolean) - Fetch only reels instead of all posts
 
 ```bash
-orth api run shofo /instagram/user-posts --query 'username=openai'
+orth run shofo /instagram/user-posts --query 'username=openai'
 ```
 
 ### Instagram Individual Post
@@ -202,7 +202,7 @@ Parameters:
 - code_or_url* (string) - Post shortcode (e.g., DRhvwVLAHAG) or full Instagram URL. Accepted Input Formats The code_or_url parameter accepts either a shortcode or a full URL:  • Shortcode: CxYz123ABC • Post URL: https://www.instagram.com/p/CxYz123ABC/ • Reel URL: https://www.instagram.com/reel/CxYz123ABC/
 
 ```bash
-orth api run shofo /instagram/post --query 'url=https://instagram.com/p/abc123'
+orth run shofo /instagram/post --query 'url=https://instagram.com/p/abc123'
 ```
 
 ### Instagram Post Comments
@@ -215,7 +215,7 @@ Parameters:
 - cursor (string) - Pagination cursor (next_min_id)
 
 ```bash
-orth api run shofo /instagram/comments --query 'post_url=https://instagram.com/p/abc123'
+orth run shofo /instagram/comments --query 'post_url=https://instagram.com/p/abc123'
 ```
 
 ### X/Twitter User Posts
@@ -226,7 +226,7 @@ Parameters:
 - count* (integer) - Number of tweets to retrieve
 
 ```bash
-orth api run shofo /x/user-posts --query 'username=OpenAI'
+orth run shofo /x/user-posts --query 'username=OpenAI'
 ```
 
 ### X/Twitter Individual Post
@@ -236,7 +236,7 @@ Parameters:
 - tweet_id_or_url* (string) - Tweet ID or full URL (twitter.com or x.com). Accepted Input Formats: The tweet_id_or_url parameter accepts either a tweet ID or a full URL:  • Tweet ID: 1808168603721650364 • twitter.com URL: https://twitter.com/user/status/1808168603721650364 • x.com URL: https://x.com/user/status/1808168603721650364
 
 ```bash
-orth api run shofo /x/post --query 'url=https://x.com/OpenAI/status/123456'
+orth run shofo /x/post --query 'url=https://x.com/OpenAI/status/123456'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-sixtyfour/SKILL.md
+++ b/skills/orthogonal-sixtyfour/SKILL.md
@@ -24,7 +24,7 @@ Parameters:
 - mode (string) - Email discovery mode. Allowed values: `"PROFESSIONAL"` (default) for company emails, `"PERSONAL"` for personal emails.
 
 ```bash
-orth api run sixtyfour /find-email --body '{
+orth run sixtyfour /find-email --body '{
   "lead": {
     "first_name": "John",
     "last_name": "Doe",
@@ -43,7 +43,7 @@ Parameters:
 - research_plan (string) - Optional research plan to guide enrichment
 
 ```bash
-orth api run sixtyfour /enrich-lead --body '{
+orth run sixtyfour /enrich-lead --body '{
   "lead_info": {
     "first_name": "John",
     "last_name": "Doe",
@@ -66,7 +66,7 @@ Parameters:
 - email (string) - Email address
 
 ```bash
-orth api run sixtyfour /find-phone --body '{
+orth run sixtyfour /find-phone --body '{
   "lead": {
     "first_name": "John",
     "last_name": "Doe",
@@ -87,7 +87,7 @@ Parameters:
 - people_focus_prompt (string) - Description of people to find, typically includes the roles or responsibilities of the people you’re looking for
 
 ```bash
-orth api run sixtyfour /enrich-company --body '{
+orth run sixtyfour /enrich-company --body '{
   "target_company": {"domain": "acme.com"},
   "struct": {"description": "Company description", "industry": "Industry"}
 }'

--- a/skills/orthogonal-social-listening/SKILL.md
+++ b/skills/orthogonal-social-listening/SKILL.md
@@ -13,7 +13,7 @@ Track brand mentions, competitor activity, and industry conversations across the
 Track competitor mentions:
 
 ```bash
-orth api run exa /search --body '{
+orth run exa /search --body '{
   "query": "Notion reviews opinions user feedback",
   "num_results": 30,
   "contents": {"text": true}
@@ -24,7 +24,7 @@ orth api run exa /search --body '{
 
 ```bash
 # Track competitor launches
-orth api run exa /search --body '{
+orth run exa /search --body '{
   "query": "Notion new features announcement launch 2024",
   "num_results": 20
 }'

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -41,7 +41,7 @@ Parameters:
 - auto_parameters (boolean) - When auto_parameters is enabled, Tavily automatically configures search parameters based on your query's content and intent. You can still set other parameters manually, and your explicit values will override the automatic ones. The parameters include_answer, include_raw_content, and max_results must always be set manually, as they directly affect response size. Note: search_depth may be automatically set to advanced when it's likely to improve results. This uses 2 API credits per request. To avoid the extra cost, you can explicitly set search_depth to basic.
 
 ```bash
-orth api run tavily /search --body '{
+orth run tavily /search --body '{
   "query": "latest developments in AI agents",
   "search_depth": "advanced",
   "include_answer": true
@@ -52,7 +52,7 @@ orth api run tavily /search --body '{
 Retrieve the status and results of a research task using its request ID.
 
 ```bash
-orth api run tavily /research/{request_id}
+orth run tavily /research/{request_id}
 ```
 
 ### Create Research Task
@@ -66,7 +66,7 @@ Parameters:
 - citation_format (enum<string>) - The format for citations in the research report.
 
 ```bash
-orth api run tavily /research --body '{"input": "Compare different AI agent frameworks for production use"}'
+orth run tavily /research --body '{"input": "Compare different AI agent frameworks for production use"}'
 ```
 
 ### Tavily Extract
@@ -83,7 +83,7 @@ Parameters:
 - timeout (number) - Maximum time in seconds to wait for the URL extraction before timing out. Must be between 1.0 and 60.0 seconds. If not specified, default timeouts are applied based on extract_depth: 10 seconds for basic extraction and 30 seconds for advanced extraction.
 
 ```bash
-orth api run tavily /extract --body '{"urls": ["https://example.com/article1", "https://example.com/article2"]}'
+orth run tavily /extract --body '{"urls": ["https://example.com/article1", "https://example.com/article2"]}'
 ```
 
 ### Tavily Map
@@ -103,7 +103,7 @@ Parameters:
 - timeout (number<float>) - Maximum time in seconds to wait for the map operation before timing out. Must be between 10 and 150 seconds.
 
 ```bash
-orth api run tavily /map --body '{"url": "https://example.com"}'
+orth run tavily /map --body '{"url": "https://example.com"}'
 ```
 
 ### Tavily Crawl
@@ -128,7 +128,7 @@ Parameters:
 - timeout (number<float>) - Maximum time in seconds to wait for the crawl operation before timing out. Must be between 10 and 150 seconds.
 
 ```bash
-orth api run tavily /crawl --body '{
+orth run tavily /crawl --body '{
   "url": "https://docs.example.com",
   "max_depth": 3
 }'

--- a/skills/orthogonal-tavus/SKILL.md
+++ b/skills/orthogonal-tavus/SKILL.md
@@ -18,7 +18,7 @@ Create real-time video conversations with AI-powered digital personas.
 This endpoint returns a list of all Personas. You can first list the Personas to choose which one you'd like to create a conversation with. Then, using the Create Conversation endpoint, you can start a conversation with that persona providing the persona ID.
 
 ```bash
-orth api run tavus /v2/personas
+orth run tavus /v2/personas
 ```
 
 ### Create Conversation
@@ -28,7 +28,7 @@ Parameters:
 - persona_id* (string) - p1b06420cfdc
 
 ```bash
-orth api run tavus /v2/conversations --body '{
+orth run tavus /v2/conversations --body '{
   "persona_id": "your-persona-id",
   "conversation_name": "Customer Support Call"
 }'

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -18,7 +18,7 @@ Send SMS messages via simple HTTP API.
 Checking SMS delivery status
 
 ```bash
-orth api run textbelt /status/{message_id}
+orth run textbelt /status/{message_id}
 ```
 
 ### Send an SMS
@@ -34,7 +34,7 @@ Parameters:
 - webhookData (string) - Endpoint supports a webhookData field.  This data is passed as data in the webhook request. There is a maximum length of 100 characters in the webhookData field.
 
 ```bash
-orth api run textbelt /text --body '{
+orth run textbelt /text --body '{
   "phone": "+1234567890",
   "message": "Hello from Orthogonal!"
 }'

--- a/skills/orthogonal-tomba/SKILL.md
+++ b/skills/orthogonal-tomba/SKILL.md
@@ -40,7 +40,7 @@ Parameters:
 - country_code (string) - Country code (e.g., US)
 
 ```bash
-orth api run tomba /v1/phone-validator --query 'phone=+14155552671'
+orth run tomba /v1/phone-validator --query 'phone=+14155552671'
 ```
 
 ### Domain Status
@@ -50,7 +50,7 @@ Parameters:
 - domain* (string) - Domain to check
 
 ```bash
-orth api run tomba /v1/domain-status --query 'domain=stripe.com'
+orth run tomba /v1/domain-status --query 'domain=stripe.com'
 ```
 
 ### Email Format
@@ -60,7 +60,7 @@ Parameters:
 - domain* (string) - Domain name, e.g. stripe.com
 
 ```bash
-orth api run tomba /v1/email-format --query 'domain=stripe.com'
+orth run tomba /v1/email-format --query 'domain=stripe.com'
 ```
 
 ### Find Person
@@ -70,7 +70,7 @@ Parameters:
 - email* (string) - Email address to look up
 
 ```bash
-orth api run tomba /v1/people/find --query 'email=john@stripe.com'
+orth run tomba /v1/people/find --query 'email=john@stripe.com'
 ```
 
 ### Combined Enrichment
@@ -80,7 +80,7 @@ Parameters:
 - email* (string) - Email address to enrich
 
 ```bash
-orth api run tomba /v1/combined/find --query 'email=john@stripe.com'
+orth run tomba /v1/combined/find --query 'email=john@stripe.com'
 ```
 
 ### Domain Suggestions
@@ -90,7 +90,7 @@ Parameters:
 - query* (string) - The domain or company name to find suggestions for
 
 ```bash
-orth api run tomba /v1/domain-suggestions --query 'query=Google'
+orth run tomba /v1/domain-suggestions --query 'query=Google'
 ```
 
 ### Email Count
@@ -100,7 +100,7 @@ Parameters:
 - domain* (string) - Domain name, e.g. stripe.com
 
 ```bash
-orth api run tomba /v1/email-count --query 'domain=openai.com'
+orth run tomba /v1/email-count --query 'domain=openai.com'
 ```
 
 ### Author Finder
@@ -110,7 +110,7 @@ Parameters:
 - url* (string) - URL of the blog post/article
 
 ```bash
-orth api run tomba /v1/author-finder --query 'url=https://example.com/blog/post'
+orth run tomba /v1/author-finder --query 'url=https://example.com/blog/post'
 ```
 
 ### LinkedIn Finder
@@ -121,7 +121,7 @@ Parameters:
 - enrich_mobile (string) - Set to true to get phone number
 
 ```bash
-orth api run tomba /v1/linkedin --query 'url=https://linkedin.com/in/johndoe'
+orth run tomba /v1/linkedin --query 'url=https://linkedin.com/in/johndoe'
 ```
 
 ### Technology Stack
@@ -131,7 +131,7 @@ Parameters:
 - domain* (string) - Domain to analyze
 
 ```bash
-orth api run tomba /v1/technology --query 'domain=stripe.com'
+orth run tomba /v1/technology --query 'domain=stripe.com'
 ```
 
 ### Verify Email
@@ -141,7 +141,7 @@ Parameters:
 - email* (string) - The email address to verify
 
 ```bash
-orth api run tomba /v1/email-verifier --query 'email=john@example.com'
+orth run tomba /v1/email-verifier --query 'email=john@example.com'
 ```
 
 ### Find Company
@@ -151,7 +151,7 @@ Parameters:
 - domain* (string) - Domain name (e.g., stripe.com)
 
 ```bash
-orth api run tomba /v1/companies/find --query 'domain=anthropic.com'
+orth run tomba /v1/companies/find --query 'domain=anthropic.com'
 ```
 
 ### Location
@@ -161,7 +161,7 @@ Parameters:
 - domain* (string) - Domain name, e.g. stripe.com
 
 ```bash
-orth api run tomba /v1/location --query 'ip=8.8.8.8'
+orth run tomba /v1/location --query 'ip=8.8.8.8'
 ```
 
 ### Domain Search
@@ -176,7 +176,7 @@ Parameters:
 - department (string) - Department filter: engineering, sales, finance, hr, it, marketing, operations, management, executive, legal, support, communication, software, security, pr, warehouse, diversity, administrative, facilities, accounting
 
 ```bash
-orth api run tomba /v1/domain-search --query 'domain=stripe.com'
+orth run tomba /v1/domain-search --query 'domain=stripe.com'
 ```
 
 ### Email Enrichment
@@ -187,7 +187,7 @@ Parameters:
 - enrich_mobile (string) - Set to true to get phone number
 
 ```bash
-orth api run tomba /v1/enrich --query 'email=john@stripe.com'
+orth run tomba /v1/enrich --query 'email=john@stripe.com'
 ```
 
 ### Find Phone
@@ -200,7 +200,7 @@ Parameters:
 - full (boolean) - Set to true to get all phone numbers
 
 ```bash
-orth api run tomba /v1/phone-finder --query domain=stripe.com first_name=John last_name=Doe
+orth run tomba /v1/phone-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ### Similar Domains
@@ -210,7 +210,7 @@ Parameters:
 - domain* (string) - Domain to find similar domains for
 
 ```bash
-orth api run tomba /v1/similar --query 'domain=stripe.com'
+orth run tomba /v1/similar --query 'domain=stripe.com'
 ```
 
 ### Email Finder
@@ -225,7 +225,7 @@ Parameters:
 - enrich_mobile (string) - Set to true to get phone number
 
 ```bash
-orth api run tomba /v1/email-finder --query domain=stripe.com first_name=John last_name=Doe
+orth run tomba /v1/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
 ### Email Sources
@@ -235,7 +235,7 @@ Parameters:
 - email* (string) - Email address to find sources for
 
 ```bash
-orth api run tomba /v1/email-sources --query 'email=john@stripe.com'
+orth run tomba /v1/email-sources --query 'email=john@stripe.com'
 ```
 
 ### Search Companies
@@ -247,7 +247,7 @@ Parameters:
 - page (integer) - Page number for pagination (1-1000, default: 1)
 
 ```bash
-orth api run tomba /v1/reveal/search --body '{"query": "AI startups in San Francisco with 50+ employees"}'
+orth run tomba /v1/reveal/search --body '{"query": "AI startups in San Francisco with 50+ employees"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-uptime-monitor/SKILL.md
+++ b/skills/orthogonal-uptime-monitor/SKILL.md
@@ -13,14 +13,14 @@ Monitor website uptime, check response times, and verify service availability.
 Verify site is accessible:
 
 ```bash
-orth api run linkup /fetch --body '{"url": "https://yoursite.com"}'
+orth run linkup /fetch --body '{"url": "https://yoursite.com"}'
 ```
 
 ### Step 2: Verify Page Content
 Ensure page loads correctly:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://yoursite.com",
   "user_prompt": "Check if page loads and contains expected content. Report any error messages."
 }'
@@ -30,14 +30,14 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Check API endpoints:
 
 ```bash
-orth api run linkup /fetch --body '{"url": "https://api.yoursite.com/health"}'
+orth run linkup /fetch --body '{"url": "https://api.yoursite.com/health"}'
 ```
 
 ### Step 4: Check Multiple Endpoints
 Monitor critical paths:
 
 ```bash
-orth api run olostep /v1/batches --body '{
+orth run olostep /v1/batches --body '{
   "urls": [
     "https://yoursite.com",
     "https://yoursite.com/login",
@@ -51,7 +51,7 @@ orth api run olostep /v1/batches --body '{
 Check official status:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://status.yoursite.com",
   "user_prompt": "Extract current service status, any incidents, and affected components"
 }'
@@ -61,7 +61,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Use SMS for critical alerts:
 
 ```bash
-orth api run textbelt /text --body '{
+orth run textbelt /text --body '{
   "phone": "+1234567890",
   "message": "ALERT: yoursite.com is down! Check immediately."
 }'
@@ -74,7 +74,7 @@ SITES=("https://example.com" "https://api.example.com/health")
 
 for site in "${SITES[@]}"; do
   echo "Checking: $site"
-  orth api run linkup /fetch --body "{\"url\": \"$site\"}"
+  orth run linkup /fetch --body "{\"url\": \"$site\"}"
 done
 ```
 
@@ -82,16 +82,16 @@ done
 
 ```bash
 # Quick status check
-orth api run linkup /fetch --body '{"url": "https://stripe.com"}'
+orth run linkup /fetch --body '{"url": "https://stripe.com"}'
 
 # Check status page
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://status.github.com",
   "user_prompt": "What is the current status of GitHub services?"
 }'
 
 # Monitor competitor uptime
-orth api run linkup /fetch --body '{"url": "https://competitor.com"}'
+orth run linkup /fetch --body '{"url": "https://competitor.com"}'
 ```
 
 ## What to Monitor

--- a/skills/orthogonal-valyu/SKILL.md
+++ b/skills/orthogonal-valyu/SKILL.md
@@ -29,7 +29,7 @@ Search the web, get AI answers, extract content, and run deep research tasks.
 Reference for getting deep research task status via GET /v1/deepresearch/tasks/{id}/status.
 
 ```bash
-orth api run valyu /v1/deepresearch/tasks/{id}/status
+orth run valyu /v1/deepresearch/tasks/{id}/status
 ```
 
 ### Update Task
@@ -39,42 +39,42 @@ Parameters:
 - instruction* (string) - Follow-up instruction to add to the running task. Must be submitted before the writing phase begins.
 
 ```bash
-orth api run valyu /v1/deepresearch/tasks/{id}/update --body '{"query": "Updated research query"}'
+orth run valyu /v1/deepresearch/tasks/{id}/update --body '{"query": "Updated research query"}'
 ```
 
 ### Cancel Task
 Reference for cancelling a running task via POST /v1/deepresearch/tasks/{id}/cancel.
 
 ```bash
-orth api run valyu /v1/deepresearch/tasks/{id}/cancel
+orth run valyu /v1/deepresearch/tasks/{id}/cancel
 ```
 
 ### Delete Task
 Reference for deleting a task via DELETE /v1/deepresearch/tasks/{id}/delete.
 
 ```bash
-orth api run valyu /v1/deepresearch/tasks/{id}/delete
+orth run valyu /v1/deepresearch/tasks/{id}/delete
 ```
 
 ### Get Batch Status
 Reference for getting batch status via GET /v1/deepresearch/batches/.
 
 ```bash
-orth api run valyu /v1/deepresearch/batches/{id}
+orth run valyu /v1/deepresearch/batches/{id}
 ```
 
 ### List Batch Tasks
 Reference for listing tasks in a batch via GET /v1/deepresearch/batches//tasks.
 
 ```bash
-orth api run valyu /v1/deepresearch/batches/{id}/tasks
+orth run valyu /v1/deepresearch/batches/{id}/tasks
 ```
 
 ### Cancel Batch
 Reference for cancelling a batch via POST /v1/deepresearch/batches//cancel.
 
 ```bash
-orth api run valyu /v1/deepresearch/batches/{id}/cancel
+orth run valyu /v1/deepresearch/batches/{id}/cancel
 ```
 
 ### Search
@@ -98,7 +98,7 @@ Parameters:
 - url_only (boolean) - When set to true, only returns URLs for results (no content). Only applies when search_type is 'web' or 'news'.
 
 ```bash
-orth api run valyu /v1/search --body '{"query": "AI agent frameworks comparison"}'
+orth run valyu /v1/search --body '{"query": "AI agent frameworks comparison"}'
 ```
 
 ### Answer
@@ -119,7 +119,7 @@ Parameters:
 - streaming (boolean) - Enable Server-Sent Events (SSE) streaming. When true, returns a stream of chunks: search_results first, then content deltas, then metadata, then [DONE].
 
 ```bash
-orth api run valyu /v1/answer --body '{"query": "What are the best practices for building AI agents?"}'
+orth run valyu /v1/answer --body '{"query": "What are the best practices for building AI agents?"}'
 ```
 
 ### Contents
@@ -134,7 +134,7 @@ Parameters:
 - summary (boolean) - Toggle AI processing (false is default)
 
 ```bash
-orth api run valyu /v1/contents --body '{"urls": ["https://example.com/article"]}'
+orth run valyu /v1/contents --body '{"urls": ["https://example.com/article"]}'
 ```
 
 ### Create Batch
@@ -149,7 +149,7 @@ Parameters:
 - metadata (object) - Custom metadata for tracking and organization
 
 ```bash
-orth api run valyu /v1/deepresearch/batches --body '{"name": "Competitor Research"}'
+orth run valyu /v1/deepresearch/batches --body '{"name": "Competitor Research"}'
 ```
 
 ### Create Task
@@ -172,7 +172,7 @@ Parameters:
 - deliverables (object[]) - Additional file outputs to generate from the research (CSV, Excel, PowerPoint, Word, PDF). Max 10 deliverables.
 
 ```bash
-orth api run valyu /v1/deepresearch/tasks --body '{"query": "Comprehensive analysis of vector databases market"}'
+orth run valyu /v1/deepresearch/tasks --body '{"query": "Comprehensive analysis of vector databases market"}'
 ```
 
 ### Add Tasks to Batch
@@ -182,7 +182,7 @@ Parameters:
 - tasks* (object[]) - Array of tasks to add to the batch (1-100 tasks per request)
 
 ```bash
-orth api run valyu /v1/deepresearch/batches/{id}/tasks
+orth run valyu /v1/deepresearch/batches/{id}/tasks
 ```
 
 ## Use Cases

--- a/skills/orthogonal-web-scraper/SKILL.md
+++ b/skills/orthogonal-web-scraper/SKILL.md
@@ -13,14 +13,14 @@ Scrape websites, extract structured data, and convert content to usable formats.
 Extract content from a single page:
 
 ```bash
-orth api run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
+orth run olostep /v1/scrapes --body '{"url_to_scrape": "https://example.com/page"}'
 ```
 
 ### Step 2: AI-Powered Extraction
 Extract specific data using natural language:
 
 ```bash
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://example.com/products",
   "user_prompt": "Extract all product names, prices, descriptions, and image URLs"
 }'
@@ -30,7 +30,7 @@ orth api run scrapegraph /v1/smartscraper --body '{
 Define a schema for consistent output:
 
 ```bash
-orth api run riveter /v1/run --body '{
+orth run riveter /v1/run --body '{
   "input": {
     "urls": ["https://example.com/products"]
   },
@@ -46,7 +46,7 @@ orth api run riveter /v1/run --body '{
 Crawl multiple pages:
 
 ```bash
-orth api run olostep /v1/crawls --body '{
+orth run olostep /v1/crawls --body '{
   "start_url": "https://docs.example.com",
   "max_pages": 50
 }'
@@ -56,30 +56,30 @@ orth api run olostep /v1/crawls --body '{
 Get clean markdown output:
 
 ```bash
-orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
+orth run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
 ```
 
 ### Step 6: Get Site Map
 Discover all URLs on a site:
 
 ```bash
-orth api run tavily /map --body '{"url": "https://example.com"}'
+orth run tavily /map --body '{"url": "https://example.com"}'
 ```
 
 ## Example Usage
 
 ```bash
 # Scrape product listings
-orth api run scrapegraph /v1/smartscraper --body '{
+orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://amazon.com/s?k=laptop",
   "user_prompt": "Extract product names, prices, ratings, and number of reviews"
 }'
 
 # Get all URLs from a site
-orth api run olostep /v1/maps --body '{"url": "https://docs.stripe.com"}'
+orth run olostep /v1/maps --body '{"url": "https://docs.stripe.com"}'
 
 # Convert docs to markdown
-orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://docs.openai.com/api"}'
+orth run scrapegraph /v1/markdownify --body '{"website_url": "https://docs.openai.com/api"}'
 ```
 
 ## Tips


### PR DESCRIPTION
## Summary
Fixes all skills to use the correct CLI syntax.

## Changes
- Replace deprecated `orth api run` with new `orth run` syntax across all 41 skills
- Fix searchapi skill to use `-q` flag with proper query string format (`&` separated)

## Before
```bash
orth api run searchapi /api/v1/search --query engine=amazon_search q=wireless%20headphones
```

## After
```bash
orth run searchapi /api/v1/search -q 'engine=amazon_search&q=wireless headphones'
```

## Testing
Tested searchapi Amazon search:
```bash
curl -X POST "https://api.orth.sh/v1/run" \
  -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"api":"searchapi","path":"/api/v1/search","query":{"engine":"amazon_search","q":"wireless earbuds"}}'
# ✅ SUCCESS - Cost: $0.01
```