### PR TITLE
update Fiber API parameter schemas across 6 skills

### DIFF
--- a/skills/orthogonal-company-funding-search/SKILL.md
+++ b/skills/orthogonal-company-funding-search/SKILL.md
@@ -83,7 +83,7 @@ Best for: Finding companies by funding stage, industry, location, etc.
 ### Natural Language Company Search
 
 ```bash
-orth run -X POST fiber /v1/natural-language-search/companies -d '{"query":"AI companies that raised Series B in 2024","limit":10}'
+orth run -X POST fiber /v1/natural-language-search/companies -d '{"query":"AI companies that raised Series B in 2024","pageSize":10}'
 ```
 
 <details>
@@ -93,7 +93,7 @@ orth run -X POST fiber /v1/natural-language-search/companies -d '{"query":"AI co
 curl -X POST https://api.orth.sh/v1/run/fiber/v1/natural-language-search/companies \
   -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"query":"AI companies that raised Series B in 2024","limit":10}'
+  -d '{"query":"AI companies that raised Series B in 2024","pageSize":10}'
 ```
 </details>
 
@@ -102,7 +102,7 @@ curl -X POST https://api.orth.sh/v1/run/fiber/v1/natural-language-search/compani
 Search for investors/VCs (filter-based, not natural language):
 
 ```bash
-orth run -X POST fiber /v1/investor-search -d '{"searchParams":{},"limit":10}'
+orth run -X POST fiber /v1/investor-search -d '{"searchParams":{},"pageSize":10}'
 ```
 
 <details>
@@ -112,7 +112,7 @@ orth run -X POST fiber /v1/investor-search -d '{"searchParams":{},"limit":10}'
 curl -X POST https://api.orth.sh/v1/run/fiber/v1/investor-search \
   -H "Authorization: Bearer $ORTHOGONAL_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"searchParams":{},"limit":10}'
+  -d '{"searchParams":{},"pageSize":10}'
 ```
 </details>
 

--- a/skills/orthogonal-comprehensive-enrichment/SKILL.md
+++ b/skills/orthogonal-comprehensive-enrichment/SKILL.md
@@ -33,7 +33,7 @@ Run ALL of these in parallel where possible. Collect everything, then compile.
 **Fiber kitchen-sink** (accepts LinkedIn URL, email, or name+company):
 ```bash
 # By LinkedIn URL:
-orth run fiber /v1/kitchen-sink/person --body '{"profileIdentifier": "https://linkedin.com/in/johndoe"}'
+orth run fiber /v1/kitchen-sink/person --body '{"profileIdentifier": {"identifier": "linkedinUrl", "value": "https://www.linkedin.com/in/johndoe"}}'
 
 # By email:
 orth run fiber /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com"}'
@@ -42,7 +42,7 @@ orth run fiber /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com
 orth run fiber /v1/kitchen-sink/person --body '{
   "personName": {"fullName": "John Doe"},
   "companyName": {"name": "Stripe"},
-  "companyDomain": {"domain": "stripe.com"}
+  "companyDomain": {"value": "stripe.com"}
 }'
 ```
 
@@ -158,7 +158,7 @@ orth run hunter /v2/domain-search --query domain=stripe.com
 
 **Fiber company data** (LinkedIn-enriched):
 ```bash
-orth run fiber /v1/kitchen-sink/company --body '{"companyDomain": {"domain": "stripe.com"}}'
+orth run fiber /v1/kitchen-sink/company --body '{"companyDomain": {"value": "stripe.com"}}'
 ```
 
 ### 3b. Leadership & Employees
@@ -228,7 +228,7 @@ Cross-reference all API results. Merge overview, leadership, funding, products, 
 **Step 2: Person enrichment** (run in parallel):
 ```bash
 # Profile (3 sources)
-orth run fiber /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com", "companyDomain": {"domain": "stripe.com"}}'
+orth run fiber /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com", "companyDomain": {"value": "stripe.com"}}'
 orth run nyne /person/search -d '{"query": "john stripe.com"}'
 orth run sixtyfour /enrich-lead --body '{"lead_info": {"email": "john@stripe.com", "company": "Stripe"}, "struct": {"work_email": "Work email", "personal_email": "Personal email", "phone": "Phone", "title": "Title", "bio": "Bio"}}'
 
@@ -263,7 +263,7 @@ orth run -X POST nyne /person/newsfeed -d '{"social_media_url": "https://x.com/T
 # Overview
 orth run brand-dev /v1/brand/retrieve --query domain=stripe.com
 orth run hunter /v2/domain-search --query domain=stripe.com
-orth run fiber /v1/kitchen-sink/company --body '{"companyDomain": {"domain": "stripe.com"}}'
+orth run fiber /v1/kitchen-sink/company --body '{"companyDomain": {"value": "stripe.com"}}'
 
 # Leadership
 orth run fiber /v1/natural-language-search/profiles --body '{"query": "CEO, CTO, CFO, COO, VP at Stripe", "pageSize": 10}'

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -107,7 +107,7 @@ Parameters:
 - getDetailedWorkExperience (['boolean', 'null']) - Whether to include deep details about each work experience item, like the company's LinkedIn URL, website, location, etc. That'll be put in the detailedWorkExperience array. This slows down the API call, so only enable this if you need it.
 
 ```bash
