### PR TITLE
feat: add team-linkedin-profiles skill

### DIFF
--- a/skills/orthogonal-team-linkedin-profiles/SKILL.md
+++ b/skills/orthogonal-team-linkedin-profiles/SKILL.md
@@ -45,7 +45,7 @@ orth run exa /search --body '{
 }'
 ```
 
-Use `numResults: 50` by default — best balance of coverage vs context window size (~30K tokens). Each Exa result averages ~600-800 tokens of structured data, so 100 results would consume ~70K tokens and roughly half tend to be noise (wrong companies). If the user explicitly wants exhaustive results, bump to 100 (max). Exa costs 1 cent per request on Orthogonal regardless of numResults.
+Use `numResults: 50` by default — best balance of coverage vs context window size (~31K tokens). Each Exa result averages ~800 tokens of structured data, so 100 results would consume ~81K tokens and roughly half tend to be noise (wrong companies). If the user explicitly wants exhaustive results, bump to 100 (max). Exa costs 1 cent per request on Orthogonal regardless of numResults.
 
 Try multiple query variations if results are sparse:
 - `"{company} {team} team"`
@@ -113,7 +113,7 @@ This returns full work history, education, skills, and recent activity. Run thes
 - **Add industry context** to all search queries — "Mercury fintech" finds the right Mercury much more reliably than just "Mercury"
 - **Expand title keywords** — Teams use varied titles. "Data team" could include data scientist, data engineer, analytics engineer, ML engineer, data analyst
 - **Exa vs Hunter** — Exa finds the most team members with best structured data. Hunter surfaces senior/executive people and provides email addresses. Use both in parallel for best coverage
-- **Context window** — Each Exa result averages ~700 tokens. 50 results ≈ 30K tokens, 100 results ≈ 70K tokens. Default to 50; only go to 100 if the user wants exhaustive results
+- **Context window** — Each Exa result averages ~800 tokens. 50 results ≈ 31K tokens, 100 results ≈ 81K tokens. Default to 50; only go to 100 if the user wants exhaustive results
 - **Handle pagination** — If Exa returns exactly `numResults`, there are likely more. Bump to 100 or run follow-up queries with different title keywords
 - **Small teams** — For niche teams (e.g., "fraud" at a 200-person startup), expect 3-8 results. This is normal
 - **Large teams** — For broad teams (e.g., "engineering" at a 5,000-person company), suggest the user narrow by sub-team or seniority

--- a/skills/orthogonal-team-linkedin-profiles/SKILL.md
+++ b/skills/orthogonal-team-linkedin-profiles/SKILL.md
@@ -40,12 +40,12 @@ Run both searches **in parallel**:
 orth run exa /search --body '{
   "query": "{company context string} {team} team members",
   "category": "people",
-  "numResults": 25,
+  "numResults": 50,
   "includeDomains": ["linkedin.com"]
 }'
 ```
 
-Use `numResults: 25` by default (cheap tier: $0.005/request). If the user wants comprehensive results or Exa returns exactly 25 (likely more exist), bump to 50-100 (same $0.025/request cost tier for 26-100).
+Use `numResults: 50` by default — best balance of coverage vs context window size (~53K tokens). Each Exa result includes full structured data (~1K tokens each), so 100 results would consume ~106K tokens and half tend to be noise (wrong companies). If the user explicitly wants exhaustive results, bump to 100 (max). Exa costs 1 cent per request on Orthogonal regardless of numResults.
 
 Try multiple query variations if results are sparse:
 - `"{company} {team} team"`
@@ -113,8 +113,8 @@ This returns full work history, education, skills, and recent activity. Run thes
 - **Add industry context** to all search queries — "Mercury fintech" finds the right Mercury much more reliably than just "Mercury"
 - **Expand title keywords** — Teams use varied titles. "Data team" could include data scientist, data engineer, analytics engineer, ML engineer, data analyst
 - **Exa vs Hunter** — Exa finds the most team members with best structured data. Hunter surfaces senior/executive people and provides email addresses. Use both in parallel for best coverage
-- **Exa cost tiers** — 1-25 results: $0.005/request. 26-100 results: $0.025/request (5x jump). Stay at 25 unless the user needs comprehensive results
-- **Handle pagination** — If Exa returns exactly `numResults`, there are likely more. Bump to 50-100 (same cost tier once past 25) or run follow-up queries with different title keywords
+- **Context window** — Each Exa result is ~1K tokens. 50 results ≈ 53K tokens, 100 results ≈ 106K tokens. Default to 50; only go to 100 if the user wants exhaustive results
+- **Handle pagination** — If Exa returns exactly `numResults`, there are likely more. Bump to 100 or run follow-up queries with different title keywords
 - **Small teams** — For niche teams (e.g., "fraud" at a 200-person startup), expect 3-8 results. This is normal
 - **Large teams** — For broad teams (e.g., "engineering" at a 5,000-person company), suggest the user narrow by sub-team or seniority
 - **Abbreviated names** — Some Exa results show partial names like "Joey G." or "Oneida D." These are real profiles with restricted LinkedIn visibility, not errors. Include them in results with the name as-is

