### PR TITLE
Add yc-batch-evaluator skill

### DIFF
--- a/skills/orthogonal-yc-batch-evaluator/SKILL.md
+++ b/skills/orthogonal-yc-batch-evaluator/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: yc-batch-evaluator
-description: Evaluate YC batch companies for investment — scrapes the YC directory, researches each company and its founders (work history, LinkedIn, website), assesses founder-company fit, and exports to Google Sheets. Use when asked to evaluate YC companies, research a YC batch, screen startups, or do due diligence on YC companies.
+description: Evaluate YC batch companies for investment — scrapes the YC directory, researches each company and its founders (work history, LinkedIn, website), assesses founder-company fit, and exports to Google Sheets with priority rankings. Use when asked to evaluate YC companies, research a YC batch, screen startups, or do due diligence on YC companies.
 ---
 
 # YC Batch Evaluator
 
-Scrape a YC batch, research every company and founder, assess founder-company fit, and export a live-updating Google Sheet. Designed for investors evaluating YC companies.
+Scrape a YC batch, research every company and founder, assess founder-company fit, and export a live-updating Google Sheet with priority rankings. Designed for investors evaluating YC companies.
 
 ## Input
 
 - **batch** (optional) — defaults to "Spring 2026". Examples: "Winter 2026", "Summer 2025"
 - **sectors** (optional) — filter to specific sectors (e.g. "AI", "fintech", "infrastructure")
-- **thesis** (optional) — investor's focus areas for tailored scoring
+- **thesis** (optional) — investor's focus areas for tailored scoring and ranking
 
 ## Step 1: Scrape the YC Batch Directory
 
@@ -43,21 +43,21 @@ orth run google-sheets /update-values --body '{
   "first_cell_location": "A1",
   "valueInputOption": "USER_ENTERED",
   "values": [
-    ["Company", "Description", "Sector", "Location", "Website", "Founders", "Founder LinkedIn(s)", "Founder Twitter/X", "Founder Background", "Founder-Company Fit", "Website Analysis", "Market/Competitors", "Overall Assessment"],
-    ["{company_name}", "{description}", "{sectors}", "{location}", "", "", "", "", "", "", "", "", ""]
+    ["Company", "Description", "Sector", "Location", "Website", "Founders", "Founder LinkedIn(s)", "Founder Twitter/X", "Founder Background", "Founder-Company Fit", "Website Analysis", "Market/Competitors", "Overall Assessment", "Priority Rank"],
+    ["{company_name}", "{description}", "{sectors}", "{location}", "", "", "", "", "", "", "", "", "", ""]
   ]
 }'
 ```
 
-**Share the sheet link with the user immediately.**
+**Share the sheet link with the user immediately** so they can watch it fill in.
 
-## Step 3: Research Each Company
+## Step 3: Research Each Company — Row by Row
 
-Run ALL of these in parallel per company. Process multiple companies simultaneously.
+Process one company at a time. For each company, run all research calls in parallel, then compile the results and **update that company's row immediately** before moving to the next. This lets the user watch the sheet fill in live — much more impressive than batching everything.
 
 ### 3a. Scrape the YC company page (~$0.03)
 
-YC company pages are rich: founders with LinkedIn, Twitter/X, bios, team size, sectors.
+YC company pages have rich data: founders with LinkedIn, Twitter/X, bios, team size, sectors, website.
 
 ```bash
 orth run scrapegraph /v1/smartscraper --body '{
@@ -65,6 +65,12 @@ orth run scrapegraph /v1/smartscraper --body '{
   "user_prompt": "Extract: full company description, all founders (full name, title, LinkedIn URL, Twitter/X URL, bio), company website URL, team size, location, sectors, founding year."
 }'
 ```
+
+**Important parsing notes:**
+- Website field may be `website_url`, `company_website_url`, or `company_website` — check all.
+- Sectors may be `sectors`, `sector_tags`, or `tags` — check all. Use the individual page data (richer) over the batch page data.
+- **Filter out YC partners** from the founders list. If title contains "Primary Partner" or "Group Partner", exclude them — they're YC staff, not founders.
+- Location from the individual page is often more specific than the batch page.
 
 ### 3b. Scrape the company's own website (~$0.03)
 
@@ -75,22 +81,22 @@ orth run scrapegraph /v1/smartscraper --body '{
 }'
 ```
 
-Skip on error (some early-stage companies may not have a website yet).
+Skip on error — some early-stage companies may not have a website yet.
 
 ### 3c. Apollo — founder work history (~$0.01 per founder)
 
-Use the LinkedIn slug from the YC page to get full employment history.
+Use the LinkedIn URL from the YC page to get full employment history.
 
 ```bash
 orth run apollo /api/v1/people/match --body '{
-  "linkedin_url": "https://linkedin.com/in/{founder_linkedin_slug}",
+  "linkedin_url": "{founder_linkedin_url}",
   "reveal_personal_emails": true
 }'
 ```
 
 Returns: employment history (companies, titles, dates), education, current role. This is the key input for founder-company fit.
 
-**No LinkedIn slug?** Try matching by name + company:
+**No LinkedIn URL on YC page?** Fallback — search by name + company:
 
 ```bash
 orth run apollo /api/v1/mixed_people/search --body '{
@@ -101,6 +107,8 @@ orth run apollo /api/v1/mixed_people/search --body '{
 }'
 ```
 
+This usually returns their LinkedIn and work history even when the YC page doesn't list it.
+
 ### 3d. Perplexity — market context (~$0.005)
 
 ```bash
@@ -110,9 +118,19 @@ orth run perplexity /chat/completions --body '{
 }'
 ```
 
-## Step 4: Evaluate and Update Sheet Row-by-Row
+## Step 4: Update Each Row Immediately After Research
 
-As each company's research completes, immediately update its row. Don't wait for all companies.
+After all research for a company completes, immediately update that row in the sheet before moving to the next company. This creates the live-filling effect.
+
+### Links — use HYPERLINK formulas
+
+All URLs should be clickable. Use `=HYPERLINK()` formulas:
+
+- **Website**: `=HYPERLINK("https://example.com","example.com")`
+- **Founder LinkedIn**: One `=HYPERLINK()` per founder, each on its own line within the cell: `=HYPERLINK("https://linkedin.com/in/slug","Founder Name")`
+- **Founder Twitter/X**: Same format as LinkedIn.
+
+If there are multiple founders, put each HYPERLINK on a separate line within the same cell using `\n`.
 
 ### Founder-Company Fit (Strong / Moderate / Weak)
 
@@ -131,7 +149,11 @@ Assess whether the founders' backgrounds make them uniquely suited to build THIS
 
 Consider: founder-company fit, market size, competitive landscape, team completeness, product clarity.
 
-If the investor provided a thesis, weight the assessment toward their focus areas.
+If the investor provided a thesis, weight the assessment heavily toward their focus areas.
+
+### Priority Rank
+
+Rank all companies 1 to N. #1 is the strongest overall. If the investor has a thesis, rank according to thesis fit. If no thesis provided, rank on general investment quality (founder-company fit × market size × team strength).
 
 ```bash
 orth run google-sheets /update-values --body '{
@@ -139,14 +161,29 @@ orth run google-sheets /update-values --body '{
   "sheet_name": "Sheet1",
   "first_cell_location": "E{row_number}",
   "valueInputOption": "USER_ENTERED",
-  "values": [["{website}", "{founders}", "{linkedin_urls}", "{twitter_urls}", "{background}", "{fit_rating}", "{website_analysis}", "{market}", "{overall}"]]
+  "values": [["=HYPERLINK(\"https://{website}\",\"{domain}\")", "{founders}", "=HYPERLINK(\"...\",\"Name\")", "=HYPERLINK(\"...\",\"Name\")", "{background}", "{fit_rating}", "{website_analysis}", "{market}", "{overall}", "{rank}"]]
 }'
+```
+
+## Step 5: Final Summary
+
+After all companies are researched and ranked, output a summary table:
+
+```
+Top 5 Priority Companies:
+1. {Company} — {one-line why}
+2. ...
+
+Companies to Skip:
+- {Company} — {one-line why}
 ```
 
 ## Tips
 
