### PR TITLE
Add find-twitter-influencers skill

### DIFF
--- a/skills/orthogonal-find-twitter-influencers/SKILL.md
+++ b/skills/orthogonal-find-twitter-influencers/SKILL.md
@@ -108,47 +108,45 @@ From Fiber results, extract any Twitter/X URLs from social profiles. Add new han
 
 Target: ~40-60 unique handles after dedup. Curated list pages typically mention 20-50 handles each, so 3-5 good listicle results yield plenty of candidates.
 
-### 5. Get Twitter Profiles
+### 5. Get Twitter Profiles + Engagement
 
-Fetch profiles for ALL candidates using Shofo. This is cheap (~200 tokens each) and provides the data needed for filtering.
+Fetch Twitter data for ALL candidates using Riveter web scraping. Each call returns the full profile AND recent tweets with engagement metrics in a single response ($0.05/call).
 
 ```bash
-orth run shofo /x/user-profile --query 'username=examplehandle'
+orth run riveter /v1/scrape --body '{
+  "url": "https://x.com/examplehandle"
+}'
 ```
 
-Run these in parallel for all candidates. From each profile, extract:
+Run these in parallel for all candidates. From each scraped profile page, extract:
+
+**Profile data:**
 - Display name, bio, location
-- Follower count, following count
-- Verified status
-- Profile URL, website link
-- Last tweet date (for activity check)
+- Follower count, following count, post count
+- Website link (from bio)
+- Joined date
+
+**Engagement data** (from the tweets visible on the page):
+- Per-tweet: likes, retweets, replies, views
+- **Average likes** per tweet
+- **Average retweets** per tweet
+- **Average replies** per tweet
+- **Engagement rate**: (avg likes + avg retweets + avg replies) / followers * 100
+- **Post frequency**: inferred from tweet dates
+- **Content themes**: what topics they tweet about most
 
 **Hard filters — discard profiles that meet any of these:**
 - Fewer than 1,000 followers
 - No tweets in the last 30 days (inactive)
 - Empty bio or bio completely unrelated to the niche
-- Protected/private accounts
+- Protected/private accounts (Riveter returns a login wall)
 - Suspended or not-found accounts
 
-### 6. Get Engagement Metrics
-
-For the top 25-30 candidates (by follower count + bio relevance after Step 5 filtering), fetch recent tweets:
-
-```bash
-orth run shofo /x/user-posts --query 'username=examplehandle' --query 'count=20'
-```
-
-The `count` parameter is required — use 20 for a good balance of data vs context size. Run these in parallel. From each user's recent posts, calculate:
-- **Average likes** per tweet
-- **Average retweets** per tweet
-- **Average replies** per tweet
-- **Engagement rate**: (avg likes + avg retweets + avg replies) / followers * 100
-- **Post frequency**: tweets per week
-- **Content themes**: what topics they tweet about most
+**Parsing tips:** Riveter returns the page as plain text. Tweet engagement numbers appear as `likes`, `retweets`, and `replies` counts next to each tweet. Follower count appears in the profile header. Parse these numbers to calculate metrics.
 
 Skip reply-only accounts (>80% of tweets are replies to others with minimal engagement).
 
-### 7. Score & Rank
+### 6. Score & Rank
 
 Apply a composite scoring model:
 
@@ -167,7 +165,7 @@ Apply a composite scoring model:
 
 Rank all candidates by composite score. Select the top N (default 15) for the final list.
 
-### 8. Enrich Contacts
+### 7. Enrich Contacts
 
 For the final list, run a contact enrichment waterfall to find email addresses. Try sources in order — stop per person once a verified email is found.
 
@@ -204,7 +202,7 @@ Also extract from enrichment results:
 - Personal website or newsletter link
 - Other social profiles
 
-### 9. Present Results
+### 8. Present Results
 
 Output a ranked markdown table with the final influencer list:
 
