### PR TITLE
Enhance email and phone finding capabilities across multiple skills

### DIFF
--- a/skills/orthogonal-comprehensive-enrichment/SKILL.md
+++ b/skills/orthogonal-comprehensive-enrichment/SKILL.md
@@ -62,11 +62,21 @@ orth run sixtyfour /enrich-lead --body '{
 }'
 ```
 
-### 2b. Email — Find & Verify
+### 2b. Email & Phone — Find & Verify
 
 Collect ALL emails — work AND personal. Many use cases (recruiting, etc.) need personal emails. Present each email with its type (work/personal) and verification status.
 
-**Find work email** (cross-reference Hunter + Tomba):
+**Fiber contact-details** (best when you have a LinkedIn URL — returns emails + phone in one call):
+```bash
+orth api run fiber /v1/contact-details/single --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true},
+  "validateEmails": true
+}'
+```
+Cost: 5 credits for all types. Returns work emails, personal emails, and phone numbers. Use turbo tier (`/v1/contact-details/turbo/sync`) for faster results at higher cost (7 credits), or exhaustive tier (`/v1/contact-details/exhaustive/start` + `/poll`) for maximum coverage (12 credits).
+
+**Find work email** (cross-reference Hunter + Tomba — use when no LinkedIn URL):
 ```bash
 # Hunter (returns work email)
 orth run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
@@ -91,9 +101,18 @@ orth run hunter /v2/email-verifier --query email=john@stripe.com
 orth run tomba /v1/email-verifier --query email=john@stripe.com
 orth run fiber /v1/validate-email/single --body '{"email": "john@stripe.com"}'
 ```
-Verify every email found — work and personal. Run verifiers in parallel across all emails.
+Verify every email found — work and personal. Run verifiers in parallel across all emails. Note: Fiber contact-details turbo tier already returns email `status` (`valid`, `risky`, `unknown`, `invalid`) — you can skip re-verification for those.
 
 ### 2c. Phone
+**Fiber contact-details** (if not already retrieved in 2b):
+```bash
+orth api run fiber /v1/contact-details/single --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": false, "getPersonalEmails": false, "getPhoneNumbers": true}
+}'
+```
+
+**Sixtyfour** (fallback — when no LinkedIn URL):
 ```bash
 orth run sixtyfour /find-phone --body '{
   "lead": {"first_name": "John", "last_name": "Doe", "company": "Stripe"}
@@ -232,6 +251,9 @@ orth run fiber /v1/kitchen-sink/person --body '{"emailAddress": "john@stripe.com
 orth run nyne /person/search -d '{"query": "john stripe.com"}'
 orth run sixtyfour /enrich-lead --body '{"lead_info": {"email": "john@stripe.com", "company": "Stripe"}, "struct": {"work_email": "Work email", "personal_email": "Personal email", "phone": "Phone", "title": "Title", "bio": "Bio"}}'
 
+# Contact details via Fiber (if LinkedIn URL is known — gets emails + phone in one call)
+orth api run fiber /v1/contact-details/single --body '{"linkedinUrl": "https://www.linkedin.com/in/johndoe", "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true}, "validateEmails": true}'
+
 # Find personal email
 orth run tomba /v1/enrich --query email=john@stripe.com
 
@@ -241,7 +263,7 @@ orth run tomba /v1/email-verifier --query email=john@stripe.com
 orth run fiber /v1/validate-email/single --body '{"email": "john@stripe.com"}'
 # Also verify any personal emails found with the same 3 verifiers
 
-# Phone
+# Phone (Fiber contact-details above already returns phone; Sixtyfour as fallback)
 orth run sixtyfour /find-phone --body '{"lead": {"email": "john@stripe.com", "company": "Stripe"}}'
 
 # Research
@@ -355,7 +377,8 @@ Present Tier 2 with clear section headers. Include source labels on every data p
 - **Conflicts**: When APIs disagree, show both values with source labels — never silently pick one
 - **LinkedIn URLs**: Dramatically improve match rates for Fiber and Tomba — extract from any source that returns them
 - **All emails matter**: Always collect both work AND personal emails — recruiting and hiring use cases need personal emails. Label each as work/personal
-- **Email verification**: Verify every email (work + personal) with all 3 verifiers (Hunter, Tomba, Fiber) and take consensus
+- **Fiber contact-details**: If you have a LinkedIn URL, this is the fastest path to emails + phone in one call. Use standard tier for most cases, turbo for speed, exhaustive for high-value targets
+- **Email verification**: Verify every email (work + personal) with all 3 verifiers (Hunter, Tomba, Fiber) and take consensus. Fiber turbo/exhaustive tiers already include verification status
 - **Person → Company**: Person enrichment always cascades — once you identify their employer, run full company enrichment automatically
 - **Linkup deep search**: Best for personalization angles — recent talks, interviews, blog posts, news mentions
 - **Sixtyfour enrich-lead is slow**: Takes 30-60 seconds (AI web research). Fire it early, don't block on it — continue processing other API results and merge Sixtyfour data when it arrives

--- a/skills/orthogonal-find-email-by-name/SKILL.md
+++ b/skills/orthogonal-find-email-by-name/SKILL.md
@@ -17,9 +17,20 @@ Find a person's email address when you know their name and company/domain. Essen
 
 ## How It Works
 
