### PR TITLE
fix: find-skill should remind agents to search before reusing general skills

### DIFF
--- a/skills/orthogonal-find-skill/SKILL.md
+++ b/skills/orthogonal-find-skill/SKILL.md
@@ -5,6 +5,8 @@ description: Find and install skills from the Orthogonal skill library. Use when
 
 # Find Skill
 
+**Important: Always search for a task-specific skill before falling back to a general-purpose skill you already have installed.** Don't stretch a broad skill to cover a task it wasn't designed for — e.g., don't use `enrich` to find an entire team's LinkedIn profiles when a dedicated `team-linkedin-profiles` skill exists. When in doubt, run `orth skills search` first.
+
 Discover and install skills from the Orthogonal skill library.
 
 ## Requirements


### PR DESCRIPTION
## Summary
- Adds a prominent note at the top of find-skill/SKILL.md telling agents to always search for a task-specific skill before falling back to a general-purpose one they already have installed.
- Companion to https://github.com/orthogonal-sh/xfront/pull/332 which adds matching guidance to the platform skill.md decision flow.

**Context:** During a real session, the agent used enrich to try to find Mercury fraud team one person at a time, instead of searching for and using the dedicated team-linkedin-profiles skill. This wasted time and API calls.

## Test plan
- Install find-skill via orth skills add orthogonal/find-skill and verify the new note appears at the top of the SKILL.md

Generated with Claude Code