### PR TITLE
chore: remove (free) pricing labels from all skills

### DIFF
--- a/skills/orthogonal-didit/SKILL.md
+++ b/skills/orthogonal-didit/SKILL.md
@@ -10,10 +10,10 @@ Verify user identities through phone/email OTP codes and screen against AML data
 ## Capabilities
 
 - **Send Email Code**: Send a one-time verification code to an email address
-- **Check Phone Code**: Verify a one-time code sent to a phone number (free)
+- **Check Phone Code**: Verify a one-time code sent to a phone number
 - **Send Phone Code**: Send a one-time verification code to a phone number
 - **AML Screening**: The AML Screening API allows you to screen individuals or companies against global watchlists and high-risk databases
-- **Check Email Code**: Verify a code sent to an email address (free)
+- **Check Email Code**: Verify a code sent to an email address
 - **Database Validation API**: Validate user-provided identity data against authoritative national and global data sources
 
 ## Usage
@@ -31,7 +31,7 @@ Parameters:
 orth api run didit /v3/email/send --body '{"email": "user@example.com"}'
 ```
 
-### Check Phone Code (free)
+### Check Phone Code
 Verify a one-time code sent to a phone number. Maximum of three verification attempts per code.
 
 Parameters:
@@ -82,7 +82,7 @@ Parameters:
 orth api run didit /v3/aml --body '{"full_name": "John Doe"}'
 ```
 
-### Check Email Code (free)
+### Check Email Code
 Verify a code sent to an email address.
 
 Parameters:

--- a/skills/orthogonal-notte/SKILL.md
+++ b/skills/orthogonal-notte/SKILL.md
@@ -10,13 +10,13 @@ Control browser sessions, scrape web pages, and run autonomous AI agents.
 ## Capabilities
 
 - **Take Screenshot**: Take a screenshot of the current page
-- **Get Session**: Get session status and details (free)
-- **Stop Session**: Stop and clean up a browser session (free)
-- **Get Session Cookies**: Get all cookies from the browser session (free)
-- **Get Network Logs**: Get network request/response logs from the session (free)
-- **Get Agent Status**: Get agent execution status and results (free)
+- **Get Session**: Get session status and details
+- **Stop Session**: Stop and clean up a browser session
+- **Get Session Cookies**: Get all cookies from the browser session
+- **Get Network Logs**: Get network request/response logs from the session
+- **Get Agent Status**: Get agent execution status and results
 - **Observe Page**: Observe the current page state and get available actions
