### PR TITLE
fix: correct Fiber API field names in job-search and fiber skills

### DIFF
--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -133,12 +133,12 @@ Parameters:
 
 ```bash
 orth api run fiber /v1/investor-search --body '{
-  "searchParams": {
-    "investment_stages": ["Seed", "Series A"],
-    "industries": ["AI", "SaaS"]
-  }
+  "searchParams": {},
+  "pageSize": 25
 }'
 ```
+
+Note: Investor search uses structured filters. Use `orth api show fiber /v1/investor-search` for exact parameter names.
 
 ### Fetch LinkedIn profile posts
 Fetches recent posts from a LinkedIn profile. Returns a paginated feed of posts with optional cursor for pagination. Each page returns up to 50 posts.
@@ -166,7 +166,7 @@ orth api run fiber /v1/linkedin-live-fetch/company/single --body '{"identifier":
 Search for people using filters
 
 Parameters:
-- searchParams (object) - Search parameters for people search.
+- searchParams (object) - Search parameters for people search. Uses structured filters (see Fiber OpenAPI docs for full schema).
 - pageSize (integer) - The number of profiles to return, if you need to get more results, you can paginate.
 - cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
 - currentCompanies (['array', 'null']) - Filter people by the companies they are currently working for. If you want to search over many companies, we suggest using the Combined Search API, which is optimized for this use case.
@@ -176,9 +176,22 @@ Parameters:
 ```bash
 orth api run fiber /v1/people-search --body '{
   "searchParams": {
-    "job_titles": ["CTO", "VP Engineering"],
-    "locations": ["San Francisco", "New York"]
-  }
+    "jobTitleV3": {
+      "anyOf": [
+        {"type": "plain", "term": "CTO"},
+        {"type": "plain", "term": "VP Engineering"}
+      ]
+    },
+    "country3LetterCode": {"anyOf": ["USA"]},
+    "location": {
+      "unionAll": [{
+        "strategy": "radial-distance",
+        "center": {"latitude": 37.7749, "longitude": -122.4194},
+        "radius": {"unit": "miles", "quantity": 50}
+      }]
+    }
+  },
+  "pageSize": 25
 }'
 ```
 
@@ -197,18 +210,29 @@ orth api run fiber /v1/linkedin-live-fetch/post-comments --body '{"identifier": 
 Search for companies using filters
 
 Parameters:
-- searchParams* (object) - Search parameters for company search API.
+- searchParams* (object) - Search parameters for company search API. Uses structured filters with specific field names (see examples below).
 - pageSize (integer) - The number of companies to return, if you need to get more results, you can paginate.
 - cursor (['string', 'null']) - A pagination cursor returned from a previous search response. Use this to fetch the next page of results.
 - companyExclusionListIDs (['array', 'null']) - Filter out companies which belong to the given company exclusion lists. You can create company exclusion lists via /v1/exclusions/companies/create-list
 
+Key searchParams fields:
+- `headquartersCountryCode`: `{"anyOf": ["USA"]}` or `{"noneOf": [...]}`
+- `employeeCountV2`: `{"lowerBoundExclusive": 50}` (values: 0, 1, 10, 50, 200, 500, 1000, 5000, 10000)
+- `industriesV2`: `{"anyOf": ["Software", "Artificial Intelligence"]}` or `{"allOf": [...]}`
+- `revenueUSD`: `{"min": {"quantity": 10, "suffix": "M"}}` and/or `{"max": {...}}`
+- `stage`: `{"anyOf": ["seed", "series_a", "series_b"]}`
+- `jobPostingsV2`: `{"allOf": [{"jobTitle": [...], "jobPostingStatus": "active", "countryOrRegionCode": ["USA"]}]}`
+- `headquartersLocation`: `{"unionAll": [{"strategy": "radial-distance", "center": {"latitude": N, "longitude": N}, "radius": {"unit": "miles", "quantity": N}}]}`
+- `keywords`: `{"containsAll": [...]}` or `{"containsAny": [...]}`
+
 ```bash
 orth api run fiber /v1/company-search --body '{
   "searchParams": {
-    "industries": ["Software", "AI"],
-    "employee_count_min": 50,
-    "employee_count_max": 500
-  }
+    "industriesV2": {"anyOf": ["Software", "Artificial Intelligence"]},
+    "employeeCountV2": {"lowerBoundExclusive": 50, "upperBoundInclusive": 500},
+    "headquartersCountryCode": {"anyOf": ["USA"]}
+  },
+  "pageSize": 25
 }'
 ```
 