--- a/skills/orthogonal-team-linkedin-profiles/SKILL.md
+++ b/skills/orthogonal-team-linkedin-profiles/SKILL.md
@@ -45,7 +45,7 @@ orth run exa /search --body '{
 }'
 ```
 
-Use `numResults: 50` by default — best balance of coverage vs context window size (~53K tokens). Each Exa result includes full structured data (~1K tokens each), so 100 results would consume ~106K tokens and half tend to be noise (wrong companies). If the user explicitly wants exhaustive results, bump to 100 (max). Exa costs 1 cent per request on Orthogonal regardless of numResults.
+Use `numResults: 50` by default — best balance of coverage vs context window size (~30K tokens). Each Exa result averages ~600-800 tokens of structured data, so 100 results would consume ~70K tokens and roughly half tend to be noise (wrong companies). If the user explicitly wants exhaustive results, bump to 100 (max). Exa costs 1 cent per request on Orthogonal regardless of numResults.
 
 Try multiple query variations if results are sparse:
 - `"{company} {team} team"`
@@ -113,7 +113,7 @@ This returns full work history, education, skills, and recent activity. Run thes
 - **Add industry context** to all search queries — "Mercury fintech" finds the right Mercury much more reliably than just "Mercury"
 - **Expand title keywords** — Teams use varied titles. "Data team" could include data scientist, data engineer, analytics engineer, ML engineer, data analyst
 - **Exa vs Hunter** — Exa finds the most team members with best structured data. Hunter surfaces senior/executive people and provides email addresses. Use both in parallel for best coverage
-- **Context window** — Each Exa result is ~1K tokens. 50 results ≈ 53K tokens, 100 results ≈ 106K tokens. Default to 50; only go to 100 if the user wants exhaustive results
+- **Context window** — Each Exa result averages ~700 tokens. 50 results ≈ 30K tokens, 100 results ≈ 70K tokens. Default to 50; only go to 100 if the user wants exhaustive results
 - **Handle pagination** — If Exa returns exactly `numResults`, there are likely more. Bump to 100 or run follow-up queries with different title keywords
 - **Small teams** — For niche teams (e.g., "fraud" at a 200-person startup), expect 3-8 results. This is normal
 - **Large teams** — For broad teams (e.g., "engineering" at a 5,000-person company), suggest the user narrow by sub-team or seniority

--- a/skills/orthogonal-team-linkedin-profiles/SKILL.md
+++ b/skills/orthogonal-team-linkedin-profiles/SKILL.md
@@ -33,30 +33,32 @@ orth run brand-dev /v1/brand/retrieve --query 'domain=mercury.com'
 
 ### 3. Search for Team Members
 
-Run both searches **in parallel** for maximum coverage:
-
 **Primary — Exa people search** (best precision, returns LinkedIn URLs + structured data):
 ```bash
 orth run exa /search --body '{
   "query": "{company context string} {team} team members",
   "category": "people",
-  "numResults": 20,
+  "numResults": 50,
   "includeDomains": ["linkedin.com"]
 }'
 ```
+
+Use `numResults: 50` as the default. If the user specifies a count, use that instead. If Exa returns exactly `numResults`, there are likely more — bump to 100 or run a follow-up with different query phrasing.
 
 Try multiple query variations if results are sparse:
 - `"{company} {team} team"`
 - `"{team} at {company} {industry}"`
 - `"{team} analyst OR engineer OR manager at {company}"`
 
-**Supplement — Fiber NL profile search** (broader coverage, different data source):
+**Fallback — Fiber NL profile search** (only if Exa is rate-limited or returns very few results):
 ```bash
 orth run fiber /v1/natural-language-search/profiles --body '{
   "query": "{team} team at {company} {industry context}",
