### PR TITLE
Sync 20 missing skills + fix broken API paths across 10 skills

### DIFF
--- a/skills/orthogonal-extract-webpage-data/SKILL.md
+++ b/skills/orthogonal-extract-webpage-data/SKILL.md
@@ -24,42 +24,42 @@ Uses Olostep, Scrapegraph, or Riveter APIs for AI-powered data extraction.
 ### Simple Scrape with Olostep
 
 ```bash
-orth run olostep /scrape -d '{"url":"https://example.com/products"}'
+orth run olostep /v1/scrapes -d '{"url_to_scrape":"https://example.com/products"}'
 ```
 
 ### AI-Powered Extraction with Scrapegraph
 
 ```bash
-orth run scrapegraph /v1/smartscraper -d '{"url":"https://example.com/team","prompt":"Extract all team members with their names, titles, and LinkedIn URLs"}'
+orth run scrapegraph /v1/smartscraper -d '{"website_url":"https://example.com/team","user_prompt":"Extract all team members with their names, titles, and LinkedIn URLs"}'
 ```
 
 ### Schema-Based Extraction with Riveter
 
 ```bash
-orth run riveter /api/scrape -d '{"url":"https://example.com","schema":{"name":"string","price":"number","description":"string"}}'
+orth run riveter /v1/scrape -d '{"url":"https://example.com","schema":{"name":"string","price":"number","description":"string"}}'
 ```
 
 ### Get AI Answer from Web
 
 ```bash
-orth run olostep /answer -d '{"task":"Find the pricing for Notion Teams plan from their website"}'
+orth run olostep /v1/answers -d '{"task":"Find the pricing for Notion Teams plan from their website"}'
 ```
 
 ### Crawl Multiple Pages
 
 ```bash
-orth run olostep /crawl/start -d '{"url":"https://example.com","maxPages":10}'
+orth run olostep /v1/crawls -d '{"start_url":"https://example.com","max_pages":10}'
 ```
 
 ## Parameters
 
 ### Olostep Scrape
-- **url** (required) - URL to scrape
+- **url_to_scrape** (required) - URL to scrape
 - **formats** - Output formats (markdown, html, text)
 
 ### Scrapegraph
-- **url** (required) - URL to scrape
-- **prompt** (required) - Natural language description of what to extract
+- **website_url** (required) - URL to scrape
+- **user_prompt** (required) - Natural language description of what to extract
 
 ### Riveter
 - **url** (required) - URL to scrape
@@ -84,22 +84,22 @@ orth run olostep /crawl/start -d '{"url":"https://example.com","maxPages":10}'
 
 **User:** "Get all the product names and prices from this page"
 ```bash
-orth run scrapegraph /v1/smartscraper -d '{"url":"https://example.com/products","prompt":"Extract all products with name, price, and description"}'
+orth run scrapegraph /v1/smartscraper -d '{"website_url":"https://example.com/products","user_prompt":"Extract all products with name, price, and description"}'
 ```
 
 **User:** "Scrape the team page and get everyone's info"
 ```bash
-orth run scrapegraph /v1/smartscraper -d '{"url":"https://example.com/about/team","prompt":"Extract team members: name, role, bio, photo URL, LinkedIn"}'
+orth run scrapegraph /v1/smartscraper -d '{"website_url":"https://example.com/about/team","user_prompt":"Extract team members: name, role, bio, photo URL, LinkedIn"}'
 ```
 
 **User:** "What are Stripe's API pricing details?"
 ```bash
-orth run olostep /answer -d '{"task":"Find Stripe API pricing breakdown from stripe.com/pricing"}'
+orth run olostep /v1/answers -d '{"task":"Find Stripe API pricing breakdown from stripe.com/pricing"}'
 ```
 
 **User:** "Get all blog post titles and dates from this blog"
 ```bash
-orth run riveter /api/scrape -d '{"url":"https://blog.example.com","schema":{"posts":[{"title":"string","date":"string","url":"string"}]}}'
+orth run riveter /v1/scrape -d '{"url":"https://blog.example.com","schema":{"posts":[{"title":"string","date":"string","url":"string"}]}}'
 ```
 
 ## Tips