-- **Parallelize aggressively**: All 4 research calls per company are independent. Process multiple companies at once.
-- **Update the sheet as you go**: Each row update takes <1 second. Don't batch — the investor wants to see it fill in live.
-- **Skip gracefully**: If a company website 404s or Apollo returns nothing, still fill what you have. Partial data > empty row.
-- **Founder LinkedIn is the most valuable signal**: Employment history directly feeds the founder-company fit assessment.
-- **Be honest**: If founders have no relevant experience, say so. If the market is tiny, say so. Investors value honesty over hype.
+- **Row by row, not batch**: Research one company → update its row → move to next. The live-fill effect is the demo.
+- **Parallelize within each company**: All 4 research calls (YC page, website, Apollo, Perplexity) for a single company run in parallel.
+- **Filter out YC partners**: Tom Blomfield, Harj Taggar, etc. appear as "Primary Partner" on company pages — they're YC staff, not founders.
+- **Check multiple field names**: Scrapegraph returns different field names depending on the page. Always check `website_url`, `company_website_url`, `company_website` for websites; `sectors`, `sector_tags`, `tags` for sectors.
+- **Apollo fallback for missing LinkedIn**: If a founder has no LinkedIn on the YC page, use Apollo's `mixed_people/search` with name + company name. This usually finds them.
+- **HYPERLINK formulas for all URLs**: Makes the sheet immediately usable. `=HYPERLINK("url","display text")`.
+- **Be honest**: If founders have no relevant experience, say so. If the market is tiny, say so. Investors value honest assessments over hype.

--- a/skills/orthogonal-yc-batch-evaluator/SKILL.md
+++ b/skills/orthogonal-yc-batch-evaluator/SKILL.md
@@ -93,25 +93,21 @@ Populate Sector (C) and Location (D) from the batch scrape initially — they'll
 
 **Share the sheet link with the user immediately** so they can watch it fill in.
 
-## Step 3: Research All Companies
+## Step 3: Research Each Company — Row by Row
 
 ### Parallelization Strategy
 
-Speed matters for a live demo. Do NOT process one company at a time. Use this phased approach:
+The investor watches the sheet fill in live. **Parallelize within each company, not across companies.** Process one company at a time so each row appears fully filled every ~5-10 seconds.
 
-**Phase 1 — Scrape all individual YC pages (parallel)**
-Run all YC page scrapes in parallel (batches of 10-11 if needed). This gets you founders, LinkedIn URLs, company websites, and detailed sectors for every company.
+For each company:
+1. **Scrape the YC company page** (Step 3a) — must run first, gives you founders, LinkedIn URLs, company website
+2. **In parallel**, run all three downstream calls:
+   - Scrape the company's website (Step 3b)
+   - Apollo lookup for each founder (Step 3c) — multiple calls if multiple founders, all in parallel
+   - Perplexity market analysis (Step 3d)
+3. **Compile results and update the row** (Step 4) — immediately, before moving to the next company
 
-**Phase 2 — Run all downstream research in parallel**
-Once you have founder LinkedIn URLs and company websites from Phase 1, launch ALL of these simultaneously:
-- All company website scrapes (Step 3b) — in parallel
-- All Apollo founder lookups (Step 3c) — in parallel (may be 30-50 calls if companies have 2-3 founders each)
-- All Perplexity market analyses (Step 3d) — in parallel
-
-**Phase 3 — Compile and update rows**
-As each company's full research set completes, immediately update its row in the sheet. Don't wait for all companies to finish.
-
-This approach completes ~22 companies in 1-2 minutes vs 10+ minutes if done sequentially.
+This gives a steady cadence of rows appearing in the sheet. The investor sees progress every few seconds instead of waiting for everything at once.
 
 ### 3a. Scrape the YC company page (~$0.03 each)
 

--- a/skills/orthogonal-yc-batch-evaluator/SKILL.md
+++ b/skills/orthogonal-yc-batch-evaluator/SKILL.md
@@ -43,8 +43,8 @@ orth run google-sheets /update-values --body '{
   "first_cell_location": "A1",
   "valueInputOption": "USER_ENTERED",
   "values": [
-    ["Company", "Description", "Sector", "Location", "Website", "Founders", "Founder LinkedIn(s)", "Founder Twitter/X", "Founder Background", "Founder-Company Fit", "Website Analysis", "Market/Competitors", "Overall Assessment", "Priority Rank"],
-    ["{company_name}", "{description}", "{sectors}", "{location}", "", "", "", "", "", "", "", "", "", ""]
+    ["Priority Rank", "Company", "Description", "Sector", "Location", "Website", "Founders", "Founder LinkedIn(s)", "Founder Twitter/X", "Founder Background", "Founder-Company Fit", "Website Analysis", "Market/Competitors", "Overall Assessment"],
+    ["", "{company_name}", "{description}", "{sectors}", "{location}", "", "", "", "", "", "", "", "", ""]
   ]
 }'
 ```
@@ -53,7 +53,7 @@ orth run google-sheets /update-values --body '{
 
 ## Step 3: Research Each Company — Row by Row
 
-Process one company at a time. For each company, run all research calls in parallel, then compile the results and **update that company's row immediately** before moving to the next. This lets the user watch the sheet fill in live — much more impressive than batching everything.
+Process one company at a time. For each company, run all 4 research calls in parallel, then compile the results and **update that company's row immediately** before moving to the next. This lets the user watch the sheet fill in live.
 
 ### 3a. Scrape the YC company page (~$0.03)
 
@@ -66,22 +66,24 @@ orth run scrapegraph /v1/smartscraper --body '{
 }'
 ```
 
-**Important parsing notes:**
-- Website field may be `website_url`, `company_website_url`, or `company_website` — check all.
-- Sectors may be `sectors`, `sector_tags`, or `tags` — check all. Use the individual page data (richer) over the batch page data.
-- **Filter out YC partners** from the founders list. If title contains "Primary Partner" or "Group Partner", exclude them — they're YC staff, not founders.
+**Parsing notes:**
+- Website field may be `website_url`, `company_website_url`, or `company_website` — check all three.
+- Sectors may be `sectors`, `sector_tags`, or `tags` — check all three. Individual page data is richer than batch data.
+- **Filter out YC partners**: If title contains "Primary Partner" or "Group Partner", exclude them — they're YC staff, not founders.
 - Location from the individual page is often more specific than the batch page.
 
 ### 3b. Scrape the company's own website (~$0.03)
 
+**Always run this step.** It provides product details, traction signals, and customer info that no other source has.
+
 ```bash
 orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://{company_website}",
-  "user_prompt": "Extract: what the product does, target customer, pricing model, key features, traction signals (customer logos, metrics, testimonials), hiring signals, tech stack."
+  "user_prompt": "Extract: what the product does, target customer, pricing model, key features, traction signals (customer logos, metrics, testimonials), hiring signals, tech stack. Be specific about what you find."
 }'
 ```
 
-Skip on error — some early-stage companies may not have a website yet.
+If the scrape fails (404, timeout), note "Website not available" in the Website Analysis column — don't leave it blank.
 
 ### 3c. Apollo — founder work history (~$0.01 per founder)
 
@@ -94,7 +96,7 @@ orth run apollo /api/v1/people/match --body '{
 }'
 ```
 
-Returns: employment history (companies, titles, dates), education, current role. This is the key input for founder-company fit.
+Returns: employment history (companies, titles, dates), education, current role, **city/state/country**. Use the city/state as a fallback for company location if the YC page doesn't list one.
 
 **No LinkedIn URL on YC page?** Fallback — search by name + company:
 
@@ -118,23 +120,25 @@ orth run perplexity /chat/completions --body '{
 }'
 ```
 
-## Step 4: Update Each Row Immediately After Research
+## Step 4: Compile and Update Row
 
-After all research for a company completes, immediately update that row in the sheet before moving to the next company. This creates the live-filling effect.
+After all 4 research calls complete for a company, compile the results and update that row.
 
-### Links — use HYPERLINK formulas
+### Links — plain URLs, not HYPERLINK formulas
 
-All URLs should be clickable. Use `=HYPERLINK()` formulas:
+Google Sheets cannot have multiple `=HYPERLINK()` formulas in one cell (extras show as FALSE). Instead:
 