-  "pageSize": 20
+  "pageSize": 25
 }'
 ```
+
+Note: Fiber NL search often returns generic role matches (e.g., fraud analysts globally) rather than company-specific results. It does not reliably filter by company. Use it only as a fallback, and always verify each Fiber result's current employer in Step 4.
 
 ### 4. Filter & Deduplicate
 
@@ -71,7 +73,7 @@ This step is critical for accuracy:
    - "Engineering" team → software engineer, SWE, developer, engineering manager
    - "Sales" team → account executive, SDR, BDR, sales manager, revenue
 
-3. **Deduplicate** — Merge results from Exa and Fiber by LinkedIn URL. Prefer Exa data when both sources have the same person (richer structured data).
+3. **Deduplicate** — If using both Exa and Fiber, merge by LinkedIn URL. Prefer Exa data (richer structured data).
 
 4. **Flag uncertain matches** — If a person's company match is ambiguous, include them in the results but flag with a note (e.g., "Could not confirm current employer — verify manually").
 
@@ -95,7 +97,7 @@ Found {N} members:
 | ... | ... | ... | ... |
 ```
 
-Include a note about coverage: "These are publicly discoverable profiles. Team members with private LinkedIn profiles or no LinkedIn presence won't appear."
+Include a note about coverage: "Some profiles may show abbreviated names (e.g., 'Oneida D.') — these are LinkedIn members with restricted visibility settings. Team members with no LinkedIn presence won't appear."
 
 ### 6. Optional Deep Enrichment
 
@@ -111,8 +113,9 @@ This returns full work history, education, skills, and recent activity. Run thes
 
 - **Add industry context** to all search queries — "Mercury fintech" finds the right Mercury much more reliably than just "Mercury"
 - **Expand title keywords** — Teams use varied titles. "Data team" could include data scientist, data engineer, analytics engineer, ML engineer, data analyst
-- **Handle pagination** — If Exa returns exactly `numResults`, there may be more. Increase `numResults` or run follow-up queries with different title keywords
-- **Rate limits** — If Exa rate-limits, lean on Fiber NL search as fallback. If both are limited, try Exa with `type: "keyword"` or different query phrasing
+- **Exa is the workhorse** — Fiber NL search doesn't reliably filter by company. Rely on Exa for primary results; only try Fiber if Exa is rate-limited or returns < 5 results
+- **Handle pagination** — If Exa returns exactly `numResults`, there are likely more. Bump to 100 or run follow-up queries with different title keywords
+- **Rate limits** — If Exa rate-limits, try again with `type: "keyword"` or different query phrasing before falling back to Fiber
 - **Small teams** — For niche teams (e.g., "fraud" at a 200-person startup), expect 3-8 results. This is normal
 - **Large teams** — For broad teams (e.g., "engineering" at a 5,000-person company), suggest the user narrow by sub-team or seniority
-- **Private profiles** won't surface in any search — mention this if results seem thin
+- **Abbreviated names** — Some results will show partial names like "Joey G." or "Oneida D." These are real profiles with restricted LinkedIn visibility, not errors. Include them in results with the name as-is

--- a/skills/orthogonal-team-linkedin-profiles/SKILL.md
+++ b/skills/orthogonal-team-linkedin-profiles/SKILL.md
@@ -33,32 +33,31 @@ orth run brand-dev /v1/brand/retrieve --query 'domain=mercury.com'
 
 ### 3. Search for Team Members
 
+Run both searches **in parallel**:
+
 **Primary — Exa people search** (best precision, returns LinkedIn URLs + structured data):
 ```bash
 orth run exa /search --body '{
   "query": "{company context string} {team} team members",
   "category": "people",
-  "numResults": 50,
+  "numResults": 25,
   "includeDomains": ["linkedin.com"]
 }'
 ```
 
-Use `numResults: 50` as the default. If the user specifies a count, use that instead. If Exa returns exactly `numResults`, there are likely more — bump to 100 or run a follow-up with different query phrasing.
+Use `numResults: 25` by default (cheap tier: $0.005/request). If the user wants comprehensive results or Exa returns exactly 25 (likely more exist), bump to 50-100 (same $0.025/request cost tier for 26-100).
 
 Try multiple query variations if results are sparse:
 - `"{company} {team} team"`
 - `"{team} at {company} {industry}"`
 - `"{team} analyst OR engineer OR manager at {company}"`
 
-**Fallback — Fiber NL profile search** (only if Exa is rate-limited or returns very few results):
+**Supplement — Hunter domain search** (surfaces senior/executive people Exa misses):
 ```bash
-orth run fiber /v1/natural-language-search/profiles --body '{
-  "query": "{team} team at {company} {industry context}",
-  "pageSize": 25
-}'
+orth run hunter /v2/domain-search --query 'domain={domain from Step 2}' --query 'limit=100'
 ```
 