@@ -231,13 +229,21 @@ Found {N} influencers ranked by relevance and engagement:
 
 Include a brief summary of search coverage: how many candidates were found, how many passed filtering, and any gaps (e.g., "Few macro influencers found in this niche — consider broadening to adjacent topics").
 
-### 10. Optional Deep Dive
+### 9. Optional Deep Dive
 
 Only if the user requests more detail on specific influencers:
 
 **Full tweet analysis** (recent content, top tweets, audience reactions):
 ```bash
-orth run shofo /x/user-posts --query 'username=TARGET' --query 'count=50'
+orth run riveter /v1/scrape --body '{"url": "https://x.com/TARGET"}'
+```
+
+If deeper tweet history is needed, Nyne can fetch recent newsfeed data asynchronously:
+```bash
+# Step 1: POST to start async retrieval
+orth run -X POST nyne /person/newsfeed -d '{"social_media_url": "https://x.com/TARGET"}'
+# Step 2: Poll with GET using request_id
+orth run nyne /person/newsfeed --query 'request_id=REQUEST_ID'
 ```
 
 **LinkedIn profile** (full work history, credentials, other ventures):
@@ -263,9 +269,9 @@ orth run sixtyfour /enrich-lead --body '{
 - **Brand accounts vs personal** — Filter out corporate accounts (@stripe, @shopify). Look for individual creators even if they work at companies (e.g., @pmarca not @a16z)
 - **Engagement rate varies by tier** — >5% is elite for any size. 2-3% is strong for 50K+ followers. <0.5% is a red flag regardless of follower count
 - **Content themes matter more than follower count** — An account with 8K followers tweeting daily about the exact niche beats a 200K account that occasionally mentions it
-- **Shofo profiles are cheap** — ~200 tokens each. Fetch all candidates. Only fetch tweets (`/x/user-posts`) for the top 25-30 to manage context
-- **Shofo `/x/user-posts` requires `count`** — Always include `--query 'count=20'` (or desired number). Omitting it will cause an error
-- **Shofo may be temporarily unavailable** — If Shofo returns `"success": false"`, retry after a few seconds. This indicates a temporary service issue, not a syntax error
+- **Riveter returns profile + tweets in one call** — Each scrape of `x.com/username` returns the full profile header (name, bio, followers) AND recent tweets with engagement metrics (likes, retweets, replies, views). No need for separate profile and posts calls
+- **Riveter costs $0.05/call** — For 60 candidates that's $3 total. Fetch all candidates since you get both profile and engagement data at once
+- **Parse Riveter text output carefully** — Riveter returns the page as plain text. Follower counts appear near the top ("3M Followers"), engagement numbers appear next to each tweet. Views are the last number after likes/retweets/replies
 - **Check for newsletters/Substacks** — Many Twitter influencers run newsletters. These are high-signal for partnership potential and often listed in the bio
 - **Fiber catches LinkedIn-heavy people** — Some professionals (B2B especially) are more discoverable via LinkedIn but still have active Twitter accounts. Don't skip Strategy C for B2B niches
 - **Fiber kitchen-sink has no Twitter URL param** — Use `profileIdentifier` (LinkedIn URL) for best match rate. Fall back to `personName` + `companyName` if no LinkedIn URL is available

--- a/skills/orthogonal-find-twitter-influencers/SKILL.md
+++ b/skills/orthogonal-find-twitter-influencers/SKILL.md
@@ -34,50 +34,52 @@ From the result, build a **company context string**: company name, domain, indus
 
 ### 3. Discover Candidates
 
-Run three strategies **in parallel** to maximize coverage (~60 unique candidates after dedup):
+Run three strategies **in parallel** to maximize coverage:
 
-**Strategy A — Exa search** (primary, highest signal):
+**Strategy A — Exa search for curated influencer lists** (primary, highest signal):
 