@@ -233,19 +257,28 @@ orth api run fiber /v1/text-to-search-params/profiles --body '{"query": "Senior 
 ```
 
 ### Job postings search
-Search for job postings with flexible filtering capabilities
-
-Parameters:
-- searchParams* (object) - Job search filter parameters
-- pageSize (integer) - Number of jobs to return per page (max 1000)
-- cursor (['string', 'null']) - Pagination cursor for fetching next page of results
+Find companies with active job postings using company-search with `jobPostingsV2` filters. Note: The `/v1/job-search` endpoint exists but has an undocumented schema. Use `/v1/company-search` with `jobPostingsV2` for reliable results.
 
 ```bash
-orth api run fiber /v1/job-search --body '{
+orth api run fiber /v1/company-search --body '{
   "searchParams": {
-    "job_titles": ["Software Engineer"],
-    "locations": ["Remote"]
-  }
+    "jobPostingsV2": {
+      "allOf": [{
+        "jobTitle": ["Software Engineer"],
+        "jobPostingStatus": "active",
+        "jobLocationType": ["Remote"]
+      }]
+    }
+  },
+  "pageSize": 25
+}'
+```
+
+Or use natural language for quick searches:
+
+```bash
+orth api run fiber /v1/natural-language-search/companies --body '{
+  "query": "Companies hiring Remote Software Engineers"
 }'
 ```
 

--- a/skills/orthogonal-job-search/SKILL.md
+++ b/skills/orthogonal-job-search/SKILL.md
@@ -1,97 +1,183 @@
 ---
 name: job-search
-description: Search for jobs matching your skills, experience, and preferences
+description: Search for jobs and companies hiring for specific roles using Fiber AI
 ---
 
-# Job Search - Find Your Next Role
+# Job Search - Find Companies Hiring for Specific Roles
 
-Search for jobs matching your skills, experience level, and location preferences.
+Search for job postings and companies actively hiring using Fiber's company search with job posting filters.
 
 ## Workflow
 
-### Step 1: Search Job Listings
-Use Fiber to search for jobs:
+### Step 1: Quick Search (Natural Language)
+
+For simple searches, use the natural language endpoint:
 
 ```bash
