### PR TITLE
Fix: add -X POST to all Fiber API calls

### DIFF
--- a/skills/orthogonal-comprehensive-enrichment/SKILL.md
+++ b/skills/orthogonal-comprehensive-enrichment/SKILL.md
@@ -33,13 +33,13 @@ Run ALL of these in parallel where possible. Collect everything, then compile.
 **Fiber kitchen-sink** (accepts LinkedIn URL, email, or name+company):
 ```bash
 # By LinkedIn URL:
-orth run fiber /v1/kitchen-sink/person --body '{"profileIdentifier": "https://linkedin.com/in/johndoe"}'
+orth run fiber -X POST /v1/kitchen-sink/person --body '{"profileIdentifier": "https://linkedin.com/in/johndoe"}'
 
 # By email:
-orth run fiber /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com"}'
+orth run fiber -X POST /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com"}'
 
 # By name + company:
-orth run fiber /v1/kitchen-sink/person --body '{
+orth run fiber -X POST /v1/kitchen-sink/person --body '{
   "personName": {"fullName": "John Doe"},
   "companyName": {"name": "Stripe"},
   "companyDomain": {"domain": "stripe.com"}
@@ -89,7 +89,7 @@ Nyne person/search and Sixtyfour enrich-lead (Section 2a) also return personal e
 ```bash
 orth run hunter /v2/email-verifier --query email=john@stripe.com
 orth run tomba /v1/email-verifier --query email=john@stripe.com
-orth run fiber /v1/validate-email/single --body '{"email": "john@stripe.com"}'
+orth run fiber -X POST /v1/validate-email/single --body '{"email": "john@stripe.com"}'
 ```
 Verify every email found — work and personal. Run verifiers in parallel across all emails.
 
@@ -104,12 +104,12 @@ orth run sixtyfour /find-phone --body '{
 
 **LinkedIn profile** (Fiber):
 ```bash
-orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
+orth run fiber -X POST /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
 **LinkedIn recent posts** (Fiber):
 ```bash
-orth run fiber /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "https://linkedin.com/in/johndoe"}'
+orth run fiber -X POST /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "https://linkedin.com/in/johndoe"}'
 ```
 
 **Twitter/X activity** (Nyne — async, returns tweets + engagement metrics):
@@ -158,14 +158,14 @@ orth run hunter /v2/domain-search --query domain=stripe.com
 
 **Fiber company data** (LinkedIn-enriched):
 ```bash
-orth run fiber /v1/kitchen-sink/company --body '{"companyDomain": {"domain": "stripe.com"}}'
+orth run fiber -X POST /v1/kitchen-sink/company --body '{"companyDomain": {"domain": "stripe.com"}}'
 ```
 
 ### 3b. Leadership & Employees
 
 **Key people by title:**
 ```bash
-orth run fiber /v1/natural-language-search/profiles --body '{"query": "CEO, CTO, CFO, COO, VP at Stripe", "pageSize": 10}'
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{"query": "CEO, CTO, CFO, COO, VP at Stripe", "pageSize": 10}'
 ```
 
 
@@ -228,7 +228,7 @@ Cross-reference all API results. Merge overview, leadership, funding, products, 
 **Step 2: Person enrichment** (run in parallel):
 ```bash
 # Profile (3 sources)
-orth run fiber /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com", "companyDomain": {"domain": "stripe.com"}}'
+orth run fiber -X POST /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com", "companyDomain": {"domain": "stripe.com"}}'
 orth run nyne /person/search -d '{"query": "john stripe.com"}'
 orth run sixtyfour /enrich-lead --body '{"lead_info": {"email": "john@stripe.com", "company": "Stripe"}, "struct": {"work_email": "Work email", "personal_email": "Personal email", "phone": "Phone", "title": "Title", "bio": "Bio"}}'
 
@@ -238,7 +238,7 @@ orth run tomba /v1/enrich --query email=john@stripe.com
 # Verify work email (3 sources)
 orth run hunter /v2/email-verifier --query email=john@stripe.com
 orth run tomba /v1/email-verifier --query email=john@stripe.com
-orth run fiber /v1/validate-email/single --body '{"email": "john@stripe.com"}'
+orth run fiber -X POST /v1/validate-email/single --body '{"email": "john@stripe.com"}'
 # Also verify any personal emails found with the same 3 verifiers
 
 # Phone
@@ -251,8 +251,8 @@ orth run linkup /search --body '{"q": "john stripe.com", "depth": "deep", "outpu
 Once you have the person's full name + LinkedIn from Step 2, fire off:
 ```bash
 # LinkedIn profile + posts
-orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "LINKEDIN_URL"}'
-orth run fiber /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "LINKEDIN_URL"}'
+orth run fiber -X POST /v1/linkedin-live-fetch/profile/single --body '{"identifier": "LINKEDIN_URL"}'
+orth run fiber -X POST /v1/linkedin-live-fetch/profile-posts --body '{"identifier": "LINKEDIN_URL"}'
 
 # Twitter (if discovered)
 orth run -X POST nyne /person/newsfeed -d '{"social_media_url": "https://x.com/TWITTER_HANDLE"}'