-Uses Hunter or Tomba APIs to find the most likely email address for a person based on their name and company domain.
+Uses Hunter, Tomba, or Fiber APIs to find email addresses. If you have a LinkedIn URL, Fiber's contact-details endpoint is the most reliable option and can also return phone numbers.
 
 ## Usage
+
+### Find Email with Fiber (Best when you have a LinkedIn URL)
+
+```bash
+orth api run fiber /v1/contact-details/single --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/patrickcollison",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": false}
+}'
+```
+
+Returns work emails, personal emails, and optionally phone numbers in one call. Cost: 2 credits (work email only), 5 credits (all contact types). Note: may take up to 2 minutes; use `/v1/contact-details/turbo/sync` (3-7 credits) for faster results.
 
 ### Find Email with Hunter
 
@@ -94,8 +105,9 @@ orth run tomba /v1/email-finder --query 'domain=google.com&company=Google&first_
 
 ## Tips
 
+- **If you have a LinkedIn URL**, use Fiber first — highest match rate and returns verified emails
 - Use the company's main domain (not subdomains)
-- Try both Hunter and Tomba if one doesn't find results
+- Try multiple sources (Fiber, Hunter, Tomba) if one doesn't find results
 - Check confidence scores - high confidence means the email is likely correct
 - Always verify important emails before sending cold outreach
-- For LinkedIn profiles, Tomba's LinkedIn finder is very effective
+- For LinkedIn profiles, Fiber contact-details or Tomba's LinkedIn finder are most effective

--- a/skills/orthogonal-lead-enrichment/SKILL.md
+++ b/skills/orthogonal-lead-enrichment/SKILL.md
@@ -9,21 +9,34 @@ Enrich partial lead data with emails, phone numbers, and company information usi
 
 ## Workflow
 
-### Step 1: Find Email Address
-Use Hunter to find email:
+### Step 1: Get Email + Phone from LinkedIn (Fiber — Best Option)
+If you have a LinkedIn URL, Fiber returns work emails, personal emails, and phone numbers in one call:
+
+```bash
+orth api run fiber /v1/contact-details/single --body '{
+  "linkedinUrl": "https://www.linkedin.com/in/johndoe",
+  "enrichmentType": {"getWorkEmails": true, "getPersonalEmails": true, "getPhoneNumbers": true},
+  "validateEmails": true
+}'
+```
+
+Cost: 5 credits for all contact types, 2 credits for work email only. Timeout: up to 2 minutes (use `/v1/contact-details/turbo/sync` if speed is critical — 7 credits, ~10s). If this returns results, you can skip Steps 2-4.
+
+### Step 2: Find Email Address (Fallback — when no LinkedIn URL)
+Use Hunter to find email by name + domain:
 
 ```bash
 orth api run hunter /v2/email-finder --query domain=stripe.com first_name=John last_name=Doe
 ```
 
-### Step 2: Verify Email
+### Step 3: Verify Email
 Verify the email is deliverable:
 
 ```bash
 orth api run hunter /v2/email-verifier --query 'email=john@stripe.com'
 ```
 
-### Step 3: Get More Contact Info
+### Step 4: Get More Contact Info
 Use Sixtyfour for additional enrichment:
 
 ```bash
@@ -38,7 +51,7 @@ orth api run sixtyfour /enrich-lead --body '{
 }'
 ```
 
-### Step 4: Find Phone Number
+### Step 5: Find Phone Number (if not from Fiber)
 Use Sixtyfour to find phone:
 
 ```bash
@@ -51,14 +64,14 @@ orth api run sixtyfour /find-phone --body '{
 }'
 ```
 
-### Step 5: Enrich Company Data
+### Step 6: Enrich Company Data
 Get detailed company information:
 
 ```bash
 orth api run hunter /v2/companies/find --query 'domain=stripe.com'
 ```
 
-### Step 6: Get LinkedIn Data
+### Step 7: Get LinkedIn Data
 Fetch real-time LinkedIn profile:
 
 ```bash


### PR DESCRIPTION
Summary                                                                                                                                       
                                                                                                                                                
  Updates 3 existing enrichment workflow skills to include Fiber's contact-details endpoints as a option for email and phone discovery  
                                                                                            
                                                                                                                                                
  - orthogonal-find-email-by-name — added Fiber  with timeout guidance                                                           
  - orthogonal-lead-enrichment — added Fiber (emails + phone in one call), renumbered steps                                         
  - orthogonal-comprehensive-enrichment — integrated Fiber in email/phone sections and pipeline example                                         
                                                                                                                                                
  Changes                                                                                                                                       
                                                                                                                                                
  - Fiber contact-details (/v1/contact-details/single) added as primary path when LinkedIn URL is known                                         
  - Existing Hunter/Tomba/Sixtyfour steps preserved                                                                             
  - Added timeout notes (standard up to 2 min, turbo ~10s)                                                                                      
  - Fixed step numbering in lead-enrichment                                                                                                     
                                                                                                                                                
  Test plan                                                                                                                                     
                                                                                                                                                
  - All orth api run fiber /v1/contact-details/... examples use correct parameters                                                              
  - Existing workflow steps still work as documented                                                                                          
  - No breaking changes to skill structure    