### PR TITLE
Add 3 Fundable skills (VC data, recent rounds, investor recent investments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ A skill is a `SKILL.md` file that tells an AI agent how to do something. When yo
 |-------|-------------|
 | [company-intel](skills/orthogonal-company-intel) | Full company reports: team, funding, products, news |
 | [company-funding-search](skills/orthogonal-company-funding-search) | Funding history, investors, investment details |
+| [fundable](skills/orthogonal-fundable) | VC data: companies, investors, deals, funding rounds with filters and AI semantic search |
+| [recent-funding-rounds](skills/orthogonal-recent-funding-rounds) | Find companies that raised recently by date, stage, industry, and size |
+| [investor-recent-investments](skills/orthogonal-investor-recent-investments) | Find an investment firm's most recent portfolio activity |
 | [competitor-research](skills/orthogonal-competitor-research) | Products, pricing, team, funding, and strategy |
 | [market-research](skills/orthogonal-market-research) | Market trends, size, competitors, growth |
 | [investor-research](skills/orthogonal-investor-research) | VC and angel investor portfolios, thesis, contact info |

--- a/skills/orthogonal-fundable/SKILL.md
+++ b/skills/orthogonal-fundable/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: fundable
+description: Venture capital data — companies, investors, deals, funding rounds. Search and filter companies by industry, location, funding stage, and deal size. Look up investors, their portfolios, and deal history. AI-powered semantic company search.
+---
+
+# Fundable — VC Data API
+
+Access venture capital data: companies, investors, and deals. Filter by industry, location, funding stage, deal size, and more. Includes AI-powered semantic search.
+
+## Capabilities
+
+- **Company Search & Filter**: Find companies by funding stage, industry, location, size, and AI semantic search
+- **Company Lookup**: Get detailed company info by domain, LinkedIn, or Crunchbase URL
+- **Company Deal History**: Get all funding rounds for a company
+- **Investor Search & Filter**: Find investors by portfolio, location, deal activity
+- **Investor Lookup**: Get investor details by domain, LinkedIn, or Crunchbase URL
+- **Investor Deal History**: Get all deals an investor participated in
+- **Deal Search & Filter**: Find deals by financing type, size, date, company, and investor
+- **Deal Details**: Get deal info including investors, valuations, and articles
+- **Location & Industry Search**: Look up permalinks for filtering
+
+---
+
+## Companies
+
+### List & Filter Companies (POST)
+
+Search and filter companies with pagination, sorting, and optional AI semantic search.
+
+```bash
+orth api run fundable /companies --body '{
+  "company": {
+    "industries": ["artificial-intelligence"],
+    "ipo_status": ["private"]
+  },
+  "latest_deal": {
+    "financing_types": [{"type": "SERIES_A"}],
+    "date_start": "2025-01-01"
+  },
+  "sort_by": "most_recent_raise",
+  "page_size": 25
+}'
+```
+
+**Filter sections:**
+- **`identifiers`** — Lookup by `ids`, `domains`, `linkedin_urls`, `crunchbase_urls` (max 100 each)
+- **`company`** — `search_query` (AI semantic search), `min_relevance` (0-1), `industries`, `super_categories`, `locations`, `employee_count`, `total_raised_min`/`max`, `ipo_status`
+- **`latest_deal`** — `financing_types` (array of `{"type": "SEED"}` etc., with optional `pre`/`extension` modifiers), `size_min`/`max`, `date_start`/`end`, `investor_ids`
+- **`investors`** — `investor_ids` (matches any round, not just latest)
+
+**Pagination & sorting:**
+- `page` (0-based), `page_size` (1-100, default 10)
+- `sort_by`: `most_recent_raise`, `oldest_raise`, `most_recent_founded`, `oldest_founded`, `largest_valuation`, `smallest_valuation`, `largest_total_raise`, `smallest_total_raise`, `most_funding_rounds`, `most_investors`
+
+**Financing types:** `SEED`, `SERIES_A` through `SERIES_M`, `SAFE`, `CONVERTIBLE_NOTE`, `EQUITY`, `PREFERRED`, `DEBT_FINANCING`, `GRANT`, `FUNDING_ROUND`, and more. Modifiers: `"pre": true`, `"extension": true`
+
+**Employee count ranges:** `1-10`, `11-50`, `51-100`, `101-250`, `251-500`, `501-1000`, `1001-5000`, `5001-10000`, `10001+`
+
+### Get Company (GET)
+
+Look up a single company by identifier.
+
+```bash
+orth api run fundable /company --query 'domain=stripe.com'
+```
+
+Parameters (provide ONE):
+- `id` — Company UUID
+- `domain` — Domain or full URL (e.g. `stripe.com`)
+- `linkedin` — LinkedIn company URL
+- `crunchbase` — Crunchbase organization URL
+
+### Search Companies (GET)
+
+Quick fuzzy search by name, or exact match by domain/LinkedIn/Crunchbase. Costs 0 credits.
+
+```bash
+orth api run fundable /company/search --query 'name=stripe'
+```
+
+Parameters (provide ONE):
+- `name` — Fuzzy name search with relevance scoring
+- `domain` — Exact domain match
+- `linkedin` — Full LinkedIn URL (required)
+- `crunchbase` — Full Crunchbase URL (required)
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "companies": [
+      {
+        "id": "uuid",
+        "guru_permalink": "stripe",
+        "name": "Stripe",
+        "short_description": "Stripe is an API-first global payments...",
+        "relevance_score": 120,
+        "domain": "stripe.com",
+        "linkedin": "https://linkedin.com/company/stripe",
+        "crunchbase": "https://crunchbase.com/organization/stripe"
+      }
+    ]
+  }
+}
+```
+
+### Company Deals (GET)
+
+Get all funding rounds for a company.
+
+```bash
+orth api run fundable /company/deals --query 'domain=stripe.com'
+```
+
+Parameters (provide ONE identifier + optional pagination):
+- `id`, `domain`, `linkedin`, `crunchbase`
+- `page` (0-based), `page_size` (1-100)
+
+---
+
+## Investors
+
+### List & Filter Investors (POST)
+
+Search and filter investors with portfolio-based filtering.
+
+```bash
+orth api run fundable /investors --body '{
+  "company_investments": {
+    "industries": ["artificial-intelligence"],
+    "financing_types": [{"type": "SERIES_A"}],
+    "deal_start_date": "2025-01-01"
+  },
+  "sort_by": "most_recent_deal",
+  "page_size": 25
+}'
+```
+
+**Filter sections:**
+- **`identifiers`** — `ids`, `domains`, `linkedin_urls`, `crunchbase_urls` (max 100 each)
+- **`investor`** — `locations`, `employee_count`
+- **`company_investments`** — Portfolio filters: `company_ids`, `industries`, `super_categories`, `locations`, `employee_count`, `ipo_status`, `total_raised_min`/`max`, `financing_types`, `deal_size_min`/`max`, `deal_start_date`/`end_date`, `only_lead_deals`, `min_matching_deals`
+
+**Sort options:** `most_recent_deal`, `recent_deals`, `deals_led_ltm`, `total_deals`, `matching_deals`
+
+### Get Investor (GET)
+
+Look up a single investor by identifier.
+
+```bash
+orth api run fundable /investor --query 'domain=sequoiacap.com'
+```
+
+Parameters (provide ONE):
+- `id`, `domain`, `linkedin`, `crunchbase`
+
+### Search Investors (GET)
+
+Quick fuzzy search by name, or exact match by domain/LinkedIn/Crunchbase. Costs 0 credits.
+
+```bash
+orth api run fundable /investor/search --query 'name=sequoia'
+```
+
+Parameters (provide ONE):
+- `name` — Fuzzy name search
+- `domain` — Exact domain match
+- `linkedin` — Full LinkedIn URL (required)
+- `crunchbase` — Full Crunchbase URL (required)
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "investors": [
+      {
+        "id": "uuid",
+        "guru_permalink": "sequoia-capital",
+        "name": "Sequoia Capital",
+        "description": "Sequoia is a venture capital firm...",
+        "image": "https://images.crunchbase.com/image/upload/...",
+        "relevance_score": 99,
+        "domain": "sequoiacap.com",
+        "website": "https://www.sequoiacap.com/",
+        "linkedin": "https://linkedin.com/company/sequoia-capital",
+        "crunchbase": "https://crunchbase.com/organization/sequoia-capital"
+      }
+    ]
+  }
+}
+```
+
+### Investor Deals (GET)
+
+Get all deals an investor participated in.
+
+```bash
+orth api run fundable /investor/deals --query 'domain=sequoiacap.com'
+```
+
+Parameters (provide ONE identifier + optional pagination):
+- `id`, `domain`, `linkedin`, `crunchbase`
+- `page` (0-based), `page_size` (1-100)
+
+---
+
+## Deals
+
+### List & Filter Deals (POST)
+
+Search and filter funding rounds.
+
+```bash
+orth api run fundable /deals --body '{
+  "deal": {
+    "financing_types": [{"type": "SERIES_A"}, {"type": "SERIES_B"}],
+    "date_start": "2025-01-01",
+    "size_min": 5000000
+  },
+  "company": {
+    "industries": ["artificial-intelligence"]
+  },
+  "sort_by": "most_recent_deal",
+  "page_size": 25
+}'
+```
+
+**Filter sections:**
+- **`identifiers`** — `deal_ids` (UUIDs)
+- **`deal`** — `financing_types`, `size_min`/`max`, `date_start`/`end`, `created_start`/`end`
+- **`company`** — `company_ids`, `locations`, `industries`, `super_categories`, `employee_count`, `total_raised_min`/`max`, `ipo_status`
+- **`investors`** — `investor_ids`
+
+**Sort options:** `most_recent_deal`, `oldest_deal`, `largest_raise`, `smallest_raise`
+
+### Get Deal (GET)
+
+Get a single deal by ID.
+
+```bash
+orth api run fundable /deals/{id}
+```
+
+### Get Deal Investors (GET)
+
+Get detailed investor info for a deal, including lead status and personnel.
+
+```bash
+orth api run fundable /deals/{id}/investors
+```
+
+---
+
+## Helpers
+
+### Location Search (GET)
+
+Find location permalinks for filtering. Costs 0 credits.
+
+```bash
+orth api run fundable /location/search --query 'name=san francisco'
+```
+
+Parameters:
+- `name`* — Location name to search
+- `type` — Filter by `CITY`, `STATE`, `REGION`, or `COUNTRY`
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "locations": [
+      {"permalink": "san-francisco-california", "name": "San Francisco", "location_type": "CITY"},
+      {"permalink": "san-francisco-bay-area", "name": "San Francisco Bay Area", "location_type": "REGION"}
+    ]
+  }
+}
+```
+
+### Industry Search (GET)
+
+Find industry permalinks for filtering. Costs 0 credits.
+
+```bash
+orth api run fundable /industry/search --query 'name=artificial intelligence'
+```
+
+Parameters:
+- `name`* — Industry name to search
+- `type` — Filter by `INDUSTRY` or `SUPER_CATEGORY`
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "industries": [
+      {"permalink": "artificial-intelligence", "name": "Artificial Intelligence (AI)", "industry_type": "INDUSTRY"},
+      {"permalink": "artificial-intelligence-e551", "name": "Artificial Intelligence (AI)", "industry_type": "SUPER_CATEGORY"}
+    ]
+  }
+}
+```
+
+---
+
+## Use Cases
+
+1. **Deal Flow Monitoring**: Filter companies by recent funding date to track new rounds
+2. **Investor Research**: Look up a VC firm's portfolio and recent deal activity
+3. **Market Mapping**: Find all companies in an industry/location with specific funding stages
+4. **Competitive Intelligence**: Look up a company's funding history and investors
+5. **Lead Generation**: Find recently funded companies by stage, size, and industry
+6. **LP Research**: Analyze investor deal patterns, lead rates, and portfolio focus
+
+## Discover More
+
+For full endpoint details and parameters:
+
+```bash
+orth api show fundable              # List all endpoints
+orth api show fundable /companies   # Get endpoint details
+```