-Run 2-3 query variations, each returning 30 results. Use `includeDomains` to restrict to Twitter profiles. Do NOT use `category: "people"` — it only works with LinkedIn domains, not x.com/twitter.com.
+IMPORTANT: x.com and twitter.com profiles are NOT in Exa's search index, so `includeDomains: ["x.com"]` will return zero Twitter results. Instead, search for curated list pages, blog posts, and articles about influencers in the niche. Use `contents.text` to get the page content so you can extract Twitter handles from it.
+
+Run 2-3 query variations, each returning 10 results with text content:
 
 ```bash
-# Query 1: Direct niche + influencer keywords
+# Query 1: Curated lists of influencers in the niche
 orth run exa /search --body '{
-  "query": "{niche} influencer thought leader must-follow",
-  "numResults": 30,
-  "includeDomains": ["x.com", "twitter.com"]
+  "query": "best {niche} Twitter accounts to follow",
+  "numResults": 10,
+  "contents": {"text": {"maxCharacters": 5000}}
 }'
 
-# Query 2: Company/product context
+# Query 2: Influencer roundup with different phrasing
 orth run exa /search --body '{
-  "query": "{industry} {product category} expert creator Twitter",
-  "numResults": 30,
-  "includeDomains": ["x.com", "twitter.com"]
+  "query": "top {industry} influencers on X Twitter must follow",
+  "numResults": 10,
+  "contents": {"text": {"maxCharacters": 5000}}
 }'
 
-# Query 3: Audience-aligned (optional, if niche is broad)
+# Query 3: Niche-specific creator lists
 orth run exa /search --body '{
-  "query": "{target audience keywords} tips advice Twitter account",
-  "numResults": 30,
-  "includeDomains": ["x.com", "twitter.com"]
+  "query": "{niche} thought leaders creators Twitter handles",
+  "numResults": 10,
+  "contents": {"text": {"maxCharacters": 5000}}
 }'
 ```
 
-Vary the query phrasing to reduce overlap. Use company context keywords (industry, target audience, product category) to stay relevant.
+These queries return listicle pages (e.g., "Top 60 Fintech Influencers", "FinTwit Accounts to Follow") whose text content contains Twitter handles, bios, and follower counts. Parse these in Step 4.
 
-**Strategy B — Exa findSimilar** (expand from strong initial finds):
+**Strategy B — Exa findSimilar** (expand from strong listicle finds):
 
-After Strategy A returns results, pick 1-2 of the strongest profile URLs and expand:
+After Strategy A returns results, pick 1-2 of the best curated list URLs and find similar pages:
 
 ```bash
 orth run exa /findSimilar --body '{
-  "url": "https://x.com/strong_candidate",
-  "numResults": 15,
-  "includeDomains": ["x.com", "twitter.com"]
+  "url": "https://example.com/top-fintech-twitter-influencers",
+  "numResults": 5,
+  "contents": {"text": {"maxCharacters": 5000}}
 }'
 ```
 
-This surfaces similar influencers that keyword search may miss.
+This surfaces additional curated lists that keyword search may miss. Do NOT use Twitter/X profile URLs for findSimilar — they are not in Exa's index and will return empty results.
 
 **Strategy C — Fiber natural-language-search** (catch LinkedIn-heavy professionals):
 
@@ -94,16 +96,17 @@ Cross-reference Fiber results with Twitter in Step 5 — only keep people with a
 
 ### 4. Extract & Deduplicate Usernames
 
-From all Exa results, parse Twitter handles:
-- Extract usernames from URLs: `x.com/username` or `twitter.com/username`
-- Strip trailing paths (e.g., `/status/123`, `/followers`) — only keep base profile URLs
-- Discard non-profile URLs (search pages, hashtag pages, moment URLs)
+From the **text content** of Exa listicle pages, parse Twitter handles using multiple patterns:
+- `@username` mentions in the article text
+- URLs matching `x.com/username` or `twitter.com/username`
+- Strip trailing URL paths (e.g., `/status/123`, `/followers`) — only keep base profile usernames
+- Discard non-profile patterns (search pages, hashtag pages, `x.com/home`, `x.com/search`)
 - Deduplicate by username (case-insensitive)
 - Flag and remove obvious brand/company accounts (e.g., `@stripe`, `@shopify`) — focus on individual creators
 
 From Fiber results, extract any Twitter/X URLs from social profiles. Add new handles to the candidate pool.
 
