### PR TITLE
Enhance Fiber AI documentation with new contact details features

### DIFF
--- a/skills/orthogonal-contact-reveal/SKILL.md
+++ b/skills/orthogonal-contact-reveal/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: contact-reveal
+description: Reveal work emails, personal emails, and phone numbers from a LinkedIn profile URL
+---
+
+# Contact Reveal - Emails & Phone Numbers from LinkedIn
+
+Given a LinkedIn URL, reveal work emails, personal emails, and phone numbers. Three tiers available depending on speed, cost, and coverage needs. Batch mode for lists up to 2000 people.
+
+## When to Use
+
+- User has a LinkedIn profile URL and needs contact info
+- Sales outreach — need verified work email for a prospect
+- Recruiting — need personal email or phone for a candidate
+- Bulk enrichment — have a list of LinkedIn URLs to enrich
+
+## Choosing a Tier
+
+| Tier | Speed | Cost | Coverage | Best For |
+|------|-------|------|----------|----------|
+| Standard | ~30s | 5 credits | Good | Default choice, balanced |
+| Turbo | ~10s | 7 credits | Good | Time-sensitive, real-time flows |
+| Exhaustive | ~60s (async) | 12 credits | Maximum | Critical contacts, need every possible email/phone |
+
+*Costs above are for all contact types. Requesting fewer types costs less (e.g., work email only = 2 credits on standard).*
+
+## Workflow
+
+### Option A: Single Person (Standard)
+
+Best default choice — good coverage at lowest cost:
+
+```bash
+orth api run fiber /v1/contact-details/single --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true},
+  "validateEmails": true
+}'
+```
+
+### Option B: Single Person (Turbo — Fastest)
+
+When you need results in seconds (e.g., real-time enrichment during a call):
+
+```bash
+orth api run fiber /v1/contact-details/turbo/sync --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}
+}'
+```
+
+### Option C: Single Person (Exhaustive — Maximum Coverage)
+
+When the contact is high-value and you need every possible email/phone:
+
+```bash
+# Step 1: Start the exhaustive search
+orth api run fiber /v1/contact-details/exhaustive/start --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}
+}'
+
+# Step 2: Poll for results (repeat until complete)
+orth api run fiber /v1/contact-details/exhaustive/poll --body '{"taskId": "TASK_ID_FROM_STEP_1"}'
+```
+
+### Option D: Batch (Up to 2000 People)
+
+For enriching a list of prospects:
+
+```bash
+# Step 1: Start batch job
+orth api run fiber /v1/contact-details/batch/start --body '{
+  "personDetails": [
+    {"linkedinUrl": {"value": "https://www.linkedin.com/in/johndoe"}},
+    {"linkedinUrl": {"value": "https://www.linkedin.com/in/janedoe"}},
+    {"linkedinUrl": {"value": "https://www.linkedin.com/in/bobsmith"}}
+  ],
+  "enrichmentTypes": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}
+}'
+
+# Step 2: Poll for results (repeat until done=true)
+orth api run fiber /v1/contact-details/batch/poll --body '{"taskId": "TASK_ID_FROM_STEP_1", "take": 100}'
+```
+
+Use `cursor` from the response to paginate through large result sets.
+
+## Example Usage
+
+```bash
+# Just work email (cheapest — 2 credits)
+orth api run fiber /v1/contact-details/single --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": false, "getPhoneNumbers": false}
+}'
+
+# Just phone number (3 credits)
+orth api run fiber /v1/contact-details/single --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": false, "getPersonalEmails": false, "getPhoneNumbers": true}
+}'
+
+# All contact info, fastest possible
+orth api run fiber /v1/contact-details/turbo/sync --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}
+}'
+```
+
+## Tips
+
+- **Start with standard** — use turbo only when speed is critical, exhaustive only for high-value targets
+- **Request only what you need** — fewer contact types = lower cost (work email only is 2 credits vs 5 for everything)
+- **Batch requires full URLs** — use `https://www.linkedin.com/in/slug`, NOT bare slugs. Single/turbo/exhaustive accept bare slugs.
+- **Only person profiles** — only `/in/`, `/sales/lead/`, or `/talent/profile/` URLs work. Company URLs (`/company/`) will error.
+- **Check email status** — turbo and exhaustive return a `status` field per email (`valid`, `risky`, `unknown`, `invalid`). Standard does not include `status`. Filter before outreach when available.
+- **Check phone type** — each phone includes a `type` field: `mobile`, `other`, or `unknown`
+- **Duplicates are deduped** — batch charges are calculated after deduplication
+- **Undelivered = refunded** — if no contact info is found for a person, credits are refunded
+
+## Discover More
+
+List all endpoints, or add a path for parameter details:
+
+```bash
+orth api show fiber
+orth api show fiber /v1/contact-details/single
+```
+
+Example: `orth api show fiber /v1/contact-details/single` for endpoint parameters.

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fiber
-description: People, company, investor, and job search with LinkedIn data enrichment
+description: People, company, investor, job search, contact details reveal, and LinkedIn data enrichment
 ---
 
 # Fiber AI - People & Company Intelligence