-- **Website**: `=HYPERLINK("https://example.com","example.com")`
-- **Founder LinkedIn**: One `=HYPERLINK()` per founder, each on its own line within the cell: `=HYPERLINK("https://linkedin.com/in/slug","Founder Name")`
-- **Founder Twitter/X**: Same format as LinkedIn.
+- **Website**: Put the plain URL — Sheets auto-linkifies single URLs.
+- **Founder LinkedIn**: One URL per line. If multiple founders, separate with newlines. Sheets auto-linkifies each.
+- **Founder Twitter/X**: Same — one URL per line.
 
-If there are multiple founders, put each HYPERLINK on a separate line within the same cell using `\n`.
+### Location fallback
+
+If the YC page has no location, use the founder's city/state from Apollo (`person.city`, `person.state`). Use the first founder's location as the company location.
 
 ### Founder-Company Fit (Strong / Moderate / Weak)
 
-Assess whether the founders' backgrounds make them uniquely suited to build THIS specific company.
+Assess whether the founders' backgrounds make them uniquely suited to build THIS specific company. YC selects well, so most founders will have decent fit — but be specific about what makes the fit strong or where there are gaps.
 
 **Strong** — Direct domain expertise in the problem they're solving.
 > "Strong — CEO spent 5 years at Stripe building payment APIs, now building payment infrastructure. Deep domain match."
@@ -142,48 +146,59 @@ Assess whether the founders' backgrounds make them uniquely suited to build THIS
 **Moderate** — Strong technical background but limited domain experience.
 > "Moderate — both founders are strong engineers (Google, Amazon) but no direct healthcare experience for a healthcare product."
 
-**Weak** — No relevant background for the space.
-> "Weak — first-time founders with no background in manufacturing or supply chain."
+**Weak** — No relevant background for the space, or very thin visible track record.
+> "Weak — general engineering background with no visible agent infrastructure or protocol experience for an agent communication platform."
+
+### Website Analysis
+
+Summarize what you found from scraping the company's website. Include: product description, target customer, any traction signals (customer logos, metrics), pricing model. If the website is pre-launch or thin, say so.
 
 ### Overall Assessment (High Priority / Interesting / Pass)
 
-Consider: founder-company fit, market size, competitive landscape, team completeness, product clarity.
+Consider: founder-company fit, market size, competitive landscape, team completeness, product clarity, website maturity.
 
 If the investor provided a thesis, weight the assessment heavily toward their focus areas.
 
 ### Priority Rank
 
-Rank all companies 1 to N. #1 is the strongest overall. If the investor has a thesis, rank according to thesis fit. If no thesis provided, rank on general investment quality (founder-company fit × market size × team strength).
+Rank all companies 1 to N. #1 is the strongest overall.
+
+- **With thesis**: Rank by thesis alignment (stage, sector, geography fit).
+- **Without thesis**: Rank on general investment quality = founder-company fit × market size × team strength.
 
 ```bash
 orth run google-sheets /update-values --body '{
   "spreadsheet_id": "{spreadsheet_id}",
   "sheet_name": "Sheet1",
-  "first_cell_location": "E{row_number}",
+  "first_cell_location": "A{row_number}",
   "valueInputOption": "USER_ENTERED",
-  "values": [["=HYPERLINK(\"https://{website}\",\"{domain}\")", "{founders}", "=HYPERLINK(\"...\",\"Name\")", "=HYPERLINK(\"...\",\"Name\")", "{background}", "{fit_rating}", "{website_analysis}", "{market}", "{overall}", "{rank}"]]
+  "values": [["{rank}", "{company}", "{desc}", "{sectors}", "{location}", "{website}", "{founders}", "{linkedins}", "{twitters}", "{background}", "{fit}", "{website_analysis}", "{market}", "{overall}"]]
 }'
 ```
 
-## Step 5: Final Summary
+## Step 5: Re-sort and Final Summary
 
-After all companies are researched and ranked, output a summary table:
+After all companies are researched, re-sort the sheet by Priority Rank (column A) so the best companies are at the top. Then output a summary:
 
 ```
-Top 5 Priority Companies:
+Top Priority:
 1. {Company} — {one-line why}
 2. ...
 
-Companies to Skip:
+Worth a Look:
+- {Company} — {one-line why}
+
+Skip:
 - {Company} — {one-line why}
 ```
 
 ## Tips
 
-- **Row by row, not batch**: Research one company → update its row → move to next. The live-fill effect is the demo.
-- **Parallelize within each company**: All 4 research calls (YC page, website, Apollo, Perplexity) for a single company run in parallel.
-- **Filter out YC partners**: Tom Blomfield, Harj Taggar, etc. appear as "Primary Partner" on company pages — they're YC staff, not founders.
-- **Check multiple field names**: Scrapegraph returns different field names depending on the page. Always check `website_url`, `company_website_url`, `company_website` for websites; `sectors`, `sector_tags`, `tags` for sectors.
-- **Apollo fallback for missing LinkedIn**: If a founder has no LinkedIn on the YC page, use Apollo's `mixed_people/search` with name + company name. This usually finds them.
-- **HYPERLINK formulas for all URLs**: Makes the sheet immediately usable. `=HYPERLINK("url","display text")`.
-- **Be honest**: If founders have no relevant experience, say so. If the market is tiny, say so. Investors value honest assessments over hype.
+- **Row by row, not batch**: Research one company → update its row → move to next. The live-fill effect is the point.
+- **Parallelize within each company**: All 4 research calls (YC page, website, Apollo, Perplexity) run in parallel per company.
+- **Never leave Website Analysis blank**: Either summarize what you found or note "Website not available / pre-launch".
+- **Filter out YC partners**: Tom Blomfield, Harj Taggar, etc. appear as "Primary Partner" on company pages — exclude them from the founders list.
+- **Check multiple field names**: Scrapegraph returns varying field names. Always check `website_url` / `company_website_url` / `company_website` for websites; `sectors` / `sector_tags` / `tags` for sectors.
+- **Apollo for missing data**: Use Apollo `city`/`state` as location fallback. Use `mixed_people/search` as LinkedIn fallback.
+- **Plain URLs, not HYPERLINK formulas**: Multiple HYPERLINKs in one cell causes FALSE. Plain URLs auto-linkify in Sheets.
+- **Be honest and specific**: Reference the actual founder backgrounds, not generic assessments. If the market is tiny, say so. Investors value honesty.

--- a/skills/orthogonal-yc-batch-evaluator/SKILL.md
+++ b/skills/orthogonal-yc-batch-evaluator/SKILL.md
@@ -15,6 +15,8 @@ Scrape a YC batch, research every company and founder, assess founder-company fi
 
 ## Step 1: Scrape the YC Batch Directory
 
+The YC companies page is JavaScript-rendered (Algolia-powered). Scrapegraph handles the JS rendering.
+
 ```bash
 orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://www.ycombinator.com/companies?batch={batch_url_encoded}",
@@ -26,13 +28,51 @@ Batch URL encoding: "Spring 2026" → `Spring%202026`, "Winter 2026" → `Winter
 
 If the investor specified sectors, filter the list. Otherwise process all companies.
 
+**Expected response structure:**
+```json
+{
+  "result": {
+    "companies": [
+      {
+        "name": "Indexable",
+        "description": "sandbox infrastructure for AI agents",
+        "tags": ["B2B", "Infrastructure"],
+        "location": "San Francisco, CA, USA",
+        "url_slug": "/companies/indexable"
+      }
+    ]
+  }
+}
+```
+
+Note: The batch page returns `tags` (e.g. "B2B", "Infrastructure"), NOT detailed sectors. Individual YC pages (Step 3a) return richer `sectors` (e.g. "Artificial Intelligence", "Manufacturing"). Always prefer individual page data when available.
+
 ## Step 2: Create Google Sheet and Share Link Immediately
 
-Before any research, create the sheet and populate it with company names + descriptions. Share the link so the investor can watch results fill in live.
+Before any research, create the sheet and populate it with company names + descriptions from the batch scrape. Share the link so the investor can watch results fill in live.
 
 ```bash
 orth run google-sheets /create-spreadsheet --body '{"title": "YC {batch} Batch Evaluation"}'
 ```