-Target: ~40-60 unique handles after dedup.
+Target: ~40-60 unique handles after dedup. Curated list pages typically mention 20-50 handles each, so 3-5 good listicle results yield plenty of candidates.
 
 ### 5. Get Twitter Profiles
 
@@ -132,10 +135,10 @@ Run these in parallel for all candidates. From each profile, extract:
 For the top 25-30 candidates (by follower count + bio relevance after Step 5 filtering), fetch recent tweets:
 
 ```bash
-orth run shofo /x/user-posts --query 'username=examplehandle'
+orth run shofo /x/user-posts --query 'username=examplehandle' --query 'count=20'
 ```
 
-Run these in parallel. From each user's recent posts, calculate:
+The `count` parameter is required — use 20 for a good balance of data vs context size. Run these in parallel. From each user's recent posts, calculate:
 - **Average likes** per tweet
 - **Average retweets** per tweet
 - **Average replies** per tweet
@@ -172,11 +175,19 @@ For the final list, run a contact enrichment waterfall to find email addresses. 
 
 **Step 2 — Fiber kitchen-sink** (best coverage for professionals):
 ```bash
+# With LinkedIn URL (best match rate):
+orth run fiber /v1/kitchen-sink/person --body '{
+  "profileIdentifier": "https://linkedin.com/in/janesmith"
+}'
+
+# Without LinkedIn — use name + company:
 orth run fiber /v1/kitchen-sink/person --body '{
   "personName": {"fullName": "Jane Smith"},
-  "twitterUrl": "https://x.com/janesmith"
+  "companyName": {"name": "Jane Smith Creative"}
 }'
 ```
+
+Note: Fiber kitchen-sink does NOT accept a Twitter URL parameter. Use `profileIdentifier` (LinkedIn URL) for best results, or fall back to `personName` + `companyName`/`companyDomain`.
 
 **Step 3 — Hunter email-finder** (if you have their name + domain from their website/LinkedIn):
 ```bash
@@ -226,7 +237,7 @@ Only if the user requests more detail on specific influencers:
 
 **Full tweet analysis** (recent content, top tweets, audience reactions):
 ```bash