-Note: Fiber NL search often returns generic role matches (e.g., fraud analysts globally) rather than company-specific results. It does not reliably filter by company. Use it only as a fallback, and always verify each Fiber result's current employer in Step 4.
+Hunter returns employees with names, titles, emails, and LinkedIn URLs. It has no useful department filter for niche teams (fraud people end up scattered across "management", "executive", "unknown"), so pull all results and filter by title keywords in Step 4. Hunter is especially good at finding senior leadership that Exa may miss.
 
 ### 4. Filter & Deduplicate
 
@@ -73,7 +72,7 @@ This step is critical for accuracy:
    - "Engineering" team → software engineer, SWE, developer, engineering manager
    - "Sales" team → account executive, SDR, BDR, sales manager, revenue
 
-3. **Deduplicate** — If using both Exa and Fiber, merge by LinkedIn URL. Prefer Exa data (richer structured data).
+3. **Deduplicate** — Merge Exa and Hunter results by LinkedIn URL. Prefer Exa data when both have the same person (richer structured data). Hunter may provide email addresses that Exa doesn't.
 
 4. **Flag uncertain matches** — If a person's company match is ambiguous, include them in the results but flag with a note (e.g., "Could not confirm current employer — verify manually").
 
@@ -113,9 +112,9 @@ This returns full work history, education, skills, and recent activity. Run thes
 
 - **Add industry context** to all search queries — "Mercury fintech" finds the right Mercury much more reliably than just "Mercury"
 - **Expand title keywords** — Teams use varied titles. "Data team" could include data scientist, data engineer, analytics engineer, ML engineer, data analyst
-- **Exa is the workhorse** — Fiber NL search doesn't reliably filter by company. Rely on Exa for primary results; only try Fiber if Exa is rate-limited or returns < 5 results
-- **Handle pagination** — If Exa returns exactly `numResults`, there are likely more. Bump to 100 or run follow-up queries with different title keywords
-- **Rate limits** — If Exa rate-limits, try again with `type: "keyword"` or different query phrasing before falling back to Fiber
+- **Exa vs Hunter** — Exa finds the most team members with best structured data. Hunter surfaces senior/executive people and provides email addresses. Use both in parallel for best coverage
+- **Exa cost tiers** — 1-25 results: $0.005/request. 26-100 results: $0.025/request (5x jump). Stay at 25 unless the user needs comprehensive results
+- **Handle pagination** — If Exa returns exactly `numResults`, there are likely more. Bump to 50-100 (same cost tier once past 25) or run follow-up queries with different title keywords
 - **Small teams** — For niche teams (e.g., "fraud" at a 200-person startup), expect 3-8 results. This is normal
 - **Large teams** — For broad teams (e.g., "engineering" at a 5,000-person company), suggest the user narrow by sub-team or seniority
-- **Abbreviated names** — Some results will show partial names like "Joey G." or "Oneida D." These are real profiles with restricted LinkedIn visibility, not errors. Include them in results with the name as-is
+- **Abbreviated names** — Some Exa results show partial names like "Joey G." or "Oneida D." These are real profiles with restricted LinkedIn visibility, not errors. Include them in results with the name as-is

