### PR TITLE
docs: fix find-skill to use full namespaced slugs

### DIFF
--- a/skills/orthogonal-find-skill/SKILL.md
+++ b/skills/orthogonal-find-skill/SKILL.md
@@ -64,12 +64,12 @@ Skills use a namespaced slug format: `owner/skill-name` (e.g. `orthogonal/find-s
 orth skills add orthogonal/restaurant-booking
 
 # Install and view the skill file
-orth skills add orthogonal/weather && cat ~/.openclaw/skills/orthogonal-weather/SKILL.md
+orth skills add orthogonal/weather && cat <your-skills-directory>/orthogonal-weather/SKILL.md
 ```
 
 > **Note:** The CLI expects the full slug with namespace prefix (e.g. `orthogonal/find-skill`), not just the short name.
 
-Skills are installed to `~/.openclaw/skills/<slug>/` and `.agent/skills/<slug>/` (project-local).
+Skills are installed to your agent's skills directory (e.g. `~/.openclaw/skills/`, `~/.claude/skills/`, `.agent/skills/`, or wherever your agent reads skill files).
 
 ## Using Installed Skills
 
@@ -82,7 +82,7 @@ After installing, the skill's `SKILL.md` contains:
 Read the skill file to understand how to use it:
 
 ```bash
-cat ~/.openclaw/skills/<slug>/SKILL.md
+cat <your-skills-directory>/<slug>/SKILL.md
 ```
 
 ## Tips

--- a/skills/orthogonal-find-skill/SKILL.md
+++ b/skills/orthogonal-find-skill/SKILL.md
@@ -21,10 +21,10 @@ orth skills search "browser automation"
 orth skills list
 
 # Get details about a specific skill
-orth skills info <slug>
+orth skills show <owner/slug>
 
-# Install a skill
-orth skills add <slug>
+# Install a skill (use full slug with namespace)
+orth skills add <owner/slug>
 ```
 
 ## Finding Skills
@@ -57,15 +57,19 @@ Browse all skills at: https://orthogonal.com/skills
 
 ## Installing Skills
 
+Skills use a namespaced slug format: `owner/skill-name` (e.g. `orthogonal/find-skill`).
+
 ```bash
-# Install by slug
-orth skills add restaurant-booking
+# Install by full slug (namespace/name)
+orth skills add orthogonal/restaurant-booking
 
 # Install and view the skill file
-orth skills add weather && cat ~/.openclaw/skills/weather/SKILL.md
+orth skills add orthogonal/weather && cat ~/.openclaw/skills/orthogonal-weather/SKILL.md
 ```
 
-Skills are installed to `~/.openclaw/skills/<slug>/`
+> **Note:** The CLI expects the full slug with namespace prefix (e.g. `orthogonal/find-skill`), not just the short name.
+
+Skills are installed to `~/.openclaw/skills/<slug>/` and `.agent/skills/<slug>/` (project-local).
 
 ## Using Installed Skills
 
@@ -86,12 +90,11 @@ cat ~/.openclaw/skills/<slug>/SKILL.md
 | Skill | Description |
 |-------|-------------|
 | `weather` | Get weather forecasts |
-| `weather-forecast` | Precipitation and temperature data via Precip API |
 | `restaurant-booking` | Book restaurant reservations via Notte |
+| `gog` | Google Workspace (Gmail, Calendar, Drive) |
+| `github` | GitHub CLI for issues, PRs, repos |
+| `web-search` | Search the web |
 | `company-intel` | Research companies |
-| `person-lookup` | Look up professional backgrounds |
-| `verify-email` | Check if an email is valid and deliverable |
-| `extract-webpage-data` | AI-powered web scraping |
 
 ## Tips
 

--- a/skills/orthogonal-find-skill/SKILL.md
+++ b/skills/orthogonal-find-skill/SKILL.md
@@ -85,17 +85,6 @@ Read the skill file to understand how to use it:
 cat ~/.openclaw/skills/<slug>/SKILL.md
 ```
 
-## Popular Skills
-
-| Skill | Description |
-|-------|-------------|
-| `weather` | Get weather forecasts |
-| `restaurant-booking` | Book restaurant reservations via Notte |
-| `gog` | Google Workspace (Gmail, Calendar, Drive) |
-| `github` | GitHub CLI for issues, PRs, repos |
-| `web-search` | Search the web |
-| `company-intel` | Research companies |
-
 ## Tips
 
 - Search is semantic - describe what you want to do


### PR DESCRIPTION
The CLI expects `owner/slug` format (e.g. `orthogonal/find-skill`), not just the short name like `find-skill`. Updated examples and added a note about the namespace prefix requirement.