--- a/skills/orthogonal-investor-recent-investments/SKILL.md
+++ b/skills/orthogonal-investor-recent-investments/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: investor-recent-investments
+description: Find an investment firm's most recent investments — look up a VC firm by domain/name and get the companies they recently invested in with full company details. Use when asked about a firm's recent deals, portfolio activity, latest investments, or "what has [firm] invested in recently?"
+---
+
+# Investor Recent Investments
+
+Find an investment firm's most recent investments with full company details. Two-step workflow:
+1. Search for the investor to get their ID(s)
+2. Use those IDs to find companies where the investor participated in the latest round
+
+## When to Use
+
+- User wants to know what companies a specific investor backed recently
+- User asks "what has Benchmark invested in recently?"
+
+---
+
+## Step 1: Search for the Investor
+
+Look up the investor by domain or name to get their UUID(s). A single domain like `benchmark.com` may return multiple entities.
+
+### By Domain
+
+```bash
+orth api run fundable /investor/search --query 'domain=benchmark.com'
+```
+
+### By Name
+
+```bash
+orth api run fundable /investor/search --query 'name=benchmark'
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "investors": [
+      {
+        "id": "abc123-...",
+        "guru_permalink": "benchmark",
+        "name": "Benchmark",
+        "description": "Benchmark is an early-stage venture capital firm...",
+        "image": "https://images.crunchbase.com/image/upload/...",
+        "relevance_score": 99,
+        "domain": "benchmark.com",
+        "website": "https://www.benchmark.com/",
+        "linkedin": "https://linkedin.com/company/benchmark",
+        "crunchbase": "https://crunchbase.com/organization/benchmark"
+      },
+      {
+        "id": "def456-...",
+        "guru_permalink": "benchmark-capital-partners",
+        "name": "Benchmark Capital Partners",
+        "description": "Benchmark Capital Partners...",
+        "image": null,
+        "relevance_score": 95,
+        "domain": "benchmark.com",
+        "website": "https://www.benchmark.com/",
+        "linkedin": null,
+        "crunchbase": null
+      }
+    ]
+  }
+}
+```
+
+Collect **all** `id` values from the response.
+
+---
+
+## Step 2: Get Their Recent Investments
+
+Pass the investor IDs into `POST /companies` using `latest_deal.investor_ids` to find companies where the investor participated in the **most recent round**.
+
+```bash
+orth api run fundable /companies --body '{
+  "latest_deal": {
+    "investor_ids": ["abc123-...", "def456-..."]
+  },
+  "sort_by": "most_recent_raise",
+  "page_size": 25
+}'
+```
+
+### With Optional Filters
+
+```bash
+orth api run fundable /companies --body '{
+  "latest_deal": {
+    "investor_ids": ["abc123-...", "def456-..."],
+    "financing_types": [{"type": "SERIES_A"}, {"type": "SERIES_B"}],
+    "date_start": "2025-01-01"
+  },
+  "company": {
+    "industries": ["artificial-intelligence"]
+  },
+  "sort_by": "most_recent_raise",
+  "page_size": 25
+}'
+```
+
+---
+
+## Parameters
+
+### Step 1: Investor Search
+- **`domain`** — Investor domain (e.g. `benchmark.com`)
+- **`name`** — Investor name, fuzzy search (e.g. `benchmark`)
+- **`linkedin`** — Full LinkedIn URL (e.g. `https://linkedin.com/company/benchmark`)
+- **`crunchbase`** — Full Crunchbase URL
+
+Only one parameter at a time.
+
+### Step 2: Companies Lookup
+- **`latest_deal.investor_ids`** — Array of investor UUIDs from Step 1 (required)
+- **`latest_deal.financing_types`** — Filter by round type (e.g. `[{"type": "SEED"}]`)
+- **`latest_deal.date_start`** — Only deals after this date (ISO 8601)
+- **`latest_deal.date_end`** — Only deals before this date (ISO 8601)
+- **`latest_deal.size_min`** / **`size_max`** — Deal size range in USD
+- **`company.industries`** — Filter by industry (e.g. `["artificial-intelligence"]`)
+- **`company.locations`** — Filter by location (e.g. `["san-francisco-california"]`)
+- **`company.ipo_status`** — `["private"]` or `["public"]`
+- **`sort_by`** — `most_recent_raise` (default), `largest_total_raise`, `most_funding_rounds`, etc.
+- **`page`** / **`page_size`** — Pagination (0-based, max 100 per page)
+
+---
+
+## Response (Step 2)
+
+```json
+{
+  "success": true,
+  "data": {
+    "companies": [
+      {
+        "id": "uuid",
+        "name": "Acme Corp",
+        "domain": "acme.com",
+        "short_description": "AI-powered solutions...",
+        "linkedin": "https://linkedin.com/company/acme",
+        "num_employees": "11-50",
+        "ipo_status": "private",
+        "total_raised": 15000000,
+        "num_funding_rounds": 2,
+        "num_investors": 5,
+        "industries": [{"name": "Artificial Intelligence", "permalink": "artificial-intelligence"}],
+        "location": {
+          "region": {"name": "North America", "permalink": "north-america"},
+          "country": {"name": "United States", "permalink": "united-states"},
+          "state": {"name": "California", "permalink": "california"},
+          "city": {"name": "San Francisco", "permalink": "san-francisco-california"}
+        },
+        "latest_deal": {
+          "id": "deal-uuid",
+          "type": "SERIES_A",
+          "size_native": 12000000,
+          "date": "2026-02-10T00:00:00Z",
+          "pre": false,
+          "extension": false,
+          "intermediate": "NONE",
+          "description": {
+            "short_description": "Acme Corp raised a $12M Series A round...",
+            "long_description": "Acme Corp secured $12 million in Series A funding..."
+          },
+          "investors": ["abc123-...", "other-investor-uuid"]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "total_count": 42,
+    "page": 0,
+    "page_size": 25,
+    "credits_used": 25
+  }
+}
+```
+
+---
+
+## Usage Examples
+
+| Use Case | Step 2 Key Parameters |
+|----------|----------------------|
+| All recent investments | `investor_ids` only, `sort_by: "most_recent_raise"` |
+| Investments this year | + `date_start: "2026-01-01"` |
+| Only Seed deals | + `financing_types: [{"type": "SEED"}]` |
+| AI companies only | + `company.industries: ["artificial-intelligence"]` |
+| Large rounds ($10M+) | + `size_min: 10000000` |
+
+---
+
+## Error Handling
+
+- **401** — Invalid or missing API key
+- **402** — Insufficient credits
+- **404** — Investor not found (Step 1) — try a different domain or name
+- **422** — Unknown parameter
+- **429** — Rate limit (200 req/min)
+- Empty arrays are not allowed — omit the field instead of sending `[]`
+
+## Tips
+
+- An investor can have multiple entities (e.g. `a16z.com` maps to a16z, a16z Speedrun, a16z Bio, etc.) — always collect **all** IDs from Step 1
+- `latest_deal.investor_ids` finds companies where the investor was in the **latest round only** — use `investors.investor_ids` instead if you want all-time portfolio companies
+- The investor search endpoint (`/investor/search`) costs 0 credits
+- Use `name` search if you don't know the firm's exact domain
+- Paginate with `page: 0`, `page: 1`, etc. — check `meta.total_count` for total results