+
+**Column layout (A through N):**
+
+| Col | Header | Source |
+|-----|--------|--------|
+| A | Company | Batch scrape |
+| B | Description | Batch scrape |
+| C | Sector | Individual YC page (`sectors`) — overwrite batch `tags` |
+| D | Location | Individual YC page → Apollo fallback |
+| E | Website | Individual YC page (`website_url`) |
+| F | Founders | Individual YC page (names + titles) |
+| G | Founder LinkedIn(s) | Individual YC page (`linkedin_url`) |
+| H | Founder Twitter/X | Individual YC page (`twitter_url`) |
+| I | Founder Background | Apollo employment history + YC page bios |
+| J | Founder-Company Fit | Your assessment |
+| K | Website Analysis | Company website scrape |
+| L | Market/Competitors | Perplexity |
+| M | Overall Assessment | Your assessment |
+| N | Priority Rank | Your ranking |
 
 Write header row + all company rows (research columns blank):
 
@@ -43,21 +83,39 @@ orth run google-sheets /update-values --body '{
   "first_cell_location": "A1",
   "valueInputOption": "USER_ENTERED",
   "values": [
-    ["Priority Rank", "Company", "Description", "Sector", "Location", "Website", "Founders", "Founder LinkedIn(s)", "Founder Twitter/X", "Founder Background", "Founder-Company Fit", "Website Analysis", "Market/Competitors", "Overall Assessment"],
-    ["", "{company_name}", "{description}", "{sectors}", "{location}", "", "", "", "", "", "", "", "", ""]
+    ["Company", "Description", "Sector", "Location", "Website", "Founders", "Founder LinkedIn(s)", "Founder Twitter/X", "Founder Background", "Founder-Company Fit", "Website Analysis", "Market/Competitors", "Overall Assessment", "Priority Rank"],
+    ["{company_name}", "{description}", "{tags}", "{location}", "", "", "", "", "", "", "", "", "", ""]
   ]
 }'
 ```
 
+Populate Sector (C) and Location (D) from the batch scrape initially — they'll be overwritten with richer data from the individual YC pages.
+
 **Share the sheet link with the user immediately** so they can watch it fill in.
 
-## Step 3: Research Each Company — Row by Row
+## Step 3: Research All Companies
 
-Process one company at a time. For each company, run all 4 research calls in parallel, then compile the results and **update that company's row immediately** before moving to the next. This lets the user watch the sheet fill in live.
+### Parallelization Strategy
 
-### 3a. Scrape the YC company page (~$0.03)
+Speed matters for a live demo. Do NOT process one company at a time. Use this phased approach:
 
-YC company pages have rich data: founders with LinkedIn, Twitter/X, bios, team size, sectors, website.
+**Phase 1 — Scrape all individual YC pages (parallel)**
+Run all YC page scrapes in parallel (batches of 10-11 if needed). This gets you founders, LinkedIn URLs, company websites, and detailed sectors for every company.
+
+**Phase 2 — Run all downstream research in parallel**
+Once you have founder LinkedIn URLs and company websites from Phase 1, launch ALL of these simultaneously:
+- All company website scrapes (Step 3b) — in parallel
+- All Apollo founder lookups (Step 3c) — in parallel (may be 30-50 calls if companies have 2-3 founders each)
+- All Perplexity market analyses (Step 3d) — in parallel
+
+**Phase 3 — Compile and update rows**
+As each company's full research set completes, immediately update its row in the sheet. Don't wait for all companies to finish.
+
+This approach completes ~22 companies in 1-2 minutes vs 10+ minutes if done sequentially.
+
+### 3a. Scrape the YC company page (~$0.03 each)
+
+YC company pages are server-rendered and contain rich data: founders with LinkedIn, Twitter/X, bios, team size, sectors, website.
 
 ```bash
 orth run scrapegraph /v1/smartscraper --body '{
@@ -66,28 +124,83 @@ orth run scrapegraph /v1/smartscraper --body '{
 }'
 ```
 
-**Parsing notes:**
-- Website field may be `website_url`, `company_website_url`, or `company_website` — check all three.
-- Sectors may be `sectors`, `sector_tags`, or `tags` — check all three. Individual page data is richer than batch data.
-- **Filter out YC partners**: If title contains "Primary Partner" or "Group Partner", exclude them — they're YC staff, not founders.
-- Location from the individual page is often more specific than the batch page.
+**Expected response structure:**
+```json
+{
+  "result": {
+    "founders": [
+      {
+        "full_name": "William Alexander",
+        "title": "Founder",
+        "linkedin_url": "https://www.linkedin.com/in/william--alexander/",
+        "twitter_url": null,
+        "bio": "Manufacturing nerd from Iowa. Stanford Econ + CS."
+      },
+      {
+        "full_name": "Tom Blomfield",
+        "title": "Primary Partner",
+        "linkedin_url": null,
+        "twitter_url": null,
+        "bio": null
+      }
+    ],
+    "website_url": "https://arzana.ai",
+    "location": "San Francisco, CA, US",
+    "sectors": ["Artificial Intelligence", "Manufacturing"],
+    "team_size": 4,
+    "founding_year": 2025
+  }
+}
+```
 
-### 3b. Scrape the company's own website (~$0.03)
+**Critical parsing rules:**
 
-**Always run this step.** It provides product details, traction signals, and customer info that no other source has.
+1. **Filter out YC partners**: Entries with title "Primary Partner" or "Group Partner" are YC staff (e.g. Tom Blomfield, Harj Taggar), NOT founders. Exclude them.
+
+2. **Website field name varies**: Check `website_url`, `company_website_url`, and `company_website` — Scrapegraph returns different field names depending on the page.
+
+3. **Sectors field name varies**: Check `sectors`, `sector_tags`, and `tags`. Prefer the individual page's `sectors` over the batch page's `tags` — individual pages return specific sectors like "Artificial Intelligence" vs generic tags like "B2B".
+
+4. **LinkedIn URL may be null**: Some founders don't have LinkedIn listed on YC. Use Apollo fallback (Step 3c) with name + company search.
+
+5. **Twitter/X URL may be null**: Only populate if present, don't invent URLs.
+
+### 3b. Scrape the company's own website (~$0.03 each)
+
+**Always run this step.** Company websites have product details, pricing, customer logos, testimonials, and hiring signals that no other source provides.
 
 ```bash
 orth run scrapegraph /v1/smartscraper --body '{
   "website_url": "https://{company_website}",
-  "user_prompt": "Extract: what the product does, target customer, pricing model, key features, traction signals (customer logos, metrics, testimonials), hiring signals, tech stack. Be specific about what you find."
+  "user_prompt": "Extract: what the product does, target customer, pricing model, key features, traction signals (customer logos, metrics, testimonials), hiring signals. Be specific about what you find."
 }'
 ```
 
-If the scrape fails (404, timeout), note "Website not available" in the Website Analysis column — don't leave it blank.
+**Expected response — varies by company, but typically includes:**
+```json
+{
+  "result": {
+    "product_description": "...",
+    "target_customer": "..." or ["...", "..."],
+    "pricing": "Not disclosed" or {"model": "...", "price": "..."},
+    "key_features": ["...", "..."],
+    "traction_signals": {
+      "customer_logos": ["Heineken", "Toyota", "..."],
+      "metrics": ["99.7% accuracy", "25K patients/day"],
+      "testimonials": [{"author": "...", "quote": "..."}]
+    },
+    "hiring_signals": ["Careers page present"]
+  }
+}
+```
+
+Note: The response structure varies significantly between companies. The `traction_signals` field is sometimes called `traction`. Customer logos may be actual names or just "logos displayed but not identified". Pricing may be a string, object, or array. Parse flexibly.
+
+If the scrape fails (404, timeout, empty), put "Website not available or pre-launch" in the Website Analysis column — never leave it blank.
 
 ### 3c. Apollo — founder work history (~$0.01 per founder)
 
-Use the LinkedIn URL from the YC page to get full employment history.
+Use the LinkedIn URL from the YC page to get full employment history. Run one call per founder.
 
 ```bash
 orth run apollo /api/v1/people/match --body '{
