### PR TITLE
Add 20 new skills from skills.sh & awesome-openclaw-skills

### DIFF
--- a/skills/orthogonal-agentmail/SKILL.md
+++ b/skills/orthogonal-agentmail/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: agentmail
+description: Email platform for AI agents - create inboxes, send/receive emails programmatically
+---
+
+# AgentMail
+
+API-first email platform designed for AI agents. Create dedicated email inboxes, send and receive emails, handle webhooks.
+
+## When to Use
+
+- Agent needs its own email address
+- User wants programmatic email send/receive
+- User needs email-based workflow automation
+- User wants webhook-triggered email processing
+
+## How It Works
+
+Uses the AgentMail API to create and manage email inboxes, send/receive messages, and handle real-time events.
+
+## Source
+
+Based on [adboio/agentmail](https://www.clawhub.com/adboio/agentmail) (708 installs)
+
+## Key Features
+
+- Create dedicated email inboxes for agents
+- Send and receive emails programmatically
+- Webhook support for real-time events
+- Thread and conversation management
+- Attachment handling

--- a/skills/orthogonal-asana/SKILL.md
+++ b/skills/orthogonal-asana/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: asana
+description: Manage Asana tasks, projects, and workspaces
+---
+
+# Asana Project Management
+
+List, search, create, and update tasks and projects in Asana.
+
+## When to Use
+
+- User wants to manage Asana tasks
+- User needs to search their Asana workspace
+- User asks to create or update projects
+- User wants task status updates from Asana
+
+## How It Works
+
+Uses the Asana REST API for full workspace, project, and task management.
+
+## Source
+
+Based on [k0nkupa/asana](https://www.clawhub.com/k0nkupa/asana) (97 installs)
+
+## Key Features
+
+- Task creation, updating, and completion
+- Project and workspace management
+- Search across workspace
+- Section and subtask support
+- OAuth authentication

--- a/skills/orthogonal-clickup/SKILL.md
+++ b/skills/orthogonal-clickup/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: clickup
+description: Manage ClickUp tasks, docs, time tracking, and projects
+---
+
+# ClickUp Project Management
+
+Manage tasks, documents, time tracking, comments, and search in ClickUp.
+
+## When to Use
+
+- User wants to manage ClickUp tasks or projects
+- User needs to track time or add comments
+- User asks to search ClickUp workspace
+- User wants to create or update documents in ClickUp
+
+## How It Works
+
+Uses the ClickUp API (via MCP) for full workspace management.
+
+## Source
+
+Based on [pvoo/clickup-mcp](https://www.clawhub.com/pvoo/clickup-mcp) (179 installs)
+
+## Key Features
+
+- Task CRUD with custom fields
+- Document management
+- Time tracking
+- Comments and chat
+- Workspace search
+- OAuth authentication

--- a/skills/orthogonal-context7/SKILL.md
+++ b/skills/orthogonal-context7/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: context7
+description: Fetch up-to-date library documentation for any framework or package
+---
+
+# Context7 Documentation Search
+
+Intelligent documentation search for any programming library. Get up-to-date docs, examples, and API references.
+
+## When to Use
+
+- Working with any external library (React, Next.js, Supabase, etc.)
+- User asks about library APIs or patterns
+- Need current documentation (not training data)
+- Looking for code examples or best practices
+
+## How It Works
+
+Uses the Context7 API to fetch and search documentation for any library or framework, providing current and accurate information.
+
+## Source
+
+Based on [TheSethRose/context7](https://www.clawhub.com/TheSethRose/context7) (451 installs)
+
+## Key Features
+
+- Search documentation for any library
+- Up-to-date API references
+- Code examples and patterns
+- Version-aware results
+- Semantic search across docs

--- a/skills/orthogonal-docx/SKILL.md
+++ b/skills/orthogonal-docx/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: docx
+description: Create, edit, and analyze Word documents (.docx)
+---
+
+# Word Document Builder
+
+Create and edit Word documents programmatically.
+
+## When to Use
+
+- User wants to create a Word document
+- User needs to edit an existing .docx file
+- User asks to generate reports, proposals, or formal documents
+- User needs document format conversion
+
+## How It Works
+
+Uses `docx` npm package for creation and `pandoc` for reading/conversion. Supports styles, headers, footers, tables, images, and tracked changes.
+
+## Source
+
+Based on [anthropics/skills/docx](https://skills.sh/anthropics/skills/docx) (12.1K+ installs)
+
+## Setup
+
+```bash
+npm install -g docx
+# pandoc for reading
+brew install pandoc
+```
+
+## Usage
+
+### Read Existing Document
+```bash
+pandoc --track-changes=all document.docx -o output.md
+```
+
+### Create New Document
+Use the `docx` npm package - supports headings, lists, tables, images, headers/footers, page numbers, and table of contents.
+
+## Key Features
+
+- Create professional documents with custom styles
+- Read and extract content from .docx files
+- Support for tracked changes
+- Tables, images, headers, footers, page numbers
+- Convert between formats (doc → docx, docx → pdf)

--- a/skills/orthogonal-edge-tts/SKILL.md
+++ b/skills/orthogonal-edge-tts/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: edge-tts
+description: Free text-to-speech with 300+ voices in 70+ languages (Microsoft Edge TTS)
+---
+
+# Edge Text-to-Speech
+
+Convert text to speech using Microsoft Edge's TTS engine. 300+ voices, 70+ languages, completely free.
+
+## When to Use
+
+- User wants text-to-speech without API costs
+- User needs multi-language voice generation
+- User wants to generate audio from text content
+- User needs subtitle/caption generation alongside audio
+
+## How It Works
+
+Uses the `node-edge-tts` npm package to access Microsoft Edge's TTS engine.
+
+## Source
+
+Based on [i3130002/edge-tts](https://www.clawhub.com/i3130002/edge-tts) (249 installs)
+
+## Setup
+
+```bash
+npm install -g node-edge-tts
+```
+
+## Key Features
+
+- 300+ voices across 70+ languages
+- Speed and pitch adjustment
+- Subtitle/caption generation
+- No API key required (free)
+- High-quality neural voices

--- a/skills/orthogonal-event-planner/SKILL.md
+++ b/skills/orthogonal-event-planner/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: event-planner
+description: Plan events by searching venues, restaurants, and activities via Google Places
+---
+
+# Event Planner
+
+Plan events (dinners, date nights, team outings, trips) by searching venues via Google Places API.
+
+## When to Use
+
+- User wants to plan a night out or event
+- User asks for venue recommendations
+- User needs restaurant, bar, or activity suggestions
+- User wants to plan based on location, budget, and group size
+
+## How It Works
+
+Uses Google Places API to search and rank venues based on location, ratings, budget, and party size.
+
+## Source
+
+Based on [udiedrichsen/event-planner](https://www.clawhub.com/udiedrichsen/event-planner) (122 installs)
+
+## Key Features
+
+- Venue search by location and type
+- Budget-aware recommendations
+- Group size consideration
+- Rating and review integration
+- Multi-stop event planning (dinner → drinks → activity)

--- a/skills/orthogonal-firecrawl/SKILL.md
+++ b/skills/orthogonal-firecrawl/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: firecrawl
+description: Crawl and scrape websites with AI-powered extraction
+---
+
+# Firecrawl Web Crawler
+
+Crawl entire websites and extract structured data using Firecrawl's API.
+
+## When to Use
+
+- User needs to crawl an entire website (not just one page)
+- User wants structured data extraction from web pages
+- User needs to scrape multiple pages with consistent format
+- User asks to index or map a website
+
+## How It Works
+
+Uses the Firecrawl API for intelligent web crawling with automatic JavaScript rendering, content extraction, and structured output.
+
+## Source
+
+Based on [firecrawl/cli](https://skills.sh/firecrawl/cli/firecrawl) (3.8K+ installs)
+
+## Usage
+
+```bash
+orth run firecrawl /v1/scrape -d '{"url": "https://example.com"}'
+```
+
+## Key Features
+
+- Full website crawling with depth control
+- JavaScript rendering
+- Markdown and structured data output
+- Sitemap generation
+- Rate limiting and politeness controls

--- a/skills/orthogonal-ga4-analytics/SKILL.md
+++ b/skills/orthogonal-ga4-analytics/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: ga4-analytics
+description: Google Analytics 4 data - traffic, page performance, demographics, real-time visitors
+---
+
+# Google Analytics 4
+
+Query website traffic, page performance, user demographics, and real-time visitor data from GA4.
+
+## When to Use
+
+- User wants to check website traffic or analytics
+- User asks about page performance, bounce rates, or conversions
+- User needs demographic or geographic visitor data
+- User wants real-time visitor counts
+
+## How It Works
+
+Uses the Google Analytics Data API (GA4) to query analytics properties.
+
+## Source
+
+Based on [adamkristopher/ga4-analytics](https://www.clawhub.com/adamkristopher/ga4-analytics) (235 installs)
+
+## Key Features
+
+- Traffic overview (sessions, users, pageviews)
+- Page-level performance metrics
+- User demographics and geography
+- Real-time active users
+- Custom date ranges and segments
+- Conversion tracking

--- a/skills/orthogonal-gemini-deep-research/SKILL.md
+++ b/skills/orthogonal-gemini-deep-research/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: gemini-deep-research
+description: Deep research tasks using Gemini's research agent for multi-source synthesis
+---
+
+# Gemini Deep Research
+
+Perform complex, long-running research tasks using Google's Gemini Deep Research agent.
+
+## When to Use
+
+- User needs comprehensive research on a topic
+- User asks for competitive analysis or market research
+- User wants multi-source synthesis and citations
+- Research requires long-running, multi-step investigation
+
+## How It Works
+
+Uses the Gemini Deep Research API for autonomous research with planning, decomposition, and cross-source synthesis.
+
+## Source
+
+Based on [arun-8687/gemini-deep-research](https://www.clawhub.com/arun-8687/gemini-deep-research) (668 installs)
+
+## Key Features
+
+- Multi-step research planning
+- Cross-source synthesis
+- Citation tracking
+- Comprehensive reports
+- Competitive and market analysis

--- a/skills/orthogonal-google-search-console/SKILL.md
+++ b/skills/orthogonal-google-search-console/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: google-search-console
+description: SEO data from Google Search Console - queries, CTR, impressions, indexing
+---
+
+# Google Search Console
+
+Query Google Search Console for SEO performance data, search queries, click-through rates, and indexing status.
+
+## When to Use
+
+- User wants to check search performance or SEO metrics
+- User asks about top search queries or pages
+- User needs CTR optimization opportunities
+- User wants to check URL indexing status or submit sitemaps
+
+## How It Works
+
+Uses the Google Search Console API to retrieve search analytics, URL inspection, and sitemap data.
+
+## Source
+
+Based on [jdrhyne/gsc](https://www.clawhub.com/jdrhyne/gsc) (405 installs)
+
+## Key Features
+
+- Search query performance (clicks, impressions, CTR, position)
+- Top pages analysis
+- CTR opportunity identification
+- URL inspection and indexing status
+- Sitemap management

--- a/skills/orthogonal-n8n/SKILL.md
+++ b/skills/orthogonal-n8n/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: n8n
+description: Manage n8n workflow automations - create, trigger, and monitor workflows
+---
+
+# n8n Workflow Automation
+
+Manage n8n workflows and automations via API. List, activate, trigger, and monitor workflows.
+
+## When to Use
+
+- User wants to manage n8n workflows
+- User needs to trigger an automation
+- User asks to check workflow execution status
+- User wants to create or modify automations
+
+## How It Works
+
+Uses the n8n REST API to manage workflows, executions, and credentials.
+
+## Source
+
+Based on [thomasansems/n8n](https://www.clawhub.com/thomasansems/n8n) (573 installs)
+
+## Key Features
+
+- List and search workflows
+- Activate/deactivate workflows
+- Trigger manual executions
+- Check execution history and status
+- Workflow creation and editing

--- a/skills/orthogonal-obsidian-daily/SKILL.md
+++ b/skills/orthogonal-obsidian-daily/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: obsidian-daily
+description: Manage Obsidian daily notes, journal entries, and vault content
+---
+
+# Obsidian Daily Notes
+
+Create and manage Obsidian daily notes, append journal entries, and search vault content.
+
+## When to Use
+
+- User wants to add to their daily note
+- User asks to journal or log something
+- User needs to search their Obsidian vault
+- User wants to read past daily notes
+
+## How It Works
+
+Uses `obsidian-cli` to interact with Obsidian vaults - create notes, append entries, and search content.
+
+## Source
+
+Based on [bastos/obsidian-daily](https://www.clawhub.com/bastos/obsidian-daily) (281 installs)
+
+## Key Features
+
+- Create and open daily notes
+- Append entries (journals, logs, tasks, links)
+- Read past notes by date
+- Search vault content
+- Relative date handling ("yesterday", "last Monday")

--- a/skills/orthogonal-postiz/SKILL.md
+++ b/skills/orthogonal-postiz/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: postiz
+description: Schedule social media posts to 28+ platforms (X, LinkedIn, Instagram, TikTok, etc.)
+---
+
+# Postiz Social Scheduler
+
+Schedule and manage social media posts across 28+ platforms from a single interface.
+
+## When to Use
+
+- User wants to schedule posts across multiple social platforms
+- User needs to manage a content calendar
+- User asks to post to X, LinkedIn, Instagram, Facebook, TikTok, YouTube, Pinterest, Reddit, Threads, Bluesky, etc.
+
+## How It Works
+
+Uses the Postiz API for multi-platform social media scheduling and management.
+
+## Source
+
+Based on [nevo-david/postiz](https://www.clawhub.com/nevo-david/postiz) (254 installs)
+
+## Supported Platforms
+
+X, LinkedIn, LinkedIn Page, Reddit, Instagram, Facebook Page, Threads, YouTube, Google My Business, TikTok, Pinterest, Dribbble, Bluesky, Mastodon, and more.
+
+## Key Features
+
+- Post scheduling with timezone support
+- Multi-platform publishing from single content
+- Content calendar management
+- Analytics and engagement tracking
+- Media upload support

--- a/skills/orthogonal-pptx/SKILL.md
+++ b/skills/orthogonal-pptx/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: pptx
+description: Create, edit, and analyze PowerPoint presentations (.pptx)
+---
+
+# PowerPoint Presentation Builder
+
+Create professional PowerPoint presentations from scratch or edit existing ones.
+
+## When to Use
+
+- User wants to create a slide deck or presentation
+- User needs to edit an existing .pptx file
+- User asks to convert content into slides
+- User needs presentation design help
+
+## How It Works
+
+Uses `pptxgenjs` (npm) for creation and `markitdown` (Python) for reading existing presentations. Supports templates, custom themes, charts, images, and professional layouts.
+
+## Source
+
+Based on [anthropics/skills/pptx](https://skills.sh/anthropics/skills/pptx) (13K+ installs)
+
+## Setup
+
+```bash
+npm install -g pptxgenjs
+pip install markitdown
+```
+
+## Usage
+
+### Read Existing Presentation
+```bash
+python -m markitdown presentation.pptx
+```
+
+### Create New Presentation
+Use pptxgenjs via Node.js script - see source skill for full creation guide including color palettes, typography, and layout patterns.
+
+## Key Features
+
+- Read/analyze existing .pptx files
+- Create from scratch with professional themes
+- Edit existing presentations (unpack → modify → repack)
+- Support for charts, images, tables, and custom layouts
+- Design-focused with color palette and typography guidance

--- a/skills/orthogonal-todoist/SKILL.md
+++ b/skills/orthogonal-todoist/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: todoist
+description: Manage tasks, projects, and to-dos in Todoist
+---
+
+# Todoist Task Manager
+
+Create, manage, and track tasks and projects in Todoist.
+
+## When to Use
+
+- User wants to add or manage tasks
+- User asks about their to-do list
+- User needs project management in Todoist
+- User wants to organize tasks with priorities and due dates
+
+## How It Works
+
+Uses the Todoist REST API for full task and project management.
+
+## Source
+
+Based on [mjrussell/todoist](https://www.clawhub.com/mjrussell/todoist) (1.1K+ installs)
+
+## Key Features
+
+- Create, update, and complete tasks
+- Project and section management
+- Priority levels and due dates
+- Labels and filters
+- Comments and attachments
+- Recurring tasks

--- a/skills/orthogonal-typefully/SKILL.md
+++ b/skills/orthogonal-typefully/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: typefully
+description: Schedule posts to X, LinkedIn, Mastodon, Threads, and Bluesky via Typefully
+---
+
+# Typefully Social Publisher
+
+Create drafts and schedule posts across X, LinkedIn, Mastodon, Threads, and Bluesky.
+
+## When to Use
+
+- User wants to draft and schedule social media posts
+- User needs to manage X/Twitter threads
+- User asks to schedule LinkedIn or Bluesky posts
+
+## How It Works
+
+Uses the Typefully API for content creation, scheduling, and cross-platform publishing.
+
+## Source
+
+Based on [TheSethRose/typefully](https://www.clawhub.com/TheSethRose/typefully) (232 installs)
+
+## Key Features
+
+- Draft creation and editing
+- Post scheduling with optimal timing
+- Thread support for X/Twitter
+- Cross-platform publishing
+- Content performance analytics

--- a/skills/orthogonal-web-perf/SKILL.md
+++ b/skills/orthogonal-web-perf/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: web-perf
+description: Analyze website performance - Core Web Vitals, render blocking, speed metrics
+---
+
+# Web Performance Analyzer
+
+Measure Core Web Vitals and identify performance bottlenecks for any website.
+
+## When to Use
+
+- User wants to check website speed/performance
+- User asks about Core Web Vitals (LCP, CLS, FCP)
+- User needs to identify render-blocking resources
+- User wants performance optimization recommendations
+
+## How It Works
+
+Uses Chrome DevTools Protocol to measure real performance metrics including FCP, LCP, TBT, CLS, and Speed Index.
+
+## Source
+
+Based on [elithrar/web-perf](https://www.clawhub.com/elithrar/web-perf) (183 installs)
+
+## Key Features
+
+- Core Web Vitals (FCP, LCP, TBT, CLS, Speed Index)
+- Render-blocking resource detection
+- Network dependency chain analysis
+- Layout shift identification
+- Caching audit
+- Actionable optimization recommendations

--- a/skills/orthogonal-website-audit/SKILL.md
+++ b/skills/orthogonal-website-audit/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: website-audit
+description: Security, accessibility, and performance audit for websites
+---
+
+# Website Audit
+
+Comprehensive website audit covering security, accessibility, SEO, and performance.
+
+## When to Use
+
+- User wants a full website audit
+- User asks about security vulnerabilities
+- User needs accessibility (WCAG) compliance check
+- User wants combined SEO + performance + security review
+
+## How It Works
+
+Runs automated checks against a website covering security headers, SSL, accessibility, performance metrics, and SEO best practices.
+
+## Source
+
+Based on [squirrelscan/skills/audit-website](https://skills.sh/squirrelscan/skills/audit-website) (21.3K+ installs)
+
+## Key Features
+
+- Security header analysis
+- SSL/TLS configuration check
+- WCAG accessibility audit
+- Performance metrics
+- SEO best practices verification
+- Actionable remediation steps

--- a/skills/orthogonal-xlsx/SKILL.md
+++ b/skills/orthogonal-xlsx/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: xlsx
+description: Create, read, and manipulate Excel spreadsheets (.xlsx)
+---
+
+# Excel Spreadsheet Handler
+
+Read, write, and manipulate Excel files programmatically.
+
+## When to Use
+
+- User wants to create or edit a spreadsheet
+- User needs data analysis from Excel files
+- User asks to generate reports in Excel format
+- User needs CSV/JSON to Excel conversion
+
+## How It Works
+
+Uses `exceljs` or `xlsx` npm packages for full spreadsheet manipulation including formulas, charts, formatting, and multiple sheets.
+
+## Source
+
+Based on [anthropics/skills/xlsx](https://skills.sh/anthropics/skills/xlsx) (11.9K+ installs)
+
+## Setup
+
+```bash
+npm install -g exceljs
+```
+
+## Key Features
+
+- Read and write .xlsx files
+- Formula support
+- Cell formatting (colors, fonts, borders)
+- Charts and data visualization
+- Multiple worksheets
+- CSV/JSON import/export


### PR DESCRIPTION
## New Skills to Add

Sourced from [skills.sh](https://skills.sh) and [awesome-openclaw-skills](https://github.com/sundial-org/awesome-openclaw-skills). All are popular skills that fill gaps in our current catalog.

### Document Creation
1. **pptx** - PowerPoint presentations (13K+ installs on skills.sh)
2. **docx** - Word documents (12.1K+)
3. **xlsx** - Excel spreadsheets (11.9K+)

### Web & SEO
4. **firecrawl** - AI web crawling/scraping (3.8K+)
5. **web-perf** - Core Web Vitals analysis (183)
6. **website-audit** - Security/accessibility/SEO audit (21.3K+)
7. **google-search-console** - SEO data (405)
8. **ga4-analytics** - Google Analytics 4 (235)

### Social Media
9. **postiz** - Schedule to 28+ platforms (254)
10. **typefully** - X/LinkedIn/Bluesky scheduling (232)

### Productivity
11. **todoist** - Task management (1.1K+)
12. **clickup** - Project management (179)
13. **asana** - Project management (97)
14. **n8n** - Workflow automation (573)
15. **obsidian-daily** - Knowledge base notes (281)

### AI & Research
16. **gemini-deep-research** - Deep research agent (668)
17. **context7** - Library documentation search (451)
18. **agentmail** - Email for AI agents (708)

### Utilities
19. **edge-tts** - Free TTS, 300+ voices, 70+ languages (249)
20. **event-planner** - Venue search via Google Places (122)

Currently stubs - each needs full implementation with Orthogonal API integration.