--- a/skills/orthogonal-recent-funding-rounds/SKILL.md
+++ b/skills/orthogonal-recent-funding-rounds/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: recent-funding-rounds
+description: Find companies that raised funding recently (last week, last month, etc.) — search recent deals by date range, round type, size, industry, and location. Use when asked about recent funding rounds, new raises, latest deals, or weekly/monthly deal flow.
+---
+
+# Recent Funding Rounds
+
+Find companies that recently raised funding using the Fundable API. Filter by date range, round type, deal size, industry, location, and more.
+
+## When to Use
+
+- User asks "what companies raised funding this week?"
+- User wants to see recent seed rounds or Series A deals
+- User asks "what fintech companies recently raised"
+---
+
+## Get Recent Funding Rounds
+
+```bash
+orth api run fundable /companies --body '{
+  "latest_deal": {
+    "date_start": "2026-03-13",
+    "date_end": "2026-03-20"
+  },
+  "sort_by": "most_recent_raise",
+  "page_size": 25
+}'
+```
+
+> **Date calculation:** Set `date_start` to 7 days before today for "last week", 30 days for "last month". Use ISO 8601 format (YYYY-MM-DD).
+
+### With Filters
+
+```bash
+orth api run fundable /companies --body '{
+  "latest_deal": {
+    "date_start": "2026-03-13",
+    "date_end": "2026-03-20",
+    "financing_types": [{"type": "SEED"}],
+    "size_min": 1000000
+  },
+  "company": {
+    "industries": ["artificial-intelligence"],
+    "ipo_status": ["private"]
+  },
+  "sort_by": "most_recent_raise",
+  "page_size": 25
+}'
+```
+
+---
+
+## Parameters
+
+### Date Range (required for this use case)
+- **`latest_deal.date_start`** — Start date (ISO 8601, e.g. `"2026-03-13"`)
+- **`latest_deal.date_end`** — End date (ISO 8601, e.g. `"2026-03-20"`)
+
+### Deal Filters (optional)
+- **`latest_deal.financing_types`** — Array of objects: `{"type": "SEED"}`, `{"type": "SERIES_A"}`, etc. Supports: `SEED`, `SERIES_A` through `SERIES_M`, `SAFE`, `CONVERTIBLE_NOTE`, `EQUITY`, `PREFERRED`, `DEBT_FINANCING`, `GRANT`, `FUNDING_ROUND`, and more. Optional modifiers: `"pre": true` (e.g. Pre-Seed), `"extension": true`
+- **`latest_deal.size_min`** — Minimum deal size in USD
+- **`latest_deal.size_max`** — Maximum deal size in USD
+
+### Company Filters (optional)
+- **`company.industries`** — Industry permalinks (e.g. `["artificial-intelligence", "fintech-e067"]`)
+- **`company.locations`** — Location permalinks (e.g. `["san-francisco-california", "new-york"]`)
+- **`company.ipo_status`** — `["private"]` or `["public"]`
+- **`company.employee_count`** — e.g. `["1-10", "11-50", "51-100"]`
+- **`company.search_query`** — AI-powered semantic search (e.g. `"AI healthcare diagnostics"`)
+
+### Pagination & Sorting
+- **`page`** — Page number, 0-based (default: 0)
+- **`page_size`** — Results per page, 1-100 (default: 10)
+- **`sort_by`** — `most_recent_raise` (default), `largest_total_raise`, `most_funding_rounds`, `most_investors`, and others
+
+---
+
+## Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "companies": [
+      {
+        "id": "uuid",
+        "name": "Acme Corp",
+        "domain": "acme.com",
+        "short_description": "AI-powered solutions...",
+        "linkedin": "https://linkedin.com/company/acme",
+        "num_employees": "11-50",
+        "ipo_status": "private",
+        "total_raised": 15000000,
+        "num_funding_rounds": 2,
+        "num_investors": 5,
+        "industries": [{"name": "Artificial Intelligence", "permalink": "artificial-intelligence"}],
+        "location": {
+          "region": {"name": "North America", "permalink": "north-america"},
+          "country": {"name": "United States", "permalink": "united-states"},
+          "state": {"name": "California", "permalink": "california"},
+          "city": {"name": "San Francisco", "permalink": "san-francisco-california"}
+        },
+        "latest_deal": {
+          "id": "deal-uuid",
+          "type": "SEED",
+          "size_native": 5000000,
+          "date": "2026-03-18T00:00:00Z",
+          "pre": false,
+          "extension": false,
+          "intermediate": "NONE",
+          "description": {
+            "short_description": "Acme Corp raised a $5M seed round...",
+            "long_description": "Acme Corp secured $5 million in seed funding..."
+          },
+          "investors": ["investor-uuid-1", "investor-uuid-2"]
+        }
+      }
+    ]
+  },
+  "meta": {
+    "total_count": 147,
+    "page": 0,
+    "page_size": 25,
+    "credits_used": 25
+  }
+}
+```
+
+---
+
+## Usage Examples
+
+| Use Case | Key Parameters |
+|----------|---------------|
+| All rounds this week | `date_start` = 7 days ago, `date_end` = today |
+| Seed rounds this month | + `financing_types: [{"type": "SEED"}]` |
+| Series A+ in fintech | + `financing_types: [{"type": "SERIES_A"}, {"type": "SERIES_B"}]`, `industries: ["fintech-e067"]` |
+| Large rounds ($10M+) | + `size_min: 10000000` |
+| AI startups in SF | + `search_query: "artificial intelligence"`, `locations: ["san-francisco-california"]` |
+
+---
+
+## Error Handling
+
+- **401** — Invalid or missing API key. Check `$FUNDABLE_API_KEY`
+- **402** — Insufficient credits. Visit https://tryfundable.ai/api-access
+- **422** — Unknown parameter. Check field names match exactly
+- **429** — Rate limit (200 req/min). Wait and retry
+- Empty arrays are not allowed — omit the field instead of sending `[]`
+
+## Tips
+
+- Calculate dates dynamically: `date -v-7d +%Y-%m-%d` (macOS) or `date -d '7 days ago' +%Y-%m-%d` (Linux)
+- Use `page_size: 100` to get more results per request (max 100)
+- Paginate with `page: 0`, `page: 1`, etc. — check `meta.total_count` for total results
+- `sort_by` is ignored when using `search_query` (results sort by relevance instead)
+- Each API call costs credits based on `page_size` — use smaller pages if browsing


### PR DESCRIPTION
## Summary

Adds 3 new skills for the Fundable VC-data API:

- **orthogonal-fundable** — full API reference covering all 13 endpoints (companies, investors, deals, location/industry helpers)
- **orthogonal-recent-funding-rounds** — find companies that raised recently by date range, stage, industry, size
- **orthogonal-investor-recent-investments** — two-step workflow: find a VC firm → list companies they most recently backed

Source: https://github.com/Jklionsky/fundable-api-example/tree/main/skills/orthogonal

## Fix included

The source copy of the fundable SKILL.md used + as a space in two query-param examples (name=san+francisco, name=artificial+intelligence). The orth CLI passes + through literally, so those commands returned empty results. Changed both to literal spaces, which works.

## Test plan

- [x] orth api show fundable — lists all 13 endpoints, matches every path referenced in the 3 skills
- [x] orth api run fundable /company/search --query 'name=stripe' — returns Stripe
- [x] orth api run fundable /investor/search --query 'name=benchmark' — returns Benchmark entities
- [x] orth api run fundable /location/search --query 'name=san francisco' — returns SF permalinks (post-fix)
- [x] orth api run fundable /industry/search --query 'name=artificial intelligence' — returns AI permalinks (post-fix)
- [x] orth api run fundable /companies with a latest_deal date window — returns recently-raised companies
- [ ] Reviewer sanity check: skim the 3 SKILL.md files and the README Company Intelligence rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)