--- a/skills/orthogonal-find-email-by-name/SKILL.md
+++ b/skills/orthogonal-find-email-by-name/SKILL.md
@@ -30,13 +30,13 @@ orth run hunter /v2/email-finder --query 'domain=stripe.com&first_name=Patrick&l
 ### Find Email with Tomba
 
 ```bash
-orth run tomba /email-finder --query 'domain=intercom.com&first_name=Eoghan&last_name=McCabe'
+orth run tomba /v1/email-finder --query 'domain=intercom.com&first_name=Eoghan&last_name=McCabe'
 ```
 
 ### Find from LinkedIn Profile
 
 ```bash
-orth run tomba /linkedin --query 'url=https://linkedin.com/in/johndoe'
+orth run tomba /v1/linkedin --query 'url=https://linkedin.com/in/johndoe'
 ```
 
 ## Parameters
@@ -64,7 +64,7 @@ orth run hunter /v2/email-finder --query 'domain=notion.so&first_name=Sarah&last
 
 **User:** "I need to contact John Smith who works at Google"
 ```bash
-orth run tomba /email-finder --query 'domain=google.com&first_name=John&last_name=Smith'
+orth run tomba /v1/email-finder --query 'domain=google.com&first_name=John&last_name=Smith'
 ```
 
 ## Tips

--- a/skills/orthogonal-image-analyzer/SKILL.md
+++ b/skills/orthogonal-image-analyzer/SKILL.md
@@ -31,12 +31,14 @@ Get specific data from images:
 
 ```bash
 orth api run riveter /v1/run --body '{
-  "url": "https://example.com/receipt.jpg",
-  "schema": {
-    "store_name": "string",
-    "date": "string",
-    "items": [{"name": "string", "price": "number"}],
-    "total": "number"
+  "input": {
+    "urls": ["https://example.com/receipt.jpg"]
+  },
+  "output": {
+    "store_name": {"prompt": "Store name", "contexts": ["urls"]},
+    "date": {"prompt": "Date", "contexts": ["urls"]},
+    "items": {"prompt": "Items with names and prices", "contexts": ["urls"]},
+    "total": {"prompt": "Total amount", "contexts": ["urls"]}
   }
 }'
 ```

--- a/skills/orthogonal-instagram-scraper/SKILL.md
+++ b/skills/orthogonal-instagram-scraper/SKILL.md
@@ -40,13 +40,13 @@ curl -X POST "https://api.orth.sh/v1/run" \
 ### Get Hashtag Posts
 
 ```bash
-orth run shofo /instagram/hashtag -q 'hashtag=artificialintelligence'
+orth run shofo /instagram/hashtag -q 'keyword=artificialintelligence'
 ```
 
 ### Get Post Comments
 
 ```bash
-orth run shofo /instagram/comments -q 'post_url=https://instagram.com/p/ABC123'
+orth run shofo /instagram/comments -q 'media_id=ABC123'
 ```
 
 ## Parameters
@@ -55,10 +55,10 @@ orth run shofo /instagram/comments -q 'post_url=https://instagram.com/p/ABC123'
 - **username** (required) - Instagram username (without @)
 
 ### Hashtag Posts