-orth api run fiber /v1/job-search --body '{
-  "searchParams": {
-    "job_titles": ["Software Engineer", "Full Stack Developer"],
-    "locations": ["San Francisco", "Remote"],
-    "experience_level": "senior"
-  }
+orth api run fiber /v1/natural-language-search/companies --body '{
+  "query": "Companies hiring Software Engineers in San Francisco",
+  "pageSize": 25
 }'
 ```
 
-### Step 2: Research Companies
-Get company information for interesting roles:
+### Step 2: Structured Search (Precise Filters)
+
+For precise control, use company-search with `jobPostingsV2` filters. This finds companies that have job postings matching your criteria:
 
 ```bash
 orth api run fiber /v1/company-search --body '{
   "searchParams": {
-    "company_names": ["Stripe", "Figma", "Notion"]
-  }
+    "jobPostingsV2": {
+      "allOf": [{
+        "jobTitle": ["Software Engineer", "Full Stack Developer"],
+        "jobPostingStatus": "active",
+        "countryOrRegionCode": ["USA"],
+        "jobLocationType": ["Remote"],
+        "seniority": ["Mid-Senior level"],
+        "employmentType": ["Full-time"]
+      }]
+    },
+    "headquartersCountryCode": {"anyOf": ["USA"]}
+  },
+  "pageSize": 25
 }'
 ```
 
-### Step 3: Get Company Intel
-Use Brand.dev for detailed company info:
+#### jobPostingsV2 Filter Fields
+
+Inside each filter object in `allOf`, `anyOf`, or `noneOf`:
+
+- `jobTitle` (string[]) - Job title keywords to match, e.g. `["GTM Engineer", "Growth Engineer"]`
+- `keywords` (string[]) - Keywords to search in job descriptions
+- `jobPostingStatus` - `"active"`, `"closed"`, or `"either"`
+- `countryOrRegionCode` (string[]) - 3-letter country codes, e.g. `["USA", "GBR"]`
+- `seniority` (string[]) - `"Entry level"`, `"Associate"`, `"Mid-Senior level"`, `"Director"`, `"Executive"`, `"Internship"`, `"Not Applicable"`
+- `employmentType` (string[]) - `"Full-time"`, `"Part-time"`, `"Contract"`, `"Temporary"`, `"Internship"`, `"Volunteer"`, `"Other"`
+- `jobFunction` (string[]) - e.g. `"Engineering"`, `"Sales"`, `"Marketing"`, `"Information Technology"`
+- `industry` (string[]) - e.g. `"Software"`, `"Healthcare"`, `"Finance"`
+- `jobLocationType` (string[]) - `"On-site"`, `"Remote"`, `"Hybrid"`
+- `postedAt` - Date filter (absolute or relative), e.g. `{"strategy": "relative", "window": {"method": "lastN", "period": "month", "quantity": 1}}`
+- `annualPayUSD` - Salary range, e.g. `{"lowerBound": 100000, "upperBound": 200000}`
+- `yearsOfExperience` - Experience range, e.g. `{"lowerBound": 3, "upperBound": 10}`
+- `geoLocation` - Radial search with lat/lng and radius
+
+#### Combining with Company Filters
+
+You can add company-level filters alongside `jobPostingsV2`:
+
+- `headquartersCountryCode`: `{"anyOf": ["USA"]}` or `{"noneOf": [...]}`
+- `employeeCountV2`: `{"lowerBoundExclusive": 50}` (values: 0, 1, 10, 50, 200, 500, 1000, 5000, 10000)
+- `industriesV2`: `{"anyOf": ["Software", "Artificial Intelligence"]}`
+- `revenueUSD`: `{"min": {"quantity": 10, "suffix": "M"}}`
+- `stage`: `{"anyOf": ["seed", "series_a", "series_b"]}`
+
+### Step 3: Convert Natural Language to Structured Filters
+
+If you want structured params from a description:
 
 ```bash
-orth api run brand-dev /v1/brand/retrieve --query 'domain=stripe.com'
+orth api run fiber /v1/text-to-search-params/companies --body '{
+  "query": "AI startups in the US with 50+ employees hiring for Machine Learning Engineers"
+}'
 ```
 
-### Step 4: Find Hiring Managers
-Find people at the company to network with:
+This returns a structured `searchParams` object you can use directly in `/v1/company-search`.
+
+### Step 4: Research Companies
+
+Get detailed info on interesting companies:
+
+```bash
+orth api run fiber /v1/kitchen-sink/company --body '{
+  "companyIdentifier": "https://linkedin.com/company/anthropic"
+}'
+```
+
+### Step 5: Find Hiring Managers
+
+Find people at target companies:
 
 ```bash
 orth api run fiber /v1/people-search --body '{
   "searchParams": {
-    "company_names": ["Stripe"],
-    "job_titles": ["Engineering Manager", "VP Engineering", "CTO"]
-  }
+    "jobTitleV3": {
+      "anyOf": [
+        {"type": "plain", "term": "Engineering Manager"},
+        {"type": "plain", "term": "VP Engineering"}
+      ]
+    }
+  },
+  "currentCompanies": [{"identifier": "domain", "domain": "anthropic.com"}],
+  "pageSize": 10
 }'
 ```
 
-### Step 5: Get Contact Info
+### Step 6: Get Contact Info
+
 Find email for outreach:
 
 ```bash
-orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
+orth api run hunter /v2/email-finder --query 'domain=anthropic.com&first_name=John&last_name=Doe'
 ```
 
-## Example Usage
+## Examples
 
 ```bash
