### PR TITLE
feat: add Hermes as supported agent in find-skill

### DIFF
--- a/skills/orthogonal-find-skill/SKILL.md
+++ b/skills/orthogonal-find-skill/SKILL.md
@@ -67,7 +67,15 @@ orth skills add restaurant-booking
 orth skills add weather && cat ~/.openclaw/skills/weather/SKILL.md
 ```
 
-Skills are installed to `~/.openclaw/skills/<slug>/`
+The CLI installs skills for all supported agents:
+- **Cursor** — `~/.cursor/skills/`
+- **Claude Code** — `~/.claude/skills/`
+- **Copilot**
+- **Windsurf**
+- **Codex**
+- **Gemini**
+- **OpenClaw** — `~/.openclaw/skills/`
+- **Hermes** — `~/.hermes/skills/`
 
 ## Using Installed Skills
 

--- a/skills/orthogonal-find-skill/SKILL.md
+++ b/skills/orthogonal-find-skill/SKILL.md
@@ -70,10 +70,10 @@ orth skills add weather && cat ~/.openclaw/skills/weather/SKILL.md
 The CLI installs skills for all supported agents:
 - **Cursor** — `~/.cursor/skills/`
 - **Claude Code** — `~/.claude/skills/`
-- **Copilot**
-- **Windsurf**
-- **Codex**
-- **Gemini**
+- **Copilot** — `~/.github/skills/`
+- **Windsurf** — `~/.codeium/windsurf/skills/`
+- **Codex** — `~/.agents/skills/`
+- **Gemini** — `~/.gemini/skills/`
 - **OpenClaw** — `~/.openclaw/skills/`
 - **Hermes** — `~/.hermes/skills/`
 


### PR DESCRIPTION
Adds Hermes (`~/.hermes/skills/`) to the list of supported agents in the find-skill SKILL.md, alongside Cursor, Claude Code, Copilot, Windsurf, Codex, Gemini, and OpenClaw.