@@ -26,6 +26,10 @@ Comprehensive search and enrichment for people, companies, investors, and jobs.
 - **Convert text into profile search filters**: Takes free-form text (e
 - **Job postings search**: Search for job postings with flexible filtering capabilities
 - **Fetch LinkedIn post reactions**: Fetches paginated reactions of a specific type for a LinkedIn post
+- **Reveal contact details (standard)**: Get work emails, personal emails, and phone numbers from a LinkedIn URL (sync, balanced speed/cost)
+- **Reveal contact details (turbo)**: Fastest contact reveal with premium enrichment stack (sync, higher cost)
+- **Reveal contact details (exhaustive)**: Maximum-coverage async contact reveal with all waterfall steps (start + poll)
+- **Batch contact details**: Reveal contact details for up to 2000 people in batch (start + poll)
 
 ## Usage
 
@@ -261,6 +265,97 @@ Parameters:
 orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
 ```
 
+### Reveal contact details (standard)
+Standard synchronous contact reveal — best balance of speed, cost, and coverage. Only requires a LinkedIn URL; profile details are resolved automatically.
+
+Parameters:
+- linkedinUrl* (string) - The person's LinkedIn URL (e.g. 'https://www.linkedin.com/in/william-h-gates') or a bare slug (e.g. 'william-h-gates')
+- enrichmentType (object) - What to request: `getWorkEmails` (bool), `getPersonalEmails` (bool), `getPhoneNumbers` (bool). All default to true.
+- validateEmails (boolean) - Whether to bounce-validate emails before returning them. Default true.
+
+Cost (per request): 5 credits (all phones + all emails), 2 credits (work email only), 2 credits (personal email only), 3 credits (phone only), 3 credits (all emails). Timeout: 2 minutes.
+
+```bash
+orth api run fiber /v1/contact-details/single --body '{"linkedinUrl": "https://www.linkedin.com/in/johndoe", "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": false, "getPhoneNumbers": false}}'
+```
+
+### Reveal contact details (turbo)
+Fastest synchronous contact reveal — optimized for speed at a higher credit cost. Uses a premium enrichment stack for lowest latency.
+
+Parameters:
+- linkedinUrl* (string) - The person's LinkedIn URL or entity URN
+- enrichmentType (object) - Same as standard: `getWorkEmails`, `getPersonalEmails`, `getPhoneNumbers`
+
+Cost (per request): 7 credits (all phones + all emails), 3 credits (work email only), 3 credits (personal email only), 5 credits (phone only), 5 credits (all emails). Timeout: 90 seconds.
+
+```bash
+orth api run fiber /v1/contact-details/turbo/sync --body '{"linkedinUrl": "https://www.linkedin.com/in/johndoe", "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}}'
+```
+
+### Start exhaustive contact details reveal
+Maximum-coverage contact reveal — async. Runs all waterfall steps in parallel for the most comprehensive results. Call this to start, then poll with the returned task ID.
+
+Parameters:
+- linkedinUrl* (string) - Person's LinkedIn URL or slug
+- enrichmentType (object) - Same as standard: `getWorkEmails`, `getPersonalEmails`, `getPhoneNumbers`
+
+Cost (per request): 12 credits (all phones + all emails), 5 credits (work email only), 5 credits (personal email only), 4 credits (phone only), 9 credits (all emails).
+
+```bash
+orth api run fiber /v1/contact-details/exhaustive/start --body '{"linkedinUrl": "https://www.linkedin.com/in/johndoe", "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}}'
+```
+
+### Poll exhaustive contact details reveal result
+Polls the status of an exhaustive contact reveal task. Returns current status and, once complete, the full set of discovered emails and phone numbers.
+
+Parameters:
+- taskId* (string) - Task ID from the start endpoint
+
+```bash
+orth api run fiber /v1/contact-details/exhaustive/poll --body '{"taskId": "TASK_ID_FROM_START"}'
+```
+
+### Start batch contact details
+Starts fetching contact details for multiple people (up to 2000) in batch. Async — use polling endpoint to check progress and get results.
+
+Parameters:
+- personDetails* (array) - Array of objects, each with `linkedinUrl: {value: "https://www.linkedin.com/in/..."}`
+- enrichmentTypes (object) - Same as standard: `getWorkEmails`, `getPersonalEmails`, `getPhoneNumbers`
+
+Cost: Same as standard per person. Credits charged upfront (after deduping). Undelivered data is refunded.
+
+```bash
+orth api run fiber /v1/contact-details/batch/start --body '{
+  "personDetails": [
+    {"linkedinUrl": {"value": "https://www.linkedin.com/in/johndoe"}},
+    {"linkedinUrl": {"value": "https://www.linkedin.com/in/janedoe"}}
+  ],
+  "enrichmentTypes": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}
+}'
+```
+
+### Poll batch contact details
+Polls a batch contact details task. Returns partial results as they complete. Call repeatedly until `done` is true.
+
+Parameters:
+- taskId* (string) - Task ID from the batch start endpoint
+- cursor (string|null) - Pagination cursor from previous poll response
+- take (integer) - Number of people to return per page (max 100, default 100)
+
+```bash
+orth api run fiber /v1/contact-details/batch/poll --body '{"taskId": "TASK_ID_FROM_START"}'
+```
+
+### Contact details — tips and gotchas
+
+- **Only person profile URLs** — only `/in/`, `/sales/lead/`, or `/talent/profile/` LinkedIn URLs are accepted. Company URLs (`/company/`) will produce a server error.
+- **Batch requires full URLs** — the batch endpoint enforces a strict regex and does NOT accept bare slugs. Use full LinkedIn URLs like `https://www.linkedin.com/in/slug`. The single/turbo/exhaustive endpoints accept bare slugs.
+- **`enrichmentType` controls billing, not filtering** — data may still appear from cached sources even when a type is set to `false`. You are only charged for the types you request.
+- **Email `status` field** — each returned email includes a `status`: `valid`, `risky`, `unknown`, or `invalid`. Use this to filter before outreach.
+- **Phone `type` field** — each returned phone includes a `type`: `mobile`, `other`, or `unknown`.
+- **Rate limits** — `/single`: 200/min, `/turbo/sync`: 120/min, `/exhaustive/start`: 120/min, `/batch/start`: 30/min, `/poll` endpoints: 240/min.
+- **402 = out of credits** — the 402 response includes an `outOfCreditsAlert` object with remaining balance and a URL to top up.
+
 ## Use Cases
 
 1. **Recruiting**: Find candidates matching specific criteria