-# Search for remote AI jobs
-orth api run fiber /v1/job-search --body '{
+# Find companies hiring GTM Engineers in SF
+orth api run fiber /v1/company-search --body '{
   "searchParams": {
-    "job_titles": ["Machine Learning Engineer", "AI Engineer"],
-    "locations": ["Remote"],
-    "keywords": ["LLM", "generative AI"]
-  }
+    "jobPostingsV2": {
+      "allOf": [{
+        "jobTitle": ["GTM Engineer", "Go-To-Market Engineer", "Growth Engineer"],
+        "jobPostingStatus": "active",
+        "countryOrRegionCode": ["USA"]
+      }]
+    },
+    "headquartersLocation": {
+      "unionAll": [{
+        "strategy": "radial-distance",
+        "center": {"latitude": 37.7749, "longitude": -122.4194},
+        "radius": {"unit": "miles", "quantity": 50}
+      }]
+    }
+  },
+  "pageSize": 25
 }'
 
-# Research a company
+# Find remote AI/ML jobs at well-funded startups
+orth api run fiber /v1/company-search --body '{
+  "searchParams": {
+    "jobPostingsV2": {
+      "allOf": [{
+        "jobTitle": ["Machine Learning Engineer", "AI Engineer"],
+        "jobPostingStatus": "active",
+        "jobLocationType": ["Remote"],
+        "keywords": ["LLM", "generative AI"]
+      }]
+    },
+    "stage": {"anyOf": ["series_a", "series_b", "series_c"]},
+    "industriesV2": {"anyOf": ["Artificial Intelligence", "Software"]}
+  },
+  "pageSize": 25
+}'
+
+# Quick natural language search
 orth api run fiber /v1/natural-language-search/companies --body '{
-  "query": "Tell me about Anthropic - funding, team size, culture"
+  "query": "YC startups hiring senior backend engineers, remote OK"
 }'
 ```
 
 ## Tips
 
-- Customize your search for each application
-- Research company culture before applying
-- Network with people at target companies
-- Set up alerts for new postings
+- Use `allOf` when ALL conditions must match, `anyOf` when ANY condition can match
+- Use `noneOf` to exclude (e.g. exclude closed positions)
+- Paginate with `cursor` from previous response
+- Use `text-to-search-params` to validate your filters before running full search
+- The natural language endpoint is great for quick searches; structured search gives more control
 
 ## Discover More
 
-List all endpoints, or add a path for parameter details:
-
 ```bash
-orth api show brand-dev
-orth api show fiber
-orth api show hunter 
+orth api show fiber              # List all endpoints
+orth api show fiber /v1/company-search   # Get endpoint details
 ```
-
-Example: `orth api show olostep /v1/scrapes` for endpoint parameters.


### PR DESCRIPTION
## Problem

The `orthogonal-job-search` and `orthogonal-fiber` skills had fabricated field names that don't match Fiber's actual Zod-validated API schema, causing 400 errors on every call. Fields like `job_titles`, `locations`, `keywords`, `industries`, `employee_count_min` don't exist in Fiber's API.

## Root Cause

Fiber uses strict Zod validation with `additionalProperties: false`, so any unrecognized key in `searchParams` returns a 400. The skills were written with guessed field names instead of the actual OpenAPI schema.

Additionally, `/v1/job-search` is not documented in Fiber's public OpenAPI spec. The endpoint exists but its schema is unknown.

## Changes

### `orthogonal-job-search`
- Rewritten to use `/v1/company-search` with `jobPostingsV2` filter (documented and working)
- Added `/v1/natural-language-search/companies` as quick alternative
- Documented all `jobPostingsV2` filter fields with correct types
- Added examples for combining job filters with company filters

### `orthogonal-fiber`
- Fixed company-search example: `industries` → `industriesV2`, `employee_count_min/max` → `employeeCountV2`
- Fixed people-search example: `job_titles` → `jobTitleV3`, `locations` → `location` with proper radial-distance structure
- Updated job postings section to use `company-search` with `jobPostingsV2` instead of undocumented `/v1/job-search`
- Added key searchParams field reference with correct types

## Testing

Verified against Fiber's OpenAPI spec at `https://api.fiber.ai/openapi.json` that all field names match the documented schema.