-orth api run fiber /v1/kitchen-sink/person --body '{"linkedin_url": "https://linkedin.com/in/johndoe"}'
+orth api run fiber /v1/kitchen-sink/person --body '{"profileIdentifier": {"identifier": "linkedinUrl", "value": "https://www.linkedin.com/in/johndoe"}}'
 ```
 
 ### Kitchen sink company lookup
@@ -120,7 +120,7 @@ Parameters:
 - numCompanies (integer) - The number of companies you want to fetch. Companies are sorted by best match first.
 
 ```bash
-orth api run fiber /v1/kitchen-sink/company --body '{"domain": "openai.com"}'
+orth api run fiber /v1/kitchen-sink/company --body '{"companyDomain": {"value": "openai.com"}}'
 ```
 
 ### Investor search
@@ -159,7 +159,7 @@ Parameters:
 - value* (string) - The company's LinkedIn slug (e.g., 'microsoft'), LinkedIn URL (e.g., 'https://www.linkedin.com/company/microsoft' or 'https://www.linkedin.com/company/1441'), LinkedIn organization ID (e.g., '1441' for Google), or Fiber company ID (e.g., 'comp_1441')
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/company/single --body '{"identifier": "https://linkedin.com/company/openai"}'
+orth api run fiber /v1/linkedin-live-fetch/company/single --body '{"type": "liUrl", "value": "https://www.linkedin.com/company/openai"}'
 ```
 
 ### People search
@@ -190,7 +190,7 @@ Parameters:
 - cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/post-comments --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
+orth api run fiber /v1/linkedin-live-fetch/post-comments --body '{"contentId": "urn:li:activity:7123456789012345678"}'
 ```
 
 ### Company search
@@ -258,7 +258,7 @@ Parameters:
 - cursor (['string', 'null']) - Pagination cursor for fetching additional pages of posts
 
 ```bash
-orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
+orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"contentId": "urn:li:activity:7123456789012345678", "reactionType": "LIKE"}'
 ```
 
 ## Use Cases

--- a/skills/orthogonal-find-dentists/SKILL.md
+++ b/skills/orthogonal-find-dentists/SKILL.md
@@ -117,7 +117,7 @@ Run in parallel for all practices with websites. This is the **most reliable met
 
 ```bash
 orth run fiber /v1/kitchen-sink/person --body '{
-  "profileIdentifier": "https://linkedin.com/in/drmanali"
+  "profileIdentifier": {"identifier": "linkedinUrl", "value": "https://www.linkedin.com/in/drmanali"}
 }'
 ```
 

--- a/skills/orthogonal-find-twitter-influencers/SKILL.md
+++ b/skills/orthogonal-find-twitter-influencers/SKILL.md
@@ -246,7 +246,7 @@ Launch ALL these Exa searches in parallel (multiple tool calls in a single messa
 ```bash
 # With LinkedIn URL (best match rate — ALWAYS prefer this):
 orth run fiber /v1/kitchen-sink/person --body '{
-  "profileIdentifier": "https://linkedin.com/in/janesmith"
+  "profileIdentifier": {"identifier": "linkedinUrl", "value": "https://www.linkedin.com/in/janesmith"}
 }'
 ```
 

--- a/skills/orthogonal-targeted-prospecting/SKILL.md
+++ b/skills/orthogonal-targeted-prospecting/SKILL.md
@@ -194,7 +194,7 @@ orth run sixtyfour /enrich-lead --body '{
 
 ```bash
 orth run fiber /v1/kitchen-sink/person --body '{
-  "profileIdentifier": "{linkedin_url}"
+  "profileIdentifier": {"identifier": "linkedinUrl", "value": "{linkedin_url}"}
 }'
 ```
 


### PR DESCRIPTION
## Summary

  - Fix `profileIdentifier` parameter in kitchen-sink/person calls: must be a discriminated union `{"identifier": "linkedinUrl", "value":
  "..."}`, not a plain URL string
  - Fix `companyDomain` parameter in kitchen-sink/company calls: uses `{"value": "..."}`, not `{"domain": "..."}`
  - Fix company live-fetch parameter: requires `{"type": "liUrl", "value": "..."}`, not `{"identifier": "..."}`
  - Fix post-comments and post-reactions: use `{"contentId": "urn:li:activity:..."}`, not `{"identifier": "https://..."}`
  - Fix pagination parameter: Fiber uses `pageSize`, not `limit`

  ## Files Changed

  - `skills/orthogonal-fiber/SKILL.md` — 5 endpoint example corrections
  - `skills/orthogonal-comprehensive-enrichment/SKILL.md` — profileIdentifier + companyDomain fixes
  - `skills/orthogonal-company-funding-search/SKILL.md` — limit → pageSize (orth + curl)
  - `skills/orthogonal-targeted-prospecting/SKILL.md` — profileIdentifier fix
  - `skills/orthogonal-find-twitter-influencers/SKILL.md` — profileIdentifier fix
  - `skills/orthogonal-find-dentists/SKILL.md` — profileIdentifier fix

  ## Why

  These examples used incorrect JSON schemas that would produce 400 errors when agents execute them against the Fiber API. Verified correct
  schemas against Fiber's OpenAPI spec and live API.

  ## Test plan

  - [ ] Verify `orth api run fiber /v1/kitchen-sink/person` with corrected `profileIdentifier` format returns 200
  - [ ] Verify `orth api run fiber /v1/kitchen-sink/company` with corrected `companyDomain` format returns 200
  - [ ] Verify `orth api run fiber /v1/linkedin-live-fetch/company/single` with `type`+`value` returns 200
  - [ ] Verify NL search with `pageSize` param paginates correctly