-orth run shofo /x/user-posts --query 'username=TARGET'
+orth run shofo /x/user-posts --query 'username=TARGET' --query 'count=50'
 ```
 
 **LinkedIn profile** (full work history, credentials, other ventures):
@@ -244,16 +255,19 @@ orth run sixtyfour /enrich-lead --body '{
 
 ## Tips
 
-- **Query variation is key** — Exa deduplicates poorly across identical queries. Vary phrasing: "fintech influencer", "finance creator Twitter", "money Twitter thought leader" all surface different people
-- **Do NOT use `category: "people"` with Exa for Twitter** — this category only works with `includeDomains: ["linkedin.com"]`. For Twitter/X discovery, use standard search with `includeDomains: ["x.com", "twitter.com"]`
+- **Exa cannot search Twitter directly** — x.com/twitter.com profiles are NOT in Exa's search index. `includeDomains: ["x.com"]` returns zero Twitter results. Instead, search for curated list pages and listicles about influencers, then extract handles from the page text
+- **Request text content from Exa** — Always use `contents: { text: { maxCharacters: 5000 } }` when searching for influencer lists. The page text contains @handles, profile URLs, and bios that you need to parse
+- **Query variation is key** — Vary phrasing across queries: "best fintech Twitter accounts to follow", "top finance creators on X", "FinTwit must-follow" all surface different listicle pages
+- **findSimilar works on listicle pages, not Twitter URLs** — Use findSimilar on the best curated list URLs from Strategy A to find more lists. Do NOT pass x.com URLs — they return empty results
 - **Micro-influencers often outperform** — accounts with 5K-50K followers frequently have 3-5x the engagement rate of 500K+ accounts. Recommend a mix unless the user specifies otherwise
-- **Brand accounts vs personal** — Filter out corporate accounts (@stripe, @shopify). Look for individual creators even if they work at companies (e.g., @pmarca not @a]16z)
+- **Brand accounts vs personal** — Filter out corporate accounts (@stripe, @shopify). Look for individual creators even if they work at companies (e.g., @pmarca not @a16z)
 - **Engagement rate varies by tier** — >5% is elite for any size. 2-3% is strong for 50K+ followers. <0.5% is a red flag regardless of follower count
 - **Content themes matter more than follower count** — An account with 8K followers tweeting daily about the exact niche beats a 200K account that occasionally mentions it
-- **Exa returns ~800 tokens per result** — 30 results per query x 3 queries = ~72K tokens. This is manageable but be mindful of context limits if running many parallel strategies
 - **Shofo profiles are cheap** — ~200 tokens each. Fetch all candidates. Only fetch tweets (`/x/user-posts`) for the top 25-30 to manage context
-- **findSimilar snowballs well** — If one Exa search finds a strong influencer, `findSimilar` on their profile URL often surfaces an entire cluster of similar creators
+- **Shofo `/x/user-posts` requires `count`** — Always include `--query 'count=20'` (or desired number). Omitting it will cause an error
+- **Shofo may be temporarily unavailable** — If Shofo returns `"success": false"`, retry after a few seconds. This indicates a temporary service issue, not a syntax error
 - **Check for newsletters/Substacks** — Many Twitter influencers run newsletters. These are high-signal for partnership potential and often listed in the bio
 - **Fiber catches LinkedIn-heavy people** — Some professionals (B2B especially) are more discoverable via LinkedIn but still have active Twitter accounts. Don't skip Strategy C for B2B niches
+- **Fiber kitchen-sink has no Twitter URL param** — Use `profileIdentifier` (LinkedIn URL) for best match rate. Fall back to `personName` + `companyName` if no LinkedIn URL is available
 - **Contact enrichment is a waterfall** — Don't blast all four sources for every person. Check Twitter bio first (free), then Fiber (most coverage), then Hunter/Tomba only if needed
 - **DM culture** — Many influencers prefer Twitter DMs for collaboration inquiries. Note "DM for collabs" or "Open DMs" from bios as a contact method