@@ -268,6 +363,7 @@ orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier":
 3. **Fundraising**: Research investors in your space
 4. **Competitive Intel**: Track companies and their employees
 5. **Job Search**: Find relevant job opportunities
+6. **Contact Enrichment**: Reveal work/personal emails and phone numbers from LinkedIn profiles
 
 ## Discover More
 

--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -351,7 +351,7 @@ orth api run fiber /v1/contact-details/batch/poll --body '{"taskId": "TASK_ID_FR
 - **Only person profile URLs** — only `/in/`, `/sales/lead/`, or `/talent/profile/` LinkedIn URLs are accepted. Company URLs (`/company/`) will produce a server error.
 - **Batch requires full URLs** — the batch endpoint enforces a strict regex and does NOT accept bare slugs. Use full LinkedIn URLs like `https://www.linkedin.com/in/slug`. The single/turbo/exhaustive endpoints accept bare slugs.
 - **`enrichmentType` controls billing, not filtering** — data may still appear from cached sources even when a type is set to `false`. You are only charged for the types you request.
-- **Email `status` field** — each returned email includes a `status`: `valid`, `risky`, `unknown`, or `invalid`. Use this to filter before outreach.
+- **Email `status` field** — turbo and exhaustive tiers return a `status` per email (`valid`, `risky`, `unknown`, `invalid`). Standard (`/single`) does not include `status`. Use this to filter before outreach when available.
 - **Phone `type` field** — each returned phone includes a `type`: `mobile`, `other`, or `unknown`.
 - **Rate limits** — `/single`: 200/min, `/turbo/sync`: 120/min, `/exhaustive/start`: 120/min, `/batch/start`: 30/min, `/poll` endpoints: 240/min.
 - **402 = out of credits** — the 402 response includes an `outOfCreditsAlert` object with remaining balance and a URL to top up.


### PR DESCRIPTION
## Summary                                                                                                                                    
                                                                                                                                                
  - Add 6 contact-details endpoints to the Fiber skill: standard, turbo, exhaustive (start+poll), batch (start+poll)                            
  - Add tips/gotchas section covering billing behavior, URL validation, rate limits, and error handling                                         
  - Update capabilities list and description                                                                                                    
                                                                                                                            
  ## Endpoints added                                                                                                                            
                                                                                                                                                
  | Path | Type | Cost |                                                                                                                      
  |------|------|------|                                                                                                                        
  | `/v1/contact-details/single` | sync | 2-5 credits |                                                                                       
  | `/v1/contact-details/turbo/sync` | sync (fastest) | 3-7 credits |                                                                           
  | `/v1/contact-details/exhaustive/start` | async start | 4-12 credits |                                                                       
  | `/v1/contact-details/exhaustive/poll` | async poll | free |                                                                                 
  | `/v1/contact-details/batch/start` | batch start (up to 2000) | 2-5 credits/person |                                                         
  | `/v1/contact-details/batch/poll` | batch poll | free |                                                                                      
                                                                                                                                                
  ## Test plan                                                                                                                                  
                                                                                                                                                
  - [ ] Verify `orth api run fiber /v1/contact-details/single` routes correctly after registry update                                           
  - [ ] Verify batch endpoint accepts array of LinkedIn URLs                                                                                    
  - [ ] Verify exhaustive start returns taskId, poll returns results                                                                          
                                                                                                                                                
  ---                                                           