@@ -96,7 +209,38 @@ orth run apollo /api/v1/people/match --body '{
 }'
 ```
 
-Returns: employment history (companies, titles, dates), education, current role, **city/state/country**. Use the city/state as a fallback for company location if the YC page doesn't list one.
+**Key fields in the Apollo response:**
+```json
+{
+  "person": {
+    "name": "William Alexander",
+    "headline": "Co-Founder & CEO, Arzana | Stanford Economics + CS",
+    "city": "San Francisco",
+    "state": "California",
+    "employment_history": [
+      {
+        "organization_name": "Arzana",
+        "title": "Co-Founder",
+        "start_date": "2025-06-01",
+        "end_date": null,
+        "current": true
+      },
+      {
+        "organization_name": "Previous Company",
+        "title": "Engineer",
+        "start_date": "2022-01-01",
+        "end_date": "2025-05-01",
+        "current": false
+      }
+    ]
+  }
+}
+```
+
+**What to extract:**
+- `person.employment_history[]` — the key input for Founder Background and Founder-Company Fit. Look at `organization_name`, `title`, and dates.
+- `person.city` + `person.state` — use as **location fallback** if the YC page didn't have a location.
+- `person.headline` — often has a concise summary of their background.
 
 **No LinkedIn URL on YC page?** Fallback — search by name + company:
 
@@ -109,9 +253,11 @@ orth run apollo /api/v1/mixed_people/search --body '{
 }'
 ```
 
-This usually returns their LinkedIn and work history even when the YC page doesn't list it.
+This usually returns their LinkedIn and work history even when the YC page doesn't list it. Results are in `people[0]` with same structure as above.
 
-### 3d. Perplexity — market context (~$0.005)
+### 3d. Perplexity — market context (~$0.005 each)
+
+Include rich context in the prompt — company description and founder bios. Generic prompts like "tell me about {company}" return generic results.
 
 ```bash
 orth run perplexity /chat/completions --body '{
@@ -120,85 +266,161 @@ orth run perplexity /chat/completions --body '{
 }'
 ```
 
-## Step 4: Compile and Update Row
+**Response parsing:** The answer is in `choices[0].message.content` as a text string. Extract the key points for the Market/Competitors column.
 
-After all 4 research calls complete for a company, compile the results and update that row.
+## Step 4: Compile and Update Each Row
 
-### Links — plain URLs, not HYPERLINK formulas
-
-Google Sheets cannot have multiple `=HYPERLINK()` formulas in one cell (extras show as FALSE). Instead:
-
-- **Website**: Put the plain URL — Sheets auto-linkifies single URLs.
-- **Founder LinkedIn**: One URL per line. If multiple founders, separate with newlines. Sheets auto-linkifies each.
-- **Founder Twitter/X**: Same — one URL per line.
-
-### Location fallback
-
-If the YC page has no location, use the founder's city/state from Apollo (`person.city`, `person.state`). Use the first founder's location as the company location.
-
-### Founder-Company Fit (Strong / Moderate / Weak)
-
-Assess whether the founders' backgrounds make them uniquely suited to build THIS specific company. YC selects well, so most founders will have decent fit — but be specific about what makes the fit strong or where there are gaps.
-
-**Strong** — Direct domain expertise in the problem they're solving.
-> "Strong — CEO spent 5 years at Stripe building payment APIs, now building payment infrastructure. Deep domain match."
-
-**Moderate** — Strong technical background but limited domain experience.
-> "Moderate — both founders are strong engineers (Google, Amazon) but no direct healthcare experience for a healthcare product."
-
-**Weak** — No relevant background for the space, or very thin visible track record.
-> "Weak — general engineering background with no visible agent infrastructure or protocol experience for an agent communication platform."
-
-### Website Analysis
-
-Summarize what you found from scraping the company's website. Include: product description, target customer, any traction signals (customer logos, metrics), pricing model. If the website is pre-launch or thin, say so.
-
-### Overall Assessment (High Priority / Interesting / Pass)
-
-Consider: founder-company fit, market size, competitive landscape, team completeness, product clarity, website maturity.
-
-If the investor provided a thesis, weight the assessment heavily toward their focus areas.
-
-### Priority Rank
-
-Rank all companies 1 to N. #1 is the strongest overall.
-
-- **With thesis**: Rank by thesis alignment (stage, sector, geography fit).
-- **Without thesis**: Rank on general investment quality = founder-company fit × market size × team strength.
+As each company's research completes, immediately update its row. The column mapping:
 
 ```bash
 orth run google-sheets /update-values --body '{
   "spreadsheet_id": "{spreadsheet_id}",
   "sheet_name": "Sheet1",
-  "first_cell_location": "A{row_number}",
+  "first_cell_location": "C{row_number}",
   "valueInputOption": "USER_ENTERED",
-  "values": [["{rank}", "{company}", "{desc}", "{sectors}", "{location}", "{website}", "{founders}", "{linkedins}", "{twitters}", "{background}", "{fit}", "{website_analysis}", "{market}", "{overall}"]]
+  "values": [["{sectors}", "{location}", "{website}", "{founders}", "{linkedins}", "{twitters}", "{background}", "{fit}", "{website_analysis}", "{market}", "{overall}", ""]]
 }'
 ```
 
-## Step 5: Re-sort and Final Summary
+This updates columns C through N for a single row (sectors through priority rank), leaving Priority Rank blank until the final sort.
 
-After all companies are researched, re-sort the sheet by Priority Rank (column A) so the best companies are at the top. Then output a summary:
+### Formatting rules
+
+**Links — plain URLs, not HYPERLINK formulas**
+
+Google Sheets cannot have multiple `=HYPERLINK()` formulas in one cell — extras evaluate to FALSE. Instead:
+- **Website (E)**: Plain URL (e.g. `https://arzana.ai`). Sheets auto-linkifies it.
+- **Founder LinkedIn (G)**: One plain URL per line. If multiple founders, separate with newlines (`\n`).
+- **Founder Twitter/X (H)**: Same — one plain URL per line.
+
+**Founders (F)**: List as "Name (Title), Name (Title)". Example: "William Alexander (CEO), Marshall Kools (COO)"
+
+**Founder Background (I)**: One line per founder with key career highlights from Apollo employment history. Example:
+> "William Alexander: Stanford Econ+CS, previously founded Athluence and Lost in the Sauce Pizza. Marshall Kools: Stanford MS Engineering, D1 wrestler, previously at [company]."
+
+**Location (D)**: Use YC page location. If blank, use Apollo `person.city`, `person.state` from the first founder.
+
+**Sectors (C)**: Use individual YC page `sectors` (e.g. "Artificial Intelligence, Manufacturing"). If unavailable, fall back to batch `tags`.
+
+### Founder-Company Fit (J) — Strong / Moderate / Weak
+
+Assess whether the founders' backgrounds make them uniquely suited to build THIS specific company. YC selects well, so most fits will be decent — but be specific about what makes it strong or where there are gaps.
+
+**Strong** — Direct domain expertise or deep work history in the problem they're solving.
+> "Strong — CEO spent 5 years at Stripe building payment APIs, now building payment infrastructure. Deep domain match."
+> "Strong — manufacturing nerd from Iowa, Stanford Econ+CS, building AI for manufacturing. Direct domain background."
+
+**Moderate** — Strong technical background but limited domain experience, or relevant adjacent experience.
+> "Moderate — both founders are strong engineers (Google, Amazon) but no direct healthcare experience for a healthcare product."
+> "Moderate — strong ML background from MIT/Caltech, but building for educators which is a different domain."
+
+**Weak** — No relevant background for the space, or very thin visible track record.
+> "Weak — general engineering background with no visible agent infrastructure or protocol experience for an agent communication platform."
+> "Weak — first-time founders, Apollo shows minimal work history, no clear domain expertise for the space."
+
+### Website Analysis (K)
+
+Summarize what you found from the company website scrape. Be specific and include:
+- What the product actually does (may be more detailed than YC one-liner)
+- Target customer
+- Pricing if disclosed
+- Traction signals: customer logos by name, metrics, testimonials
+- Hiring signals
+- How mature the site/product looks
+
+Examples from real scrapes:
+> "Strong product site. AI for manufacturing office — quoting, estimating, purchasing, CRM. $2.5-7K/mo pricing. 9 customer logos (Tier1, Tecton, Koike, Zeiss, Schneider). TTQ reduced 5 days to 1 day. Testimonial from VP Sales. Hiring."
+> "AI voice agents focused on MENA/Arabic dialects. Batch calling, knowledge base, call transfer. 100+ users. 8 testimonials. Hiring via Zoho Recruit."
+> "Developer email service — email to webhook as JSON. Free for unlimited domains. Minimal traction signals — very early stage."
+
+### Market/Competitors (L)
+
+Extract from Perplexity response: market size, top competitors, any press/traction mentions. Keep it to 2-3 sentences.
+
+### Overall Assessment (M) — High Priority / Interesting / Pass
+
+Consider: founder-company fit, market size, competitive landscape, team completeness, product/website maturity, traction signals.
+
+If the investor provided a thesis, weight the assessment heavily toward their focus areas.
+
+> "High Priority — strong founder-market fit, clear product with paying customers, large TAM in manufacturing automation."
+> "Interesting — impressive tech (26ms forks) but very early, single founder, no customers yet."
+> "Pass — minimal traction, thin founder backgrounds for the space, crowded market."
+
+### Priority Rank (N)
+
+Assigned in Step 5 after all companies are researched.
+
+## Step 5: Rank, Re-sort, and Summary
+
+After ALL companies are researched and their rows updated:
+
+1. **Assign ranks 1 to N** based on overall quality:
+   - **With thesis**: Rank by thesis alignment (stage, sector, geography fit).
+   - **Without thesis**: Rank on general investment quality = founder-company fit × market size × traction signals × team strength.
+
+2. **Update the Priority Rank column** for all companies.
+
+3. **Re-sort the entire sheet** by Priority Rank so the strongest companies appear at the top. Read all rows, sort by rank, rewrite:
+
+```bash
+# Read all current data
+orth run google-sheets /get-values --body '{
+  "spreadsheet_id": "{spreadsheet_id}",
+  "ranges": ["Sheet1!A2:N{last_row}"]
+}'
+
+# Sort rows by Priority Rank (column N), then rewrite
+orth run google-sheets /update-values --body '{
+  "spreadsheet_id": "{spreadsheet_id}",
+  "sheet_name": "Sheet1",
+  "first_cell_location": "A2",
+  "valueInputOption": "USER_ENTERED",
+  "values": [{sorted_rows}]
+}'
+```
+
+4. **Output a summary** to the user:
 
 ```
+Evaluated {N} companies from YC {batch}.
+Sheet: {sheet_url}
+
 Top Priority:
 1. {Company} — {one-line why}
-2. ...
+2. {Company} — {one-line why}
+3. {Company} — {one-line why}
 
 Worth a Look:
+- {Company} — {one-line why}
 - {Company} — {one-line why}
 
 Skip:
 - {Company} — {one-line why}
 ```
 