-- **Stop Agent**: Stop a running agent (free)
+- **Stop Agent**: Stop a running agent
 - **Scrape Webpage**: Scrape content from a URL without managing sessions
 - **Execute Page Action**: Execute an action on the page (click, type, navigate, etc
 - **Set Session Cookies**: Set cookies in the browser session
@@ -38,7 +38,7 @@ Parameters:
 orth api run notte /sessions/{session_id}/page/screenshot --body '{}'
 ```
 
-### Get Session (free)
+### Get Session
 Get session status and details.
 
 Parameters:
@@ -48,7 +48,7 @@ Parameters:
 orth api run notte /sessions/{session_id}
 ```
 
-### Stop Session (free)
+### Stop Session
 Stop and clean up a browser session.
 
 Parameters:
@@ -58,7 +58,7 @@ Parameters:
 orth api run notte /sessions/{session_id}/stop
 ```
 
-### Get Session Cookies (free)
+### Get Session Cookies
 Get all cookies from the browser session.
 
 Parameters:
@@ -68,7 +68,7 @@ Parameters:
 orth api run notte /sessions/{session_id}/cookies
 ```
 
-### Get Network Logs (free)
+### Get Network Logs
 Get network request/response logs from the session.
 
 Parameters:
@@ -78,7 +78,7 @@ Parameters:
 orth api run notte /sessions/{session_id}/network/logs --query session_id=example
 ```
 
-### Get Agent Status (free)
+### Get Agent Status
 Get agent execution status and results.
 
 Parameters:
@@ -101,7 +101,7 @@ Parameters:
 orth api run notte /sessions/{session_id}/page/observe --body '{"instruction": "Find the search box"}'
 ```
 
-### Stop Agent (free)
+### Stop Agent
 Stop a running agent.
 
 Parameters:

--- a/skills/orthogonal-parallel/SKILL.md
+++ b/skills/orthogonal-parallel/SKILL.md
@@ -9,13 +9,13 @@ Web research API that returns OpenAI ChatCompletions-compatible responses.
 
 ## Capabilities
 
-- **Retrieve FindAll Run Status**: Retrieve a FindAll run (free)
-- **FindAll Run Result**: Retrieve the FindAll run result at the time of the request (free)
-- **Cancel FindAll Run**: Cancel a FindAll run (free)
-- **Retrieve Task Run Input**: Retrieves the input of a run by run_id (free)
-- **Retrieve Task Run**: Retrieves run status by run_id (free)
+- **Retrieve FindAll Run Status**: Retrieve a FindAll run
+- **FindAll Run Result**: Retrieve the FindAll run result at the time of the request
+- **Cancel FindAll Run**: Cancel a FindAll run
+- **Retrieve Task Run Input**: Retrieves the input of a run by run_id
+- **Retrieve Task Run**: Retrieves run status by run_id
 - **Ingest FindAll Run**: Transforms a natural language search objective into a structured FindAll spec
-- **Retrieve Task Run Result**: Retrieves a run result by run_id, blocking until the run is completed (free)
+- **Retrieve Task Run Result**: Retrieves a run result by run_id, blocking until the run is completed
 - **Create FindAll Run**: Starts a FindAll run
 - **Search**: Searches the web
 - **Chat API**: Parallel Chat is a web research API that returns OpenAI ChatCompletions compatible streaming text and JSON
@@ -24,35 +24,35 @@ Web research API that returns OpenAI ChatCompletions-compatible responses.
 
 ## Usage
 
-### Retrieve FindAll Run Status (free)
+### Retrieve FindAll Run Status
 Retrieve a FindAll run.
 
 ```bash
 orth api run parallel /v1beta/findall/runs/{findall_id}
 ```
 
-### FindAll Run Result (free)
+### FindAll Run Result
 Retrieve the FindAll run result at the time of the request.
 
 ```bash
 orth api run parallel /v1beta/findall/runs/{findall_id}/result
 ```
 
-### Cancel FindAll Run (free)
+### Cancel FindAll Run
 Cancel a FindAll run.
 
 ```bash
 orth api run parallel /v1beta/findall/runs/{findall_id}/cancel
 ```
 
-### Retrieve Task Run Input (free)
+### Retrieve Task Run Input
 Retrieves the input of a run by run_id.
 
 ```bash
 orth api run parallel /v1/tasks/runs/{run_id}/input
 ```
 
-### Retrieve Task Run (free)
+### Retrieve Task Run
 Retrieves run status by run_id.The run result is available from the /result endpoint.
 
 ```bash
@@ -69,7 +69,7 @@ Parameters:
 orth api run parallel /v1beta/findall/ingest --body '{"objective": "Find all AI startups in San Francisco"}'
 ```
 
-### Retrieve Task Run Result (free)
+### Retrieve Task Run Result
 Retrieves a run result by run_id, blocking until the run is completed.
 
 Parameters:

--- a/skills/orthogonal-riveter/SKILL.md
+++ b/skills/orthogonal-riveter/SKILL.md
@@ -11,9 +11,9 @@ Scrape web pages and extract data into your defined structure.
 
 - **Scrape**: Scrape a webpage and return the text content
 - **Run**: Copy link Define the structure of your output directly in the API request
-- **Run data**: Retrieve the processed data from a completed project run (free)
-- **Run status**: Check the current status of a project run (free)
-- **Stop run**: Stop a currently running project (free)
+- **Run data**: Retrieve the processed data from a completed project run
+- **Run status**: Check the current status of a project run
+- **Stop run**: Stop a currently running project
 
 ## Usage
 
@@ -49,7 +49,7 @@ orth api run riveter /v1/run --body '{
 }'
 ```
 
-### Run data (free)
+### Run data
 Retrieve the processed data from a completed project run
 
 Parameters:
@@ -59,7 +59,7 @@ Parameters:
 orth api run riveter /v1/run_data --query 'run_key=abc123'
 ```
 
-### Run status (free)
+### Run status
 Check the current status of a project run
 
 Parameters:
@@ -69,7 +69,7 @@ Parameters:
 orth api run riveter /v1/run_status --query 'run_key=abc123'
 ```
 
-### Stop run (free)
+### Stop run
 Stop a currently running project. This will halt all processing and mark the run as stopped. Behavior:  If the run is already stopped or success, returns success with current status. If the run is in progress, stops all pending cells and marks the run as stopped.  Stopped runs cannot be resumed
 
 Parameters:

--- a/skills/orthogonal-scrapegraph/SKILL.md
+++ b/skills/orthogonal-scrapegraph/SKILL.md
@@ -15,11 +15,11 @@ Extract web content using AI with natural language prompts.
 - **Start SmartCrawler**: Start a new web crawl request with AI extraction or markdown conversion
 - **Start Sitemap**: Extract all URLs from a website sitemap automatically
 - **Start Markdownify**: Convert any webpage into clean, readable Markdown format
-- **Get SearchScraper Status**: Get the status and results of a previous search request (free)
-- **Get Markdownify Status**: Check the status and retrieve results of a Markdownify request (free)
-- **Get Sitemap Status**: Check the status and retrieve results of a Sitemap request (free)
-- **Get SmartCrawler Status**: Get the status and results of a previous smartcrawl request (free)
-- **Get SmartScraper Status**: Check the status and retrieve results of a SmartScraper request (free)
+- **Get SearchScraper Status**: Get the status and results of a previous search request
+- **Get Markdownify Status**: Check the status and retrieve results of a Markdownify request
+- **Get Sitemap Status**: Check the status and retrieve results of a Sitemap request
+- **Get SmartCrawler Status**: Get the status and results of a previous smartcrawl request
+- **Get SmartScraper Status**: Check the status and retrieve results of a SmartScraper request
 
 ## Usage
 
@@ -125,35 +125,35 @@ Parameters:
 orth api run scrapegraph /v1/markdownify --body '{"website_url": "https://example.com/article"}'
 ```
 
-### Get SearchScraper Status (free)
+### Get SearchScraper Status
 Get the status and results of a previous search request
 
 ```bash
 orth api run scrapegraph /v1/searchscraper/{request_id}
 ```
 
-### Get Markdownify Status (free)
+### Get Markdownify Status
 Check the status and retrieve results of a Markdownify request.
 
 ```bash
 orth api run scrapegraph /v1/markdownify/{request_id}
 ```
 
-### Get Sitemap Status (free)
+### Get Sitemap Status
 Check the status and retrieve results of a Sitemap request.
 
 ```bash
 orth api run scrapegraph /v1/sitemap/{request_id}
 ```
 
-### Get SmartCrawler Status (free)
+### Get SmartCrawler Status
 Get the status and results of a previous smartcrawl request
 
 ```bash
 orth api run scrapegraph /v1/crawl/{task_id}
 ```
 
-### Get SmartScraper Status (free)
+### Get SmartScraper Status
 Check the status and retrieve results of a SmartScraper request.
 
 ```bash

--- a/skills/orthogonal-tavily/SKILL.md
+++ b/skills/orthogonal-tavily/SKILL.md
@@ -10,7 +10,7 @@ Comprehensive web search, crawling, content extraction, and deep research.
 ## Capabilities
 
 - **Tavily Search**: Execute a search query using Tavily Search
-- **Get Research Task Status**: Retrieve the status and results of a research task using its request ID (free)
+- **Get Research Task Status**: Retrieve the status and results of a research task using its request ID
 - **Create Research Task**: Tavily Research performs comprehensive research on a given topic by conducting multiple searches, analyzing sources, and generating a detailed research report
 - **Tavily Extract**: Extract web page content from one or more specified URLs using Tavily Extract
 - **Tavily Map**: Tavily Map traverses websites like a graph and can explore hundreds of paths in parallel with intelligent discovery to generate comprehensive site maps
@@ -48,7 +48,7 @@ orth api run tavily /search --body '{
 }'
 ```
 
-### Get Research Task Status (free)
+### Get Research Task Status
 Retrieve the status and results of a research task using its request ID.
 
 ```bash

--- a/skills/orthogonal-textbelt/SKILL.md
+++ b/skills/orthogonal-textbelt/SKILL.md
@@ -9,12 +9,12 @@ Send SMS messages via simple HTTP API.
 
 ## Capabilities
 
-- **Status**: Checking SMS delivery status (free)
+- **Status**: Checking SMS delivery status
 - **Send an SMS**: Send an SMS using HTTP POST
 
 ## Usage
 
-### Status (free)
+### Status
 Checking SMS delivery status
 
 ```bash


### PR DESCRIPTION
Removes `(free)` labels from 7 skills: textbelt, riveter, didit, parallel, notte, scrapegraph, tavily.

These are pricing indicators that shouldn't be in skills.