### PR TITLE
Add scrapegraph to Search & Research section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A skill is a `SKILL.md` file that tells an AI agent how to do something. When yo
 | [perplexity](skills/orthogonal-perplexity) | AI search and chat with real-time web data |
 | [tavily](skills/orthogonal-tavily) | AI-powered web search, crawling, and deep research |
 | [valyu](skills/orthogonal-valyu) | Web search, AI answers, and async deep research |
+| [scrapegraph](skills/orthogonal-scrapegraph) | AI-powered web search and data extraction using natural language |
 | [searchapi](skills/orthogonal-searchapi) | Multi-platform search: YouTube, Amazon, eBay, TikTok, and more |
 | [prediction-market-odds](skills/orthogonal-prediction-market-odds) | Polymarket and Kalshi odds and prices |
 | [dome](skills/orthogonal-dome) | Prediction markets data, positions, and trades |


### PR DESCRIPTION
## Summary

- Added `scrapegraph` to the **Search & Research** section of the README
- scrapegraph's `SearchScraper` feature provides AI-powered web search, making it relevant alongside other search tools like `exa`, `tavily`, and `perplexity`
- It remains listed in Web Scraping & Automation as well, since it covers both use cases

## Test plan

- [ ] Verify the link `skills/orthogonal-scrapegraph` resolves correctly in the Search & Research table
- [ ] Confirm the description accurately reflects the SearchScraper capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)