--- a/skills/orthogonal-find-twitter-influencers/SKILL.md
+++ b/skills/orthogonal-find-twitter-influencers/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: find-twitter-influencers
+description: Find Twitter/X influencers to promote a product or brand. Use when asked to find influencers, discover Twitter accounts for partnerships, identify creators in a niche, or build an influencer outreach list.
+---
+
+# Find Twitter Influencers
+
+Discover, score, and enrich Twitter/X influencers relevant to a company, product, or niche. Returns a ranked list with engagement metrics, relevance reasoning, and contact info.
+
+## Workflow
+
+### 1. Parse the Request
+
+Extract from the user's query:
+- **Company name or domain** (required) — the brand seeking influencers
+- **Niche/vertical** (optional) — e.g., "fintech Twitter", "AI/ML creators", "DTC beauty"
+- **Size preference** (optional) — micro (1K-10K), mid-tier (10K-100K), macro (100K+), or mixed
+- **Max results** (optional, default 15)
+
+### 2. Resolve the Company
+
+Use Brand.dev to get domain, industry, description, target audience, and keywords. This context drives all subsequent searches.
+
+```bash
+orth run brand-dev /v1/brand/retrieve-by-name --query 'name=Acme Corp'
+```
+
+If a domain is provided directly:
+```bash
+orth run brand-dev /v1/brand/retrieve --query 'domain=acme.com'
+```
+
+From the result, build a **company context string**: company name, domain, industry, description, and target audience keywords. Example: `"Acme Corp acme.com developer tools API platform engineering teams"`. Use this in all search queries.
+
+### 3. Discover Candidates
+
+Run three strategies **in parallel** to maximize coverage (~60 unique candidates after dedup):
+
+**Strategy A — Exa search** (primary, highest signal):
+
+Run 2-3 query variations, each returning 30 results. Use `includeDomains` to restrict to Twitter profiles. Do NOT use `category: "people"` — it only works with LinkedIn domains, not x.com/twitter.com.
+
+```bash
+# Query 1: Direct niche + influencer keywords
+orth run exa /search --body '{
+  "query": "{niche} influencer thought leader must-follow",
+  "numResults": 30,
+  "includeDomains": ["x.com", "twitter.com"]
+}'
+
+# Query 2: Company/product context
+orth run exa /search --body '{
+  "query": "{industry} {product category} expert creator Twitter",
+  "numResults": 30,
+  "includeDomains": ["x.com", "twitter.com"]
+}'
+
+# Query 3: Audience-aligned (optional, if niche is broad)
+orth run exa /search --body '{
+  "query": "{target audience keywords} tips advice Twitter account",
+  "numResults": 30,
+  "includeDomains": ["x.com", "twitter.com"]
+}'
+```
+
+Vary the query phrasing to reduce overlap. Use company context keywords (industry, target audience, product category) to stay relevant.
+
+**Strategy B — Exa findSimilar** (expand from strong initial finds):
+
+After Strategy A returns results, pick 1-2 of the strongest profile URLs and expand:
+
+```bash
+orth run exa /findSimilar --body '{
+  "url": "https://x.com/strong_candidate",
+  "numResults": 15,
+  "includeDomains": ["x.com", "twitter.com"]
+}'
+```
+
+This surfaces similar influencers that keyword search may miss.
+
+**Strategy C — Fiber natural-language-search** (catch LinkedIn-heavy professionals):
+
+Some influencers are better indexed on LinkedIn but have active Twitter accounts. Fiber can surface these:
+
+```bash
+orth run fiber /v1/natural-language-search/profiles --body '{
+  "query": "{niche} thought leader content creator with Twitter presence at {industry} companies",
+  "pageSize": 20
+}'
+```
+
+Cross-reference Fiber results with Twitter in Step 5 — only keep people with active Twitter accounts.
+
+### 4. Extract & Deduplicate Usernames
+
+From all Exa results, parse Twitter handles:
+- Extract usernames from URLs: `x.com/username` or `twitter.com/username`
+- Strip trailing paths (e.g., `/status/123`, `/followers`) — only keep base profile URLs
+- Discard non-profile URLs (search pages, hashtag pages, moment URLs)
+- Deduplicate by username (case-insensitive)
+- Flag and remove obvious brand/company accounts (e.g., `@stripe`, `@shopify`) — focus on individual creators
+
+From Fiber results, extract any Twitter/X URLs from social profiles. Add new handles to the candidate pool.
+
+Target: ~40-60 unique handles after dedup.
+
+### 5. Get Twitter Profiles
+
+Fetch profiles for ALL candidates using Shofo. This is cheap (~200 tokens each) and provides the data needed for filtering.
+
+```bash
+orth run shofo /x/user-profile --query 'username=examplehandle'
+```
+
+Run these in parallel for all candidates. From each profile, extract:
+- Display name, bio, location
+- Follower count, following count
+- Verified status
+- Profile URL, website link
+- Last tweet date (for activity check)
+
+**Hard filters — discard profiles that meet any of these:**
+- Fewer than 1,000 followers
+- No tweets in the last 30 days (inactive)
+- Empty bio or bio completely unrelated to the niche
+- Protected/private accounts
+- Suspended or not-found accounts
+
+### 6. Get Engagement Metrics
+
+For the top 25-30 candidates (by follower count + bio relevance after Step 5 filtering), fetch recent tweets:
+
+```bash
+orth run shofo /x/user-posts --query 'username=examplehandle'
+```
+
+Run these in parallel. From each user's recent posts, calculate:
+- **Average likes** per tweet
+- **Average retweets** per tweet
+- **Average replies** per tweet
+- **Engagement rate**: (avg likes + avg retweets + avg replies) / followers * 100
+- **Post frequency**: tweets per week
+- **Content themes**: what topics they tweet about most
+
+Skip reply-only accounts (>80% of tweets are replies to others with minimal engagement).
+
+### 7. Score & Rank
+
+Apply a composite scoring model:
+
+| Factor | Weight | Signal |
+|--------|--------|--------|
+| **Relevance** | 40% | Bio keywords, content themes, audience overlap with target company |
+| **Engagement rate** | 25% | Higher is better; micro-influencers often outperform macro here |
+| **Follower count** | 15% | Log-scaled — diminishing returns above 100K |
+| **Content quality** | 10% | Original content vs retweets, thread depth, media usage |
+| **Audience alignment** | 10% | Do their followers match the company's target audience? Inferred from bio + content themes |
+
+**Scoring guidelines:**
+- Relevance: Compare bio and recent tweet topics against the company context string from Step 2. Exact niche match = high score. Adjacent niche = medium. Generic/unrelated = low.
+- Engagement rate benchmarks: >3% excellent, 1-3% good, <1% below average (varies by follower tier)
+- Content quality: Penalize accounts that are >50% retweets. Reward original threads, insights, and media-rich posts.
+
+Rank all candidates by composite score. Select the top N (default 15) for the final list.
+
+### 8. Enrich Contacts
+
+For the final list, run a contact enrichment waterfall to find email addresses. Try sources in order — stop per person once a verified email is found.
+
+**Step 1 — Check Twitter bio**: Many influencers list their email or a link to a contact page directly in their bio. Extract any email addresses or "DM for collabs" notes.
+
+**Step 2 — Fiber kitchen-sink** (best coverage for professionals):
+```bash
+orth run fiber /v1/kitchen-sink/person --body '{
+  "personName": {"fullName": "Jane Smith"},
+  "twitterUrl": "https://x.com/janesmith"
+}'
+```
+
+**Step 3 — Hunter email-finder** (if you have their name + domain from their website/LinkedIn):
+```bash
+orth run hunter /v2/email-finder --query 'domain=janesmithcreative.com' --query 'first_name=Jane' --query 'last_name=Smith'
+```
+
+**Step 4 — Tomba LinkedIn-to-email** (if LinkedIn URL was discovered):
+```bash
+orth run tomba /v1/linkedin --query 'url=https://linkedin.com/in/janesmith'
+```
+
+Also extract from enrichment results:
+- LinkedIn URL (for outreach or further research)
+- Personal website or newsletter link
+- Other social profiles
+
+### 9. Present Results
+
+Output a ranked markdown table with the final influencer list:
+
+```
+## Twitter Influencers for {Company} — {Niche}
+
+Found {N} influencers ranked by relevance and engagement:
+
+| # | Name | Handle | Followers | Eng. Rate | Why They Fit | Email | LinkedIn |
+|---|------|--------|-----------|-----------|--------------|-------|----------|
+| 1 | Jane Smith | [@janesmith](https://x.com/janesmith) | 45.2K | 3.8% | {1-line reason} | jane@... | [Profile](https://linkedin.com/in/...) |
+| 2 | ... | ... | ... | ... | ... | ... | ... |
+
+### Size Distribution
+- Micro (1K-10K): {count}
+- Mid-tier (10K-100K): {count}
+- Macro (100K+): {count}
+
+### Notes
+- Engagement rates above 3% are excellent for partnership ROI
+- Influencers marked with "DM preferred" indicated in their bio they prefer DMs over email
+- {Any caveats about the search — e.g., niche is small so fewer results}
+```
+
+Include a brief summary of search coverage: how many candidates were found, how many passed filtering, and any gaps (e.g., "Few macro influencers found in this niche — consider broadening to adjacent topics").
+
+### 10. Optional Deep Dive
+
+Only if the user requests more detail on specific influencers:
+
+**Full tweet analysis** (recent content, top tweets, audience reactions):
+```bash
+orth run shofo /x/user-posts --query 'username=TARGET'
+```
+
+**LinkedIn profile** (full work history, credentials, other ventures):
+```bash
+orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/TARGET"}'
+```
+
+**Deep enrichment** (AI-powered research — slow, ~30-60s):
+```bash
+orth run sixtyfour /enrich-lead --body '{
+  "lead_info": {"first_name": "Jane", "last_name": "Smith", "linkedin_url": "https://linkedin.com/in/janesmith"},
+  "struct": {"work_email": "Work email", "personal_email": "Personal email", "phone": "Phone number", "audience_size": "Total audience across platforms", "collab_history": "Known brand collaborations", "content_style": "Content style and themes"}
+}'
+```
+
+## Tips
+
+- **Query variation is key** — Exa deduplicates poorly across identical queries. Vary phrasing: "fintech influencer", "finance creator Twitter", "money Twitter thought leader" all surface different people
+- **Do NOT use `category: "people"` with Exa for Twitter** — this category only works with `includeDomains: ["linkedin.com"]`. For Twitter/X discovery, use standard search with `includeDomains: ["x.com", "twitter.com"]`
+- **Micro-influencers often outperform** — accounts with 5K-50K followers frequently have 3-5x the engagement rate of 500K+ accounts. Recommend a mix unless the user specifies otherwise
+- **Brand accounts vs personal** — Filter out corporate accounts (@stripe, @shopify). Look for individual creators even if they work at companies (e.g., @pmarca not @a]16z)
+- **Engagement rate varies by tier** — >5% is elite for any size. 2-3% is strong for 50K+ followers. <0.5% is a red flag regardless of follower count
+- **Content themes matter more than follower count** — An account with 8K followers tweeting daily about the exact niche beats a 200K account that occasionally mentions it
+- **Exa returns ~800 tokens per result** — 30 results per query x 3 queries = ~72K tokens. This is manageable but be mindful of context limits if running many parallel strategies
+- **Shofo profiles are cheap** — ~200 tokens each. Fetch all candidates. Only fetch tweets (`/x/user-posts`) for the top 25-30 to manage context
+- **findSimilar snowballs well** — If one Exa search finds a strong influencer, `findSimilar` on their profile URL often surfaces an entire cluster of similar creators
+- **Check for newsletters/Substacks** — Many Twitter influencers run newsletters. These are high-signal for partnership potential and often listed in the bio
+- **Fiber catches LinkedIn-heavy people** — Some professionals (B2B especially) are more discoverable via LinkedIn but still have active Twitter accounts. Don't skip Strategy C for B2B niches
+- **Contact enrichment is a waterfall** — Don't blast all four sources for every person. Check Twitter bio first (free), then Fiber (most coverage), then Hunter/Tomba only if needed
+- **DM culture** — Many influencers prefer Twitter DMs for collaboration inquiries. Note "DM for collabs" or "Open DMs" from bios as a contact method


### PR DESCRIPTION
## Summary
- Adds a new `find-twitter-influencers` skill that discovers, scores, and enriches Twitter/X influencers relevant to a company or niche
- 10-step workflow: company resolution (Brand.dev) -> candidate discovery (Exa search + findSimilar + Fiber) -> profile fetching (Shofo) -> engagement scoring -> contact enrichment waterfall (Fiber -> Hunter -> Tomba -> Twitter bio)
- Composite scoring model: relevance (40%), engagement rate (25%), follower count (15%), content quality (10%), audience alignment (10%)

## Test plan
- [ ] Install locally: `orth skills add orthogonal/find-twitter-influencers`
- [ ] Test with a specific company: "Find Twitter influencers to promote Stripe"
- [ ] Verify Exa queries work with `includeDomains: ["x.com", "twitter.com"]` (no `category: "people"`)
- [ ] Verify Shofo `/x/user-profile` and `/x/user-posts` return expected data
- [ ] Confirm contact enrichment waterfall produces emails for at least some influencers
- [ ] Check output table formatting and size distribution summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)