-- **hashtag** (required) - Hashtag to search (without #)
+- **keyword** (required) - Hashtag to search (without #)
 
 ### Post Comments
-- **post_url** (required) - Full Instagram post URL
+- **media_id** (required) - Instagram post/media ID
 
 ## Response
 
@@ -85,12 +85,12 @@ orth run shofo /instagram/user-posts -q 'username=openai'
 
 **User:** "Show me posts with #AI hashtag"
 ```bash
-orth run shofo /instagram/hashtag -q 'hashtag=AI'
+orth run shofo /instagram/hashtag -q 'keyword=AI'
 ```
 
 **User:** "Get comments on this Instagram post"
 ```bash
-orth run shofo /instagram/comments -q 'post_url=https://instagram.com/p/ABC123'
+orth run shofo /instagram/comments -q 'media_id=ABC123'
 ```
 
 ## Tips

--- a/skills/orthogonal-send-text-message/SKILL.md
+++ b/skills/orthogonal-send-text-message/SKILL.md
@@ -29,7 +29,7 @@ orth run textbelt /text --body '{
 The response includes a `textId`. Use it to check delivery status:
 
 ```bash
-orth run textbelt /status/<textId>
+orth run textbelt /status/{textId}
 ```
 
 This endpoint is free.

--- a/skills/orthogonal-shofo/SKILL.md
+++ b/skills/orthogonal-shofo/SKILL.md
@@ -39,7 +39,7 @@ Parameters:
 - feed_type (string) - Feed type: "top", "recent", or "reels"
 
 ```bash
-orth api run shofo /instagram/hashtag --query 'hashtag=artificialintelligence'
+orth api run shofo /instagram/hashtag --query 'keyword=artificialintelligence&count=10'
 ```
 
 ### X/Twitter Tweet Comments
@@ -51,7 +51,7 @@ Parameters:
 - cursor (string) - Pagination cursor from previous response
 
 ```bash
-orth api run shofo /x/comments --query 'tweet_url=https://x.com/OpenAI/status/123456'
+orth api run shofo /x/comments --query 'tweet_id=123456&count=10'
 ```
 
 ### LinkedIn Company Posts
@@ -64,7 +64,7 @@ Parameters:
 - sort_by (string) - "top" for popular, "recent" for newest (default: top)
 
 ```bash
-orth api run shofo /linkedin/company-posts --query 'url=https://linkedin.com/company/openai'
+orth api run shofo /linkedin/company-posts --query 'company=openai&count=5'
 ```
 
 ### TikTok Hashtag Videos
@@ -97,7 +97,7 @@ Parameters:
 - count* (integer) - Number of videos to retrieve (1-100)
 
 ```bash
-orth api run shofo /tiktok/feed --query 'keyword=artificial%20intelligence'
+orth api run shofo /tiktok/feed --query 'count=10'
 ```
 
 ### Instagram User Profile
@@ -134,7 +134,7 @@ Parameters:
 - cursor (integer) - Pagination cursor from previous response
 
 ```bash
-orth api run shofo /tiktok/comments --query 'video_url=https://tiktok.com/@user/video/123'
+orth api run shofo /tiktok/comments --query 'video_id=123&count=10'
 ```
 
 ### Linkedin User Profile
@@ -144,7 +144,7 @@ Parameters:
 - username* (string) - LinkedIn username (from URL: linkedin.com/in/username). Provide either profile_url or username.
 
 ```bash
-orth api run shofo /linkedin/user-profile --query 'url=https://linkedin.com/in/johndoe'
+orth api run shofo /linkedin/user-profile --query 'username=johndoe'
 ```
 
 ### Linkedin User Posts
@@ -155,7 +155,7 @@ Parameters:
 - count* (integer) - Number of posts to retrieve
 
 ```bash
-orth api run shofo /linkedin/user-posts --query 'url=https://linkedin.com/in/johndoe'
+orth api run shofo /linkedin/user-posts --query 'username=johndoe&count=5'
 ```
 
 ### Linkedin Company Profile
@@ -167,7 +167,7 @@ Parameters:
 - employee_count (string) - Number of employees to fetch (default: 0)
 
 ```bash
-orth api run shofo /linkedin/company-profile --query 'url=https://linkedin.com/company/openai'
+orth api run shofo /linkedin/company-profile --query 'company=openai'
 ```
 
 ### Linkedin Search Employees
@@ -180,7 +180,7 @@ Parameters:
 - count* (integer) - Number of people to retrieve
 
 ```bash
-orth api run shofo /linkedin/search-employees --query 'company_url=https://linkedin.com/company/openai'
+orth api run shofo /linkedin/search-employees --query 'company=openai&count=10'
 ```
 
 ### Instagram User Posts
@@ -202,7 +202,7 @@ Parameters:
 - code_or_url* (string) - Post shortcode (e.g., DRhvwVLAHAG) or full Instagram URL. Accepted Input Formats The code_or_url parameter accepts either a shortcode or a full URL:  • Shortcode: CxYz123ABC • Post URL: https://www.instagram.com/p/CxYz123ABC/ • Reel URL: https://www.instagram.com/reel/CxYz123ABC/
 
 ```bash
-orth api run shofo /instagram/post --query 'url=https://instagram.com/p/abc123'
+orth api run shofo /instagram/post --query 'code_or_url=https://instagram.com/p/abc123'
 ```
 
 ### Instagram Post Comments
@@ -215,7 +215,7 @@ Parameters:
 - cursor (string) - Pagination cursor (next_min_id)
 
 ```bash
-orth api run shofo /instagram/comments --query 'post_url=https://instagram.com/p/abc123'
+orth api run shofo /instagram/comments --query 'media_id=abc123'
 ```
 
 ### X/Twitter User Posts
@@ -236,7 +236,7 @@ Parameters:
 - tweet_id_or_url* (string) - Tweet ID or full URL (twitter.com or x.com). Accepted Input Formats: The tweet_id_or_url parameter accepts either a tweet ID or a full URL:  • Tweet ID: 1808168603721650364 • twitter.com URL: https://twitter.com/user/status/1808168603721650364 • x.com URL: https://x.com/user/status/1808168603721650364
 
 ```bash
-orth api run shofo /x/post --query 'url=https://x.com/OpenAI/status/123456'
+orth api run shofo /x/post --query 'tweet_id_or_url=https://x.com/OpenAI/status/123456'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-tiktok-search/SKILL.md
+++ b/skills/orthogonal-tiktok-search/SKILL.md
@@ -16,14 +16,14 @@ Search TikTok for profiles, videos, and hashtag content.
 
 ## How It Works
 
-Uses the SearchAPI TikTok engines to query TikTok data.
+Uses the Shofo API to scrape TikTok data including profiles, hashtags, and trending content.
 
 ## Usage
 
-### Get TikTok Profile
+### Get TikTok Profile Videos
 
 ```bash
-orth run searchapi /api/v1/search -q 'engine=tiktok_profile&username=charlidamelio'
+orth run shofo /tiktok/profile -q 'username=charlidamelio&count=10'
 ```
 
 <details>
@@ -33,35 +33,34 @@ orth run searchapi /api/v1/search -q 'engine=tiktok_profile&username=charlidamel
 curl -X POST "https://api.orth.sh/v1/run" \
   -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"api":"searchapi","path":"/api/v1/search","query":{"engine":"tiktok_profile","username":"charlidamelio"}}'
+  -d '{"api":"shofo","path":"/tiktok/profile","query":{"username":"charlidamelio","count":"10"}}'
 ```
 </details>
 
-### Search TikTok Videos
+### Search Hashtag Videos
 
 ```bash
-orth run searchapi /api/v1/search -q 'engine=tiktok&q=AI tutorials'
+orth run shofo /tiktok/hashtag -q 'hashtag=tech&count=10'
 ```
 
-### Search Hashtag
+### Get Trending Feed
 
 ```bash
-orth run searchapi /api/v1/search -q 'engine=tiktok_hashtag&hashtag=tech'
+orth run shofo /tiktok/feed -q 'count=10'
 ```
 
 ## Parameters
 
-### Profile Lookup
-- **engine** - `tiktok_profile`
+### Profile Videos
 - **username** (required) - TikTok username (without @)
+- **count** (required) - Number of videos to retrieve
 
-### Video Search
-- **engine** - `tiktok`
-- **q** (required) - Search query
-
-### Hashtag Search
-- **engine** - `tiktok_hashtag`
+### Hashtag Videos
 - **hashtag** (required) - Hashtag to search (without #)
+- **count** (required) - Number of videos to retrieve
+
+### Trending Feed
+- **count** (required) - Number of videos to retrieve (1-100)
 
 ## Response
 
@@ -84,17 +83,17 @@ orth run searchapi /api/v1/search -q 'engine=tiktok_hashtag&hashtag=tech'
 
 **User:** "Look up charlidamelio on TikTok"
 ```bash
-orth run searchapi /api/v1/search -q 'engine=tiktok_profile&username=charlidamelio'
+orth run shofo /tiktok/profile -q 'username=charlidamelio&count=10'
 ```
 
-**User:** "Find AI tutorial videos on TikTok"
+**User:** "What's trending on TikTok?"
 ```bash
-orth run searchapi /api/v1/search -q 'engine=tiktok&q=AI tutorial'
+orth run shofo /tiktok/feed -q 'count=10'
 ```
 
 **User:** "What's trending with #tech on TikTok?"
 ```bash
-orth run searchapi /api/v1/search -q 'engine=tiktok_hashtag&hashtag=tech'
+orth run shofo /tiktok/hashtag -q 'hashtag=tech&count=10'
 ```
 
 ## Tips

--- a/skills/orthogonal-verify-email/SKILL.md
+++ b/skills/orthogonal-verify-email/SKILL.md
@@ -30,7 +30,7 @@ orth run hunter /v2/email-verifier --query 'email=john@example.com'
 ### Verify with Tomba
 
 ```bash
-orth run tomba /email-verifier --query 'email=jane@company.com'
+orth run tomba /v1/email-verifier --query 'email=jane@company.com'
 ```
 
 ## Parameters
@@ -69,7 +69,7 @@ orth run hunter /v2/email-verifier --query 'email=hello@acme.com'
 
 **User:** "Verify sarah.jones@startup.io before I send my pitch"
 ```bash
-orth run tomba /email-verifier --query 'email=sarah.jones@startup.io'
+orth run tomba /v1/email-verifier --query 'email=sarah.jones@startup.io'
 ```
 
 ## Tips

--- a/skills/orthogonal-vhs-terminal-recordings/SKILL.md
+++ b/skills/orthogonal-vhs-terminal-recordings/SKILL.md
@@ -135,7 +135,7 @@ Enter
 Sleep 2.5s
 
 # Run command
-Type "orth run olostep /v1/scrape url=https://example.com"
+Type "orth run olostep /v1/scrapes url_to_scrape=https://example.com"
 Sleep 500ms
 Enter
 Sleep 4s

--- a/skills/orthogonal-website-screenshot/SKILL.md
+++ b/skills/orthogonal-website-screenshot/SKILL.md
@@ -27,7 +27,7 @@ Uses Notte or Brand.dev APIs to capture website screenshots.
 # First start a session, then screenshot
 orth run notte /sessions/start -d '{"url":"https://stripe.com"}'
 # Then take screenshot with the session_id
-orth run notte /sessions/{session_id}/screenshot
+orth run notte /sessions/{session_id}/page/screenshot
 ```
 
 ### Screenshot with Brand.dev (simpler)


### PR DESCRIPTION
## Summary

- **Sync 46 skills** from the database (adds 20 new workflow skills, removes 17 redundant/obsolete skills)
- **Audit and fix all 64 skills** against `orth api show` ground truth — corrects broken API paths, wrong parameter names, and incorrect body keys across 10 SKILL.md files

### Fixes applied

| File | Issues Fixed |
|------|-------------|
| `orthogonal-verify-email` | tomba `/email-verifier` → `/v1/email-verifier` |
| `orthogonal-find-email-by-name` | tomba `/email-finder` → `/v1/email-finder`, `/linkedin` → `/v1/linkedin` |
| `orthogonal-extract-webpage-data` | olostep paths + params, scrapegraph params, riveter path |
| `orthogonal-website-screenshot` | notte `/sessions/{id}/screenshot` → `/sessions/{id}/page/screenshot` |
| `orthogonal-send-text-message` | textbelt `<textId>` → `{textId}` |
| `orthogonal-shofo` | 11 wrong query param names (Instagram, LinkedIn, X/Twitter, TikTok) |
| `orthogonal-instagram-scraper` | `hashtag=` → `keyword=`, `post_url=` → `media_id=` |
| `orthogonal-tiktok-search` | Migrated from broken searchapi engines to shofo API |
| `orthogonal-image-analyzer` | Fixed riveter `/v1/run` body structure |
| `orthogonal-vhs-terminal-recordings` | Fixed olostep path in demo tape |

## Test plan

- [x] `bash test-endpoints.sh` — 96/101 canonical endpoints pass (5 false positives: data-not-found 404s from hunter and riveter)
- [x] Runtime tested workflow skill commands
- [ ] Manual spot-check of hunter `/v2/people/find`, `/v2/combined/find` and riveter `/v1/run_status`, `/v1/run_data`, `/v1/stop_run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)