--- a/skills/orthogonal-team-linkedin-profiles/SKILL.md
+++ b/skills/orthogonal-team-linkedin-profiles/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: team-linkedin-profiles
+description: Find LinkedIn profiles of a specific team or department at a company. Use when asked to get LinkedIn profiles, find team members, or look up people in a particular team/department/group at a company.
+---
+
+# Team LinkedIn Profiles
+
+Find everyone on a specific team/department at a company and return their LinkedIn profiles.
+
+## Workflow
+
+### 1. Parse the Request
+
+Extract from the user's query:
+- **Company name** (required)
+- **Team/department name** (required) — e.g., fraud, engineering, sales, marketing, growth, data science
+- **Filters** (optional) — seniority level, location, max results count
+
+### 2. Resolve the Company
+
+Use Brand.dev to disambiguate the company and get its domain, industry, and description. This is critical for companies with common names (e.g., "Mercury" the fintech vs "Mercury Financial" the credit card company).
+
+```bash
+orth run brand-dev /v1/brand/retrieve-by-name --query 'name=Mercury'
+```
+
+From the result, build a **company context string** combining the company name, domain, industry, and a short description. Example: `"Mercury fintech banking startup mercury.com"`. Use this context string in all subsequent search queries to improve precision.
+
+If the user provides a domain directly, use `/v1/brand/retrieve` instead:
+```bash
+orth run brand-dev /v1/brand/retrieve --query 'domain=mercury.com'
+```
+
+### 3. Search for Team Members
+
+Run both searches **in parallel** for maximum coverage:
+
+**Primary — Exa people search** (best precision, returns LinkedIn URLs + structured data):
+```bash
+orth run exa /search --body '{
+  "query": "{company context string} {team} team members",
+  "category": "people",
+  "numResults": 20,
+  "includeDomains": ["linkedin.com"]
+}'
+```
+
+Try multiple query variations if results are sparse:
+- `"{company} {team} team"`
+- `"{team} at {company} {industry}"`
+- `"{team} analyst OR engineer OR manager at {company}"`
+
+**Supplement — Fiber NL profile search** (broader coverage, different data source):
+```bash
+orth run fiber /v1/natural-language-search/profiles --body '{
+  "query": "{team} team at {company} {industry context}",
+  "pageSize": 20
+}'
+```
+
+### 4. Filter & Deduplicate
+
+This step is critical for accuracy:
+
+1. **Verify current company** — For each result, confirm they currently work at the target company (not a similarly-named one). Use the domain and description from Step 2 to distinguish:
+   - Example: Mercury (fintech, mercury.com) vs Mercury Financial (credit cards, mercuryfinancial.com)
+   - Check the person's current employer name and domain against the Brand.dev data
+
+2. **Verify team/department** — Check that the person's title or department matches the target team. Be flexible with title variations:
+   - "Fraud" team → fraud analyst, fraud investigator, fraud ops, risk & fraud, trust & safety
+   - "Engineering" team → software engineer, SWE, developer, engineering manager
+   - "Sales" team → account executive, SDR, BDR, sales manager, revenue
+
+3. **Deduplicate** — Merge results from Exa and Fiber by LinkedIn URL. Prefer Exa data when both sources have the same person (richer structured data).
+
+4. **Flag uncertain matches** — If a person's company match is ambiguous, include them in the results but flag with a note (e.g., "Could not confirm current employer — verify manually").
+
+### 5. Present Results
+
+Output a clean markdown table:
+
+```
+## {Team} Team at {Company}
+
+Found {N} members:
+
+| Name | Title | Location | LinkedIn |
+|------|-------|----------|----------|
+| Jane Smith | Senior Fraud Analyst | San Francisco, CA | [Profile](https://linkedin.com/in/janesmith) |
+| ... | ... | ... | ... |
+
+**Uncertain matches** (verify manually):
+| Name | Title | Note | LinkedIn |
+|------|-------|------|----------|
+| ... | ... | ... | ... |
+```
+
+Include a note about coverage: "These are publicly discoverable profiles. Team members with private LinkedIn profiles or no LinkedIn presence won't appear."
+
+### 6. Optional Deep Enrichment
+
+Only if the user requests more detail on specific people, use Fiber live-fetch per profile:
+
+```bash
+orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/USERNAME"}'
+```
+
+This returns full work history, education, skills, and recent activity. Run these in parallel for multiple profiles.
+
+## Tips
+
+- **Add industry context** to all search queries — "Mercury fintech" finds the right Mercury much more reliably than just "Mercury"
+- **Expand title keywords** — Teams use varied titles. "Data team" could include data scientist, data engineer, analytics engineer, ML engineer, data analyst
+- **Handle pagination** — If Exa returns exactly `numResults`, there may be more. Increase `numResults` or run follow-up queries with different title keywords
+- **Rate limits** — If Exa rate-limits, lean on Fiber NL search as fallback. If both are limited, try Exa with `type: "keyword"` or different query phrasing
+- **Small teams** — For niche teams (e.g., "fraud" at a 200-person startup), expect 3-8 results. This is normal
+- **Large teams** — For broad teams (e.g., "engineering" at a 5,000-person company), suggest the user narrow by sub-team or seniority
+- **Private profiles** won't surface in any search — mention this if results seem thin


### PR DESCRIPTION
## Summary
- Adds new `team-linkedin-profiles` skill that finds LinkedIn profiles for a specific team/department at a company
- Uses Brand.dev for company disambiguation (critical for ambiguous names like "Mercury"), Exa people search as primary source, and Fiber NL search as supplement
- Includes filtering, deduplication, uncertain-match flagging, and optional deep enrichment via Fiber live-fetch

## Test plan
- [ ] Install skill and test with "get me the LinkedIn profiles of the fraud team at Mercury"
- [ ] Verify Brand.dev correctly disambiguates Mercury (fintech) vs Mercury Financial (credit cards)
- [ ] Verify Exa people search returns real team members with LinkedIn URLs
- [ ] Verify Fiber NL search supplements with additional results
- [ ] Confirm deduplication and filtering logic excludes false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)