@@ -263,10 +263,10 @@ orth run -X POST nyne /person/newsfeed -d '{"social_media_url": "https://x.com/T
 # Overview
 orth run brand-dev /v1/brand/retrieve --query domain=stripe.com
 orth run hunter /v2/domain-search --query domain=stripe.com
-orth run fiber /v1/kitchen-sink/company --body '{"companyDomain": {"domain": "stripe.com"}}'
+orth run fiber -X POST /v1/kitchen-sink/company --body '{"companyDomain": {"domain": "stripe.com"}}'
 
 # Leadership
-orth run fiber /v1/natural-language-search/profiles --body '{"query": "CEO, CTO, CFO, COO, VP at Stripe", "pageSize": 10}'
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{"query": "CEO, CTO, CFO, COO, VP at Stripe", "pageSize": 10}'
 
 # Funding
 orth run -X POST nyne /company/funding -d '{"company_name": "Stripe"}'

--- a/skills/orthogonal-find-dentists/SKILL.md
+++ b/skills/orthogonal-find-dentists/SKILL.md
@@ -116,7 +116,7 @@ Run in parallel for all practices with websites. This is the **most reliable met
 **Fallback — Fiber kitchen-sink** (if you found a LinkedIn URL for someone at the practice):
 
 ```bash
-orth run fiber /v1/kitchen-sink/person --body '{
+orth run fiber -X POST /v1/kitchen-sink/person --body '{
   "profileIdentifier": "https://linkedin.com/in/drmanali"
 }'
 ```

--- a/skills/orthogonal-find-twitter-influencers/SKILL.md
+++ b/skills/orthogonal-find-twitter-influencers/SKILL.md
@@ -107,13 +107,13 @@ Some influencers are better indexed on LinkedIn but have active Twitter accounts
 
 ```bash
 # Core niche
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "{niche} thought leader content creator with Twitter presence at {industry} companies",
   "pageSize": 20
 }'
 
 # Adjacent niche — broader coverage
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "{adjacent_niche} influencer expert with large social media following",
   "pageSize": 20
 }'
@@ -245,7 +245,7 @@ Launch ALL these Exa searches in parallel (multiple tool calls in a single messa
 **Step 3 — Fiber kitchen-sink** (best coverage for professionals):
 ```bash
 # With LinkedIn URL (best match rate — ALWAYS prefer this):
-orth run fiber /v1/kitchen-sink/person --body '{
+orth run fiber -X POST /v1/kitchen-sink/person --body '{
   "profileIdentifier": "https://linkedin.com/in/janesmith"
 }'
 ```
@@ -317,7 +317,7 @@ orth run nyne /person/newsfeed --query 'request_id=REQUEST_ID'
 
 **LinkedIn profile** (full work history, credentials, other ventures):
 ```bash
-orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/TARGET"}'
+orth run fiber -X POST /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/TARGET"}'
 ```
 
 **Deep enrichment** (AI-powered research — slow, ~30-60s):

--- a/skills/orthogonal-targeted-prospecting/SKILL.md
+++ b/skills/orthogonal-targeted-prospecting/SKILL.md
@@ -38,7 +38,7 @@ Best source for industry-specific company lists. Returns targeted results from i
 **Strategy B — Fiber NL company search** (co-primary — best structured data):
 
 ```bash
-orth run fiber /v1/natural-language-search/companies --body '{
+orth run fiber -X POST /v1/natural-language-search/companies --body '{
   "query": "{industry} companies in {location} with {employee_min}+ employees",
   "pageSize": 20
 }'
@@ -63,12 +63,12 @@ For 20+ results, run parallel searches by sub-region or sub-vertical:
 
 ```bash
 # Parallel searches for different sub-regions
-orth run fiber /v1/natural-language-search/companies --body '{
+orth run fiber -X POST /v1/natural-language-search/companies --body '{
   "query": "{industry} companies in New York with {size}+ employees",
   "pageSize": 15
 }'
 
-orth run fiber /v1/natural-language-search/companies --body '{
+orth run fiber -X POST /v1/natural-language-search/companies --body '{
   "query": "{industry} companies in California with {size}+ employees",
   "pageSize": 15
 }'
@@ -101,7 +101,7 @@ In testing, a single broad query like "COO at staffing companies in the US" retu
 **Primary — Fiber NL profile search (broad industry query):**
 
 ```bash
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "{title_1} or {title_2} at a {industry} company in {location}",
   "pageSize": 15
 }'
@@ -112,7 +112,7 @@ This is the highest-yield approach. Returns decision makers across the industry 
 **Per-company fallback — Fiber NL profile search** (for companies not covered by the broad search):
 
 ```bash
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "{title_1} or {title_2} at {company_name}",
   "pageSize": 5
 }'
@@ -193,7 +193,7 @@ orth run sixtyfour /enrich-lead --body '{
 **Fiber kitchen-sink enrichment** (if LinkedIn URL available — may return 400):
 
 ```bash