+## Cost Estimate
+
+For a batch of ~22 companies with ~40 founders:
+
+| API | Calls | Cost |
+|-----|-------|------|
+| Scrapegraph (batch page) | 1 | ~$0.03 |
+| Scrapegraph (YC pages) | 22 | ~$0.66 |
+| Scrapegraph (company websites) | 22 | ~$0.66 |
+| Apollo (founder lookups) | ~40 | ~$0.40 |
+| Perplexity (market analysis) | 22 | ~$0.11 |
+| Google Sheets | ~25 | free |
+| **Total** | | **~$1.86** |
+
 ## Tips
 
-- **Row by row, not batch**: Research one company → update its row → move to next. The live-fill effect is the point.
-- **Parallelize within each company**: All 4 research calls (YC page, website, Apollo, Perplexity) run in parallel per company.
+- **Parallel, then row-by-row updates**: Research ALL companies in parallel phases, but UPDATE the sheet one row at a time as each company's data arrives. The live-fill effect is the point.
 - **Never leave Website Analysis blank**: Either summarize what you found or note "Website not available / pre-launch".
-- **Filter out YC partners**: Tom Blomfield, Harj Taggar, etc. appear as "Primary Partner" on company pages — exclude them from the founders list.
+- **Filter out YC partners**: Tom Blomfield, Harj Taggar, etc. appear with title "Primary Partner" or "Group Partner" on company pages. They are YC staff, not founders — exclude them.
 - **Check multiple field names**: Scrapegraph returns varying field names. Always check `website_url` / `company_website_url` / `company_website` for websites; `sectors` / `sector_tags` / `tags` for sectors.
-- **Apollo for missing data**: Use Apollo `city`/`state` as location fallback. Use `mixed_people/search` as LinkedIn fallback.
-- **Plain URLs, not HYPERLINK formulas**: Multiple HYPERLINKs in one cell causes FALSE. Plain URLs auto-linkify in Sheets.
-- **Be honest and specific**: Reference the actual founder backgrounds, not generic assessments. If the market is tiny, say so. Investors value honesty.
+- **Apollo for missing data**: Use `person.city`/`person.state` as location fallback. Use `mixed_people/search` as LinkedIn fallback when no LinkedIn URL on YC page.
+- **Plain URLs, not HYPERLINK formulas**: Multiple `=HYPERLINK()` in one cell → FALSE. Plain URLs auto-linkify in Sheets.
+- **Rich Perplexity prompts**: Include company description and founder bios. "Tell me about {company_name}" gets generic results. Specific context gets useful answers.
+- **Be honest and specific**: Reference actual founder backgrounds, not generic assessments. If the market is tiny, say so. Investors value honesty over hype.
+- **Skip gracefully**: If a company website 404s or Apollo returns nothing, still fill what you have. Partial data > empty row.

--- a/skills/orthogonal-yc-batch-evaluator/SKILL.md
+++ b/skills/orthogonal-yc-batch-evaluator/SKILL.md
@@ -7,11 +7,17 @@ description: Evaluate YC batch companies for investment — scrapes the YC direc
 
 Scrape a YC batch, research every company and founder, assess founder-company fit, and export a live-updating Google Sheet with priority rankings. Designed for investors evaluating YC companies.
 
+## IMPORTANT: Do NOT ask clarifying questions. Just start immediately.
+
+All inputs are optional. If the user said a batch, use it. If they didn't specify sectors or thesis, process ALL companies. **Always create a new Google Sheet** — never ask for an existing spreadsheet ID. **Start scraping immediately — do not ask "which batch?", "any sector filters?", or "should I create a sheet?".** This is designed for live demos where speed and visual impact matter.
+
+"Spring 2026" is a real YC batch (also called "X26"). It exists and has ~22 companies.
+
 ## Input
 
 - **batch** (optional) — defaults to "Spring 2026". Examples: "Winter 2026", "Summer 2025"
-- **sectors** (optional) — filter to specific sectors (e.g. "AI", "fintech", "infrastructure")
-- **thesis** (optional) — investor's focus areas for tailored scoring and ranking
+- **sectors** (optional) — filter to specific sectors (e.g. "AI", "fintech", "infrastructure"). If not provided, process ALL companies.
+- **thesis** (optional) — investor's focus areas for tailored scoring and ranking. If not provided, rank on general investment quality.
 
 ## Step 1: Scrape the YC Batch Directory
 
@@ -97,7 +103,9 @@ Populate Sector (C) and Location (D) from the batch scrape initially — they'll
 
 ### Parallelization Strategy
 
-Process companies in **batches of 3-5 at a time**. Within each batch, all companies run in parallel. Rows appear in the sheet as each company's research completes — giving a steady live-fill cadence while being 3-5x faster than purely sequential.
+**The demo effect matters.** Rows filling in one-by-one on the spreadsheet is the visual payoff. Optimize for a steady stream of rows appearing — not for dumping everything at once.
+
+Process companies in **batches of 3-5 at a time**. Within each batch, all companies' research runs in parallel. But **update each row individually** the moment that company's research completes — do NOT wait for the whole batch to finish before writing.
 
 For each batch of companies (run all in parallel):
 1. **Scrape all YC company pages** in the batch simultaneously (Step 3a)
@@ -105,10 +113,12 @@ For each batch of companies (run all in parallel):
    - Scrape the company's website (Step 3b)
    - Apollo lookup for each founder (Step 3c) — multiple calls if multiple founders, all in parallel
    - Perplexity market analysis (Step 3d)
-3. As each company's full research set completes, **compile and update its row** (Step 4) immediately
+3. As each company's full research set completes, **compile and update its row** (Step 4) **immediately** — one `update-values` call per row, don't batch them
 4. Move to the next batch
 
