### PR TITLE
feat: add Fiber discovery endpoints and workflow skills (GitHub-to-LinkedIn, stealth founders, JD search)

### DIFF
--- a/skills/orthogonal-fiber/SKILL.md
+++ b/skills/orthogonal-fiber/SKILL.md
@@ -26,6 +26,11 @@ Comprehensive search and enrichment for people, companies, investors, and jobs.
 - **Convert text into profile search filters**: Takes free-form text (e
 - **Job postings search**: Search for job postings with flexible filtering capabilities
 - **Fetch LinkedIn post reactions**: Fetches paginated reactions of a specific type for a LinkedIn post
+- **Find person by GitHub username (single)**: Given a GitHub username, find the person's LinkedIn profile and extract work emails
+- **Start GitHub to LinkedIn batch lookup**: Convert up to 1000 GitHub usernames to LinkedIn profiles in batch
+- **Poll GitHub to LinkedIn batch results**: Poll for results of a batch GitHub-to-LinkedIn lookup
+- **Search stealth/ex-stealth founders**: Find people currently at stealth-mode companies, or who recently left stealth
+- **Search profiles from a job description**: Paste a raw job description and get matching LinkedIn profiles
 
 ## Usage
 
@@ -261,6 +266,90 @@ Parameters:
 orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier": "https://linkedin.com/feed/update/urn:li:activity:1234"}'
 ```
 
+### Find person by GitHub username (single)
+Given a GitHub username, find the person's LinkedIn profile and extract work emails. Synchronous — returns results directly.
+
+Parameters:
+- githubUsername* (string) - The GitHub username to look up (NOT a URL, just the username)
+- outputType (string) - What to extract: `linkedin` (find LinkedIn), `email` (extract work emails from commits), `both` (default). Cost varies by type.
+
+Cost: 5 credits (LinkedIn lookup) + 3 credits (email extraction). Use `outputType: "linkedin"` or `"email"` to pay for only what you need. Timeout: 2 minutes.
+
+```bash
+orth api run fiber /v1/github-to-linkedin/single --body '{"githubUsername": "torvalds", "outputType": "both"}'
+```
+
+Returns: `linkedInUrl`, `linkedInSlug`, `confidenceOutOf10` (0-10), `matchSource`, `extractedEmails[]`, `githubProfile` (name, company, bio, etc).
+
+### Start GitHub to LinkedIn batch lookup
+Convert up to 1000 GitHub usernames to LinkedIn profiles in batch. Async — use polling endpoint to get results.
+
+Parameters:
+- people* (array) - Array of objects with `githubUsername` (string). Max 1000.
+- outputType (string) - `linkedin`, `email`, or `both` (default: `linkedin`)
+- overallContext (string|null) - What the people have in common (e.g. "YC founders 2021 batch"). Helps disambiguate.
+
+Cost: 1 credit/person (linkedin only), 1 credit/person (email only), 2 credits/person (both). Rate limit: 30/min.
+
+```bash
+orth api run fiber /v1/github-to-linkedin/trigger --body '{
+  "people": [
+    {"githubUsername": "torvalds"},
+    {"githubUsername": "gaearon"}
+  ],
+  "outputType": "linkedin",
+  "overallContext": "Notable open source maintainers"
+}'
+```
+
+### Poll GitHub to LinkedIn batch results
+Poll for results of a batch GitHub-to-LinkedIn lookup.
+
+Parameters:
+- githubAgentRunId* (string) - Run ID from the trigger endpoint
+- cursor (string|null) - Pagination cursor from previous response
+- pageSize (number) - Results per page (default 10, max 100)
+
+```bash
+orth api run fiber /v1/github-to-linkedin/polling --body '{"githubAgentRunId": "RUN_ID_FROM_TRIGGER"}'
+```
+
+### Search stealth/ex-stealth founders
+Find people currently at stealth-mode companies, or who recently left stealth (launched). Supports profile search filters.
+
+Parameters:
+- stealthConfig* (object) - `{"mode": "in-stealth"}` for current stealth founders, or `{"mode": "left-stealth"}` for exited founders. Optional date filters available.
+- searchParams (object) - Standard people-search filters (location, keywords, job titles, etc.)
+- pageSize (integer) - Number of profiles per page (max 1000)
+- cursor (string|null) - Pagination cursor
+
+Cost: 1 credit per profile found. Rate limit: 120/min.
+
+```bash
+orth api run fiber /v1/stealth-founders/search --body '{"stealthConfig": {"mode": "in-stealth"}, "pageSize": 10}'
+```
+
+### Search profiles from a job description
+Paste a raw job description and get matching LinkedIn profiles. Ideal for sourcing candidates directly from a JD.
+
+Parameters:
+- search* (object) - For first page: `{"request": "initial", "query": "...full JD text..."}`. For next pages: `{"request": "next", "cursor": "..."}`
+- pageSize (integer) - Profiles per page (default 25, max 1000)
+- getDetailedEducation (boolean) - Include school details (slower)
+- getDetailedWorkExperience (boolean) - Include company details (slower)
+
+Cost: 2 credits per request + 1 credit per profile found. Rate limit: 120/min.
+
+```bash
+orth api run fiber /v1/natural-language-search/job-description-search --body '{
+  "search": {
+    "request": "initial",
+    "query": "Senior Backend Engineer with 5+ years experience in Go or Rust, distributed systems, Kubernetes. Remote-friendly, Series B startup."
+  },
+  "pageSize": 10
+}'
+```
+
 ## Use Cases
 
 1. **Recruiting**: Find candidates matching specific criteria
@@ -268,6 +357,8 @@ orth api run fiber /v1/linkedin-live-fetch/post-reactions --body '{"identifier":
 3. **Fundraising**: Research investors in your space
 4. **Competitive Intel**: Track companies and their employees
 5. **Job Search**: Find relevant job opportunities
+6. **Developer Sourcing**: Convert GitHub contributors to LinkedIn profiles with contact info
+7. **Stealth Tracking**: Find founders entering or exiting stealth mode
 
 ## Discover More
 

--- a/skills/orthogonal-github-to-linkedin/SKILL.md
+++ b/skills/orthogonal-github-to-linkedin/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: github-to-linkedin
+description: Convert GitHub usernames to LinkedIn profiles with contact emails
+---
+
+# GitHub to LinkedIn - Developer Sourcing
+
+Convert GitHub usernames to LinkedIn profiles and extract work emails. Ideal for sourcing open-source contributors, mapping GitHub communities, and building developer talent pipelines.
+
+## Workflow
+
+### Step 1: Single Lookup (1-5 people)
+For quick lookups, use the synchronous endpoint:
+
+```bash
+orth api run fiber /v1/github-to-linkedin/single --body '{"githubUsername": "torvalds", "outputType": "both"}'
+```
+
+Parameters:
+- **githubUsername** (required) - GitHub username only (NOT a URL)
+- **outputType** - `linkedin` (find LinkedIn), `email` (extract work emails from commits), `both` (default)
+
+Returns: `linkedInUrl`, `linkedInSlug`, `confidenceOutOf10`, `matchSource`, `extractedEmails[]`, `githubProfile` (name, company, bio).
+
+### Step 2: Batch Lookup (6-1000 people)
+For larger lists, use the async batch endpoint:
+
+```bash
+orth api run fiber /v1/github-to-linkedin/trigger --body '{
+  "people": [
+    {"githubUsername": "torvalds"},
+    {"githubUsername": "gaearon"},
+    {"githubUsername": "sindresorhus"}
+  ],
+  "outputType": "linkedin",
+  "overallContext": "Top open source maintainers"
+}'
+```
+
+The `overallContext` field helps disambiguate — describe what the people have in common.
+
+### Step 3: Poll Batch Results
+Poll until results are ready:
+
+```bash
+orth api run fiber /v1/github-to-linkedin/polling --body '{"githubAgentRunId": "RUN_ID_FROM_TRIGGER", "pageSize": 50}'
+```
+
+Use `cursor` from the response to paginate through large result sets.
+
+### Step 4: Enrich High-Confidence Matches
+For matches with high confidence scores, get full LinkedIn profiles:
+
+```bash
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/SLUG_FROM_RESULTS"}'
+```
+
+### Step 5: Get Contact Info
+Find emails for outreach:
+
+```bash
+orth api run hunter /v2/email-finder --query 'domain=company.com&first_name=Linus&last_name=Torvalds'
+```
+
+## Example Usage
+
+```bash
+# Find LinkedIn for a single GitHub user
+orth api run fiber /v1/github-to-linkedin/single --body '{"githubUsername": "antirez", "outputType": "linkedin"}'
+
+# Batch resolve contributors to a repo
+orth api run fiber /v1/github-to-linkedin/trigger --body '{
+  "people": [
+    {"githubUsername": "user1"},
+    {"githubUsername": "user2"},
+    {"githubUsername": "user3"}
+  ],
+  "outputType": "both",
+  "overallContext": "Contributors to kubernetes/kubernetes"
+}'
+
+# Extract only emails (cheaper, no LinkedIn lookup)
+orth api run fiber /v1/github-to-linkedin/single --body '{"githubUsername": "jessfraz", "outputType": "email"}'
+```
+
+## Tips
+
+- Use `outputType: "linkedin"` if you only need profiles (cheaper — 5 credits vs 8 for "both")
+- Use `outputType: "email"` if you only need emails from commit history (3 credits)
+- `overallContext` significantly improves batch accuracy — always include it
+- Confidence scores range 0-10; treat 7+ as reliable matches
+- For batch jobs, poll every 5-10 seconds until results appear
+- Combine with people-search to find more devs at the same companies
+
+## Discover More
+
+List all endpoints, or add a path for parameter details:
+
+```bash
+orth api show fiber
+orth api show hunter
+```
+
+Example: `orth api show fiber /v1/github-to-linkedin/single` for endpoint parameters.

--- a/skills/orthogonal-jd-candidate-search/SKILL.md
+++ b/skills/orthogonal-jd-candidate-search/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: jd-candidate-search
+description: Paste a job description and find matching LinkedIn profiles instantly
+---
+
+# JD Candidate Search - Job Description to Candidates
+
+Paste a raw job description and get matching LinkedIn profiles. Converts unstructured JD text into candidate results — no manual filter building needed.
+
+## Workflow
+
+### Step 1: Search with Job Description
+Paste the full JD text:
+
+```bash
+orth api run fiber /v1/natural-language-search/job-description-search --body '{
+  "search": {
+    "request": "initial",
+    "query": "Senior Backend Engineer with 5+ years experience in Go or Rust, distributed systems, Kubernetes. Remote-friendly, Series B startup."
+  },
+  "pageSize": 25
+}'
+```
+
+### Step 2: Get More Results
+Use the cursor from the first response to paginate:
+
+```bash
+orth api run fiber /v1/natural-language-search/job-description-search --body '{
+  "search": {
+    "request": "next",
+    "cursor": "CURSOR_FROM_PREVIOUS_RESPONSE"
+  },
+  "pageSize": 25
+}'
+```
+
+### Step 3: Enrich Top Candidates
+Get full profile details for promising matches:
+
+```bash
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/CANDIDATE_SLUG"}'
+```
+
+### Step 4: Get Contact Info
+Reach out to candidates:
+
+```bash
+orth api run hunter /v2/email-finder --query 'domain=candidate-company.com&first_name=Jane&last_name=Doe'
+```
+
+## Example Usage
+
+```bash
+# Search from a full JD
+orth api run fiber /v1/natural-language-search/job-description-search --body '{
+  "search": {
+    "request": "initial",
+    "query": "Staff Frontend Engineer. Requirements: 8+ years React/TypeScript, design system experience, accessibility expertise. Nice to have: Next.js, GraphQL, Figma plugin development. Location: NYC or remote US."
+  },
+  "pageSize": 10
+}'
+
+# Shorter role description also works
+orth api run fiber /v1/natural-language-search/job-description-search --body '{
+  "search": {
+    "request": "initial",
+    "query": "VP of Sales, B2B SaaS, enterprise sales experience, team of 20+, based in Austin TX"
+  },
+  "pageSize": 10
+}'
+
+# Include detailed work experience in results
+orth api run fiber /v1/natural-language-search/job-description-search --body '{
+  "search": {
+    "request": "initial",
+    "query": "Machine Learning Engineer, PyTorch, recommendation systems, 3+ years"
+  },
+  "pageSize": 10,
+  "getDetailedWorkExperience": true
+}'
+```
+
+## Tips
+
+- Longer, more specific JD text produces better matches
+- Include requirements, nice-to-haves, location, and seniority for best results
+- Use `getDetailedWorkExperience: true` to see full career history (slower)
+- Use `getDetailedEducation: true` to see school details (slower)
+- Cost: 2 credits per request + 1 credit per profile returned
+- Page through results with `cursor` — first page often has the strongest matches
+- Works great alongside natural-language profile search for different angles on the same role
+
+## Discover More
+
+List all endpoints, or add a path for parameter details:
+
+```bash
+orth api show fiber
+orth api show hunter
+```
+
+Example: `orth api show fiber /v1/natural-language-search/job-description-search` for endpoint parameters.

--- a/skills/orthogonal-stealth-startup-finder/SKILL.md
+++ b/skills/orthogonal-stealth-startup-finder/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: stealth-startup-finder
+description: Find founders at stealth-mode startups or who recently launched from stealth
+---
+
+# Stealth Startup Finder
+
+Find people currently building at stealth-mode companies, or who recently left stealth (launched). Useful for investor deal sourcing, competitive intelligence, and recruiting at early-stage companies.
+
+## Workflow
+
+### Step 1: Find In-Stealth Founders
+Search for people currently at stealth companies:
+
+```bash
+orth api run fiber /v1/stealth-founders/search --body '{"stealthConfig": {"mode": "in-stealth"}, "pageSize": 25}'
+```
+
+### Step 2: Find Ex-Stealth (Recently Launched)
+Find founders who recently exited stealth:
+
+```bash
+orth api run fiber /v1/stealth-founders/search --body '{"stealthConfig": {"mode": "left-stealth"}, "pageSize": 25}'
+```
+
+### Step 3: Filter by Profile Criteria
+Add search filters to narrow results:
+
+```bash
+orth api run fiber /v1/stealth-founders/search --body '{
+  "stealthConfig": {"mode": "in-stealth"},
+  "searchParams": {
+    "locations": ["San Francisco", "New York"],
+    "keywords": ["AI", "machine learning"]
+  },
+  "pageSize": 25
+}'
+```
+
+### Step 4: Enrich Interesting Profiles
+Get full details on promising matches:
+
+```bash
+orth api run fiber /v1/linkedin-live-fetch/profile/single --body '{"identifier": "https://linkedin.com/in/SLUG"}'
+```
+
+### Step 5: Research Their Background
+Check their career history and network:
+
+```bash
+orth api run fiber /v1/natural-language-search/profiles --body '{"query": "Former engineers at [previous company] now at startups"}'
+```
+
+## Example Usage
+
+```bash
+# All currently stealth founders
+orth api run fiber /v1/stealth-founders/search --body '{"stealthConfig": {"mode": "in-stealth"}, "pageSize": 10}'
+
+# Stealth founders in AI/ML in SF
+orth api run fiber /v1/stealth-founders/search --body '{
+  "stealthConfig": {"mode": "in-stealth"},
+  "searchParams": {
+    "locations": ["San Francisco Bay Area"],
+    "keywords": ["artificial intelligence", "machine learning", "LLM"]
+  },
+  "pageSize": 25
+}'
+
+# Recently launched companies (left stealth)
+orth api run fiber /v1/stealth-founders/search --body '{
+  "stealthConfig": {"mode": "left-stealth"},
+  "pageSize": 25
+}'
+```
+
+## Tips
+
+- `in-stealth` finds people whose current company is stealth/unnamed
+- `left-stealth` finds people who were recently at stealth companies but have since launched
+- Combine with location and keyword filters to narrow large result sets
+- Cost: 1 credit per profile returned
+- Use pagination (`cursor`) to iterate through large result sets
+- Cross-reference with investor search to find funded stealth companies
+
+## Discover More
+
+List all endpoints, or add a path for parameter details:
+
+```bash
+orth api show fiber
+```
+
+Example: `orth api show fiber /v1/stealth-founders/search` for endpoint parameters.


### PR DESCRIPTION
Summary

  Registers 5 new Fiber AI discovery endpoints and adds 3 workflow skills for developer sourcing, stealth company tracking, and
  job-description-based candidate search.

  New endpoints in orthogonal-fiber:
  - /v1/github-to-linkedin/single — resolve GitHub username → LinkedIn profile (sync)
  - /v1/github-to-linkedin/trigger + /polling — batch resolution up to 1000 usernames
  - /v1/stealth-founders/search — find founders at stealth-mode companies or recently launched
  - /v1/natural-language-search/job-description-search — paste raw JD → matching profiles

  New workflow skills:
  - orthogonal-github-to-linkedin — full workflow for developer sourcing from GitHub
  - orthogonal-stealth-startup-finder — investor/recruiter workflow for stealth companies
  - orthogonal-jd-candidate-search — paste a JD and find candidates instantly

  Test plan

  - Each orth api run fiber /v1/... example is syntactically valid
  - Parameter names and types match Fiber's OpenAPI spec
  - Workflow skills follow existing repo patterns (frontmatter, steps, tips, discover more)
  - No breaking changes to existing endpoint documentation