-orth run fiber /v1/kitchen-sink/person --body '{
+orth run fiber -X POST /v1/kitchen-sink/person --body '{
   "profileIdentifier": "{linkedin_url}"
 }'
 ```
@@ -205,7 +205,7 @@ Kitchen-sink can intermittently return 400 errors regardless of parameter format
 ```bash
 orth run hunter /v2/email-verifier --query 'email={email}'
 orth run tomba /v1/email-verifier --query 'email={email}'
-orth run fiber /v1/validate-email/single --body '{"email": "{email}"}'
+orth run fiber -X POST /v1/validate-email/single --body '{"email": "{email}"}'
 ```
 
 Take the consensus. Label each email as verified/unverified. Collect both work and personal emails.
@@ -245,7 +245,7 @@ orth run scrapegraph /v1/smartscraper --body '{
 **Optional — Fiber job search** (attempt, may be unreliable):
 
 ```bash
-orth run fiber /v1/job-search --body '{
+orth run fiber -X POST /v1/job-search --body '{
   "searchParams": {
     "job_titles": ["{signal_role}"],
     "industries": ["{industry}"]
@@ -353,7 +353,7 @@ Found {N} companies with {M} decision makers identified.
 
 ```bash
 # Step 2: Find staffing companies (parallel)
-orth run fiber /v1/natural-language-search/companies --body '{
+orth run fiber -X POST /v1/natural-language-search/companies --body '{
   "query": "staffing and recruiting companies in the United States with 100 or more employees",
   "pageSize": 20
 }'
@@ -366,7 +366,7 @@ orth run scrapegraph /v1/searchscraper --body '{
 }'
 
 # Step 4: Find COOs (parallel, per company)
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "COO or Chief Operating Officer or Head of Operations at {company_name}",
   "pageSize": 3
 }'
@@ -389,13 +389,13 @@ orth run scrapegraph /v1/searchscraper --body '{
 
 ```bash
 # Companies
-orth run fiber /v1/natural-language-search/companies --body '{
+orth run fiber -X POST /v1/natural-language-search/companies --body '{
   "query": "fintech startups in the United States with 50 to 200 employees",
   "pageSize": 20
 }'
 
 # Decision makers (per company)
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "VP Engineering or CTO at {company_name}",
   "pageSize": 3
 }'
@@ -413,13 +413,13 @@ orth run scrapegraph /v1/searchscraper --body '{
 
 ```bash
 # Companies
-orth run fiber /v1/natural-language-search/companies --body '{
+orth run fiber -X POST /v1/natural-language-search/companies --body '{
   "query": "healthcare companies in Texas with 500 or more employees",
   "pageSize": 20
 }'
 
 # Decision makers
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "HR Director or VP Human Resources at {company_name}",
   "pageSize": 3
 }'
@@ -431,13 +431,13 @@ orth run fiber /v1/natural-language-search/profiles --body '{
 
 ```bash
 # Companies
-orth run fiber /v1/natural-language-search/companies --body '{
+orth run fiber -X POST /v1/natural-language-search/companies --body '{
   "query": "construction companies in California",
   "pageSize": 15
 }'
 
 # Decision makers
-orth run fiber /v1/natural-language-search/profiles --body '{
+orth run fiber -X POST /v1/natural-language-search/profiles --body '{
   "query": "Head of Safety or Safety Director or VP Safety at {company_name}",
   "pageSize": 3
 }'

--- a/skills/orthogonal-team-linkedin-profiles/SKILL.md
+++ b/skills/orthogonal-team-linkedin-profiles/SKILL.md
@@ -103,7 +103,7 @@ Include a note about coverage: "Some profiles may show abbreviated names (e.g., 
 Only if the user requests more detail on specific people, use Fiber live-fetch per profile:
 
 ```bash
-orth run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/USERNAME"}'
+orth run fiber -X POST /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/USERNAME"}'
 ```
 
 This returns full work history, education, skills, and recent activity. Run these in parallel for multiple profiles.


### PR DESCRIPTION
## Summary
- The `orth` CLI defaults to `GET`, but all Fiber API endpoints require `POST`
- Without `-X POST`, Fiber calls fail with `"Endpoint not found"`
- Adds `-X POST` to all `orth run fiber` commands across 5 skills:
  - `orthogonal-comprehensive-enrichment`
  - `orthogonal-find-dentists`
  - `orthogonal-find-twitter-influencers`
  - `orthogonal-targeted-prospecting`
  - `orthogonal-team-linkedin-profiles`

## Test plan
- [ ] Run `orth run fiber -X POST /v1/natural-language-search/profiles --body '{"query": "software engineers in NYC", "pageSize": 5}'` and confirm it returns results
- [ ] Run `orth run fiber /v1/natural-language-search/profiles --body '{"query": "software engineers in NYC", "pageSize": 5}'` (without -X POST) to confirm it still fails — validates the fix is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)