-This gives a steady cadence of rows appearing every few seconds. With batches of 5, a 22-company batch completes in ~2-3 minutes.
+**Key: each row gets its own sheet update call.** This creates the live-fill effect where the investor watches rows appear every 3-5 seconds. Never batch multiple rows into a single sheet write — that kills the visual cadence.
+
+With batches of 5, a 22-company batch completes in ~2-3 minutes with rows streaming in throughout.
 
 ### 3a. Scrape the YC company page (~$0.03 each)
 
@@ -267,7 +277,26 @@ orth run perplexity /chat/completions --body '{
 
 ## Step 4: Compile and Update Each Row
 
-As each company's research completes, immediately update its row. The column mapping:
+As each company's research completes, immediately update its row. **The values array MUST have exactly 12 elements in this exact order:**
+
+```
+values: [[
+  C: sectors,           // e.g. "AI, Manufacturing" (from YC page)
+  D: location,          // e.g. "San Francisco, CA" (from YC page, short)
+  E: website,           // e.g. "https://arzana.ai" (plain URL)
+  F: founders,          // e.g. "William Alexander (CEO)\nMarshall Kools (COO)"
+  G: linkedin_urls,     // e.g. "https://linkedin.com/in/william--alexander/\nhttps://linkedin.com/in/marshallkools/"
+  H: twitter_urls,      // e.g. "https://x.com/alexisaftalion" or ""
+  I: background,        // Founder work history from Apollo
+  J: fit_rating,        // "Strong — ..." or "Moderate — ..." or "Weak — ..."
+  K: website_analysis,  // Summary of company website scrape
+  L: market,            // Market size + competitors from Perplexity
+  M: overall,           // "High Priority — ..." or "Interesting — ..." or "Pass — ..."
+  N: ""                 // Priority Rank — leave blank, filled in Step 5
+]]
+```
+
+**CRITICAL: Exactly 12 values starting at column C. Do NOT include extra fields like company description, founding year, or team size — those go in the wrong columns and misalign the entire row.**
 
 ```bash
 orth run google-sheets /update-values --body '{
@@ -279,7 +308,7 @@ orth run google-sheets /update-values --body '{
 }'
 ```
 
-This updates columns C through N for a single row (sectors through priority rank), leaving Priority Rank blank until the final sort.
+This updates columns C through N for a single row. One call per company — this creates the live-fill demo effect.
 
 ### Formatting rules
 
@@ -350,32 +379,38 @@ Assigned in Step 5 after all companies are researched.
 
 ## Step 5: Rank, Re-sort, and Summary
 
+**This step is NOT optional. You MUST sort the sheet after all research is complete.** The investor expects the best companies at the top.
+
 After ALL companies are researched and their rows updated:
 
 1. **Assign ranks 1 to N** based on overall quality:
    - **With thesis**: Rank by thesis alignment (stage, sector, geography fit).
    - **Without thesis**: Rank on general investment quality = founder-company fit × market size × traction signals × team strength.
 
-2. **Update the Priority Rank column** for all companies.
+2. **Write ranks to column N** for all companies.
 
-3. **Re-sort the entire sheet** by Priority Rank so the strongest companies appear at the top. Read all rows, sort by rank, rewrite:
+3. **Re-sort the entire sheet by Priority Rank.** This is critical — the sheet must end with rank #1 at the top.
 
 ```bash
-# Read all current data
+# Step 5a: Read all current data
 orth run google-sheets /get-values --body '{
   "spreadsheet_id": "{spreadsheet_id}",
   "ranges": ["Sheet1!A2:N{last_row}"]
 }'
+```
 
-# Sort rows by Priority Rank (column N), then rewrite
+```bash
+# Step 5b: Sort the rows by column N (Priority Rank) ascending, then rewrite ALL rows
 orth run google-sheets /update-values --body '{
   "spreadsheet_id": "{spreadsheet_id}",
   "sheet_name": "Sheet1",
   "first_cell_location": "A2",
   "valueInputOption": "USER_ENTERED",
-  "values": [{sorted_rows}]
+  "values": [{rows_sorted_by_column_N_ascending}]
 }'
 ```
+
+**Do not skip the sort.** Writing rank numbers without reordering the rows defeats the purpose. The investor opens the sheet and should see the top-ranked companies first.
 
 4. **Output a summary** to the user:
 
@@ -416,7 +451,7 @@ For a batch of ~22 companies with ~40 founders:
 - **Never leave Website Analysis blank**: Either summarize what you found or note "Website not available / pre-launch".
 - **Filter out YC partners**: Tom Blomfield, Harj Taggar, etc. appear with title "Primary Partner" or "Group Partner" on company pages. They are YC staff, not founders — exclude them.
 - **Check multiple field names**: Scrapegraph returns varying field names. Always check `website_url` / `company_website_url` / `company_website` for websites; `sectors` / `sector_tags` / `tags` for sectors.
-- **Apollo for missing data**: Use `person.city`/`person.state` as location fallback. Use `mixed_people/search` as LinkedIn fallback when no LinkedIn URL on YC page.
+- **Apollo for missing data**: Use `person.city`/`person.state` as location fallback. Use `people/match` with `first_name`/`last_name`/`organization_name` as fallback when no LinkedIn URL on YC page. The `mixed_people/search` endpoint is NOT available.
 - **Plain URLs, not HYPERLINK formulas**: Multiple `=HYPERLINK()` in one cell → FALSE. Plain URLs auto-linkify in Sheets.
 - **Rich Perplexity prompts**: Include company description and founder bios. "Tell me about {company_name}" gets generic results. Specific context gets useful answers.
 - **Be honest and specific**: Reference actual founder backgrounds, not generic assessments. If the market is tiny, say so. Investors value honesty over hype.

--- a/skills/orthogonal-yc-batch-evaluator/SKILL.md
+++ b/skills/orthogonal-yc-batch-evaluator/SKILL.md
@@ -97,17 +97,18 @@ Populate Sector (C) and Location (D) from the batch scrape initially — they'll
 
 ### Parallelization Strategy
 
-The investor watches the sheet fill in live. **Parallelize within each company, not across companies.** Process one company at a time so each row appears fully filled every ~5-10 seconds.
+Process companies in **batches of 3-5 at a time**. Within each batch, all companies run in parallel. Rows appear in the sheet as each company's research completes — giving a steady live-fill cadence while being 3-5x faster than purely sequential.
 
-For each company:
-1. **Scrape the YC company page** (Step 3a) — must run first, gives you founders, LinkedIn URLs, company website
-2. **In parallel**, run all three downstream calls:
+For each batch of companies (run all in parallel):
+1. **Scrape all YC company pages** in the batch simultaneously (Step 3a)
+2. As each YC page returns, **immediately launch its downstream calls in parallel**:
    - Scrape the company's website (Step 3b)
    - Apollo lookup for each founder (Step 3c) — multiple calls if multiple founders, all in parallel
    - Perplexity market analysis (Step 3d)
-3. **Compile results and update the row** (Step 4) — immediately, before moving to the next company
+3. As each company's full research set completes, **compile and update its row** (Step 4) immediately
+4. Move to the next batch
 
-This gives a steady cadence of rows appearing in the sheet. The investor sees progress every few seconds instead of waiting for everything at once.
+This gives a steady cadence of rows appearing every few seconds. With batches of 5, a 22-company batch completes in ~2-3 minutes.
 
 ### 3a. Scrape the YC company page (~$0.03 each)
 
@@ -238,18 +239,18 @@ orth run apollo /api/v1/people/match --body '{
 - `person.city` + `person.state` — use as **location fallback** if the YC page didn't have a location.
 - `person.headline` — often has a concise summary of their background.
 
-**No LinkedIn URL on YC page?** Fallback — search by name + company:
+**No LinkedIn URL on YC page?** Fallback — match by name + company:
 
 ```bash
-orth run apollo /api/v1/mixed_people/search --body '{
-  "q_person_name": "{founder_name}",
-  "q_organization_names": ["{company_name}"],
-  "page": 1,
-  "per_page": 1
+orth run apollo /api/v1/people/match --body '{
+  "first_name": "{first_name}",
+  "last_name": "{last_name}",
+  "organization_name": "{company_name}",
+  "reveal_personal_emails": true
 }'
 ```
 
-This usually returns their LinkedIn and work history even when the YC page doesn't list it. Results are in `people[0]` with same structure as above.
+Note: The `mixed_people/search` endpoint is NOT available. Use `people/match` with `first_name`, `last_name`, and `organization_name` as the fallback. This usually returns their employment history even without a LinkedIn URL.
 
 ### 3d. Perplexity — market context (~$0.005 each)
 

--- a/skills/orthogonal-yc-batch-evaluator/SKILL.md
+++ b/skills/orthogonal-yc-batch-evaluator/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: yc-batch-evaluator
+description: Evaluate YC batch companies for investment — scrapes the YC directory, researches each company and its founders (work history, LinkedIn, website), assesses founder-company fit, and exports to Google Sheets. Use when asked to evaluate YC companies, research a YC batch, screen startups, or do due diligence on YC companies.
+---
+
+# YC Batch Evaluator
+
+Scrape a YC batch, research every company and founder, assess founder-company fit, and export a live-updating Google Sheet. Designed for investors evaluating YC companies.
+
+## Input
+
+- **batch** (optional) — defaults to "Spring 2026". Examples: "Winter 2026", "Summer 2025"
+- **sectors** (optional) — filter to specific sectors (e.g. "AI", "fintech", "infrastructure")
+- **thesis** (optional) — investor's focus areas for tailored scoring
+
+## Step 1: Scrape the YC Batch Directory
+
+```bash
+orth run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.ycombinator.com/companies?batch={batch_url_encoded}",
+  "user_prompt": "Extract every company listed: company name, one-line description, sector/tags, location, and URL slug for each company page (e.g. /companies/orthogonal). Return as a structured list."
+}'
+```
+
+Batch URL encoding: "Spring 2026" → `Spring%202026`, "Winter 2026" → `Winter%202026`.
+
+If the investor specified sectors, filter the list. Otherwise process all companies.
+
+## Step 2: Create Google Sheet and Share Link Immediately
+
+Before any research, create the sheet and populate it with company names + descriptions. Share the link so the investor can watch results fill in live.
+
+```bash
+orth run google-sheets /create-spreadsheet --body '{"title": "YC {batch} Batch Evaluation"}'
+```
+
+Write header row + all company rows (research columns blank):
+
+```bash
+orth run google-sheets /update-values --body '{
+  "spreadsheet_id": "{spreadsheet_id}",
+  "sheet_name": "Sheet1",
+  "first_cell_location": "A1",
+  "valueInputOption": "USER_ENTERED",
+  "values": [
+    ["Company", "Description", "Sector", "Location", "Website", "Founders", "Founder LinkedIn(s)", "Founder Twitter/X", "Founder Background", "Founder-Company Fit", "Website Analysis", "Market/Competitors", "Overall Assessment"],
+    ["{company_name}", "{description}", "{sectors}", "{location}", "", "", "", "", "", "", "", "", ""]
+  ]
+}'
+```
+
+**Share the sheet link with the user immediately.**
+
+## Step 3: Research Each Company
+
+Run ALL of these in parallel per company. Process multiple companies simultaneously.
+
+### 3a. Scrape the YC company page (~$0.03)
+
+YC company pages are rich: founders with LinkedIn, Twitter/X, bios, team size, sectors.
+
+```bash
+orth run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://www.ycombinator.com/companies/{company_slug}",
+  "user_prompt": "Extract: full company description, all founders (full name, title, LinkedIn URL, Twitter/X URL, bio), company website URL, team size, location, sectors, founding year."
+}'
+```
+
+### 3b. Scrape the company's own website (~$0.03)
+
+```bash
+orth run scrapegraph /v1/smartscraper --body '{
+  "website_url": "https://{company_website}",
+  "user_prompt": "Extract: what the product does, target customer, pricing model, key features, traction signals (customer logos, metrics, testimonials), hiring signals, tech stack."
+}'
+```
+
+Skip on error (some early-stage companies may not have a website yet).
+
+### 3c. Apollo — founder work history (~$0.01 per founder)
+
+Use the LinkedIn slug from the YC page to get full employment history.
+
+```bash
+orth run apollo /api/v1/people/match --body '{
+  "linkedin_url": "https://linkedin.com/in/{founder_linkedin_slug}",
+  "reveal_personal_emails": true
+}'
+```
+
+Returns: employment history (companies, titles, dates), education, current role. This is the key input for founder-company fit.
+
+**No LinkedIn slug?** Try matching by name + company:
+
+```bash
+orth run apollo /api/v1/mixed_people/search --body '{
+  "q_person_name": "{founder_name}",
+  "q_organization_names": ["{company_name}"],
+  "page": 1,
+  "per_page": 1
+}'
+```
+
+### 3d. Perplexity — market context (~$0.005)
+
+```bash
+orth run perplexity /chat/completions --body '{
+  "model": "sonar",
+  "messages": [{"role": "user", "content": "{company_name} ({website}) is a YC {batch} startup: {description}. Founders: {founder_names_and_bios}. Answer concisely:\n1. Market size and opportunity?\n2. Top 3 competitors?\n3. What makes the founders uniquely qualified?\n4. Any traction, press, or notable mentions?\n5. Red flags or concerns?"}]
+}'
+```
+
+## Step 4: Evaluate and Update Sheet Row-by-Row
+
+As each company's research completes, immediately update its row. Don't wait for all companies.
+
+### Founder-Company Fit (Strong / Moderate / Weak)
+
+Assess whether the founders' backgrounds make them uniquely suited to build THIS specific company.
+
+**Strong** — Direct domain expertise in the problem they're solving.
+> "Strong — CEO spent 5 years at Stripe building payment APIs, now building payment infrastructure. Deep domain match."
+
+**Moderate** — Strong technical background but limited domain experience.
+> "Moderate — both founders are strong engineers (Google, Amazon) but no direct healthcare experience for a healthcare product."
+
+**Weak** — No relevant background for the space.
+> "Weak — first-time founders with no background in manufacturing or supply chain."
+
+### Overall Assessment (High Priority / Interesting / Pass)
+
+Consider: founder-company fit, market size, competitive landscape, team completeness, product clarity.
+
+If the investor provided a thesis, weight the assessment toward their focus areas.
+
+```bash
+orth run google-sheets /update-values --body '{
+  "spreadsheet_id": "{spreadsheet_id}",
+  "sheet_name": "Sheet1",
+  "first_cell_location": "E{row_number}",
+  "valueInputOption": "USER_ENTERED",
+  "values": [["{website}", "{founders}", "{linkedin_urls}", "{twitter_urls}", "{background}", "{fit_rating}", "{website_analysis}", "{market}", "{overall}"]]
+}'
+```
+
+## Tips
+
+- **Parallelize aggressively**: All 4 research calls per company are independent. Process multiple companies at once.
+- **Update the sheet as you go**: Each row update takes <1 second. Don't batch — the investor wants to see it fill in live.
+- **Skip gracefully**: If a company website 404s or Apollo returns nothing, still fill what you have. Partial data > empty row.
+- **Founder LinkedIn is the most valuable signal**: Employment history directly feeds the founder-company fit assessment.
+- **Be honest**: If founders have no relevant experience, say so. If the market is tiny, say so. Investors value honesty over hype.


### PR DESCRIPTION
## Summary
- Adds `orthogonal-yc-batch-evaluator` skill for investors evaluating YC batch companies
- Scrapes YC directory, researches founders (Apollo work history) + companies (website scraping), assesses founder-company fit
- Live-updating Google Sheet — investor watches results fill in
- Tested: Scrapegraph extracts all 21 S26 companies, individual pages return founder LinkedIn/Twitter/bios, Apollo returns full employment history

## APIs used
Scrapegraph, Apollo, Perplexity (sonar), Google Sheets

## Test plan
- [x] Scrapegraph on YC batch page — extracts 21 companies with slugs
- [x] Scrapegraph on individual company page — founders, LinkedIn, Twitter, bios
- [x] Apollo founder lookup by LinkedIn — full employment history
- [ ] Full pipeline end-to-end on S26 batch
- [ ] Google Sheets live update

Generated with [Claude Code](https://claude.com/claude-code)