### PR TITLE
Targeted-prospecting: accuracy fixes + Context.dev rebrand

### DIFF
--- a/skills/orthogonal-targeted-prospecting/SKILL.md
+++ b/skills/orthogonal-targeted-prospecting/SKILL.md
@@ -17,7 +17,10 @@ Extract from the user's query:
 - **Location** (optional, default: US) — country, state, city, or region
 - **Company size** (optional) — employee count min/max, revenue floor
 - **Hiring signal roles** (optional) — job postings that indicate buying intent (e.g., "Scheduling Coordinator" = ops pain, "DevOps Engineer" = infra investment)
-- **Max results** (optional, default 15)
+- **Quantitative thresholds** (optional) — counts the user wants to filter on. Triggers Step 6b. Examples:
+  - "≥10 job postings" / "10+ openings" / "actively hiring at scale"
+  - "fewer than 10 recruiters" / "<5 engineers" / "small TA team"
+- **Max results** (optional, default 25 — bump higher when the user asks for "as many as possible" or specifies a count)
 - **Company/product** (optional) — if user mentions what they're selling, triggers competitive intel in Step 7
 
 ### 2. Find Target Companies
@@ -59,7 +62,9 @@ Nyne is async — POST returns a `request_id`, poll with GET until complete (5-2
 
 #### Scaling Up
 
-For 20+ results, run parallel searches by sub-region or sub-vertical:
+**Default behavior at higher counts.** When `Max results ≥ 20` (the new default of 25 lands here), run parallel searches by sub-region or sub-vertical *automatically* rather than treating it as opt-in. A single Fiber/Scrapegraph call caps at ~15–20 high-quality results before noise increases; splitting the query roughly doubles yield without a runtime penalty since the calls run in parallel.
+
+Example:
 
 ```bash
 # Parallel searches for different sub-regions
@@ -80,16 +85,22 @@ Merge results from all strategies. For each company, extract:
 - **Company name**
 - **Domain / website URL**
 - **Employee count** (primary size proxy — revenue data is often unavailable)
+- **Headcount source** — track which API the count came from. One of:
+  - `Fiber` — from `/v1/natural-language-search/companies` structured `employee_count`
+  - `Context.dev` — from `/v1/brand/retrieve`
+  - `Scrapegraph (web estimate)` — from `searchscraper` prose; least authoritative
+  - `LinkedIn (kitchen-sink)` — from Fiber `/v1/kitchen-sink/company` if available
+  - `Multiple` — when ≥2 sources agree within 20%
 - **Headquarters / location**
 - **LinkedIn company URL** (if returned by Fiber/Nyne)
 - **Description / industry tags**
 
-Deduplicate by domain first, then by normalized company name. Apply user's size filters — use employee count as revenue proxy when revenue is unavailable (100+ employees ≈ $10M+ revenue as rough heuristic).
+Deduplicate by domain first, then by normalized company name. Apply user's size filters — use employee count as revenue proxy when revenue is unavailable (100+ employees ≈ $10M+ revenue as rough heuristic). When two sources disagree on headcount, prefer Fiber > LinkedIn > Context.dev > Scrapegraph and label `headcount_source` accordingly. Surface the source in the final output (Step 8) so the user can judge confidence.
 
-Enrich top companies with Brand.dev for industry context:
+Enrich top companies with Context.dev for industry context:
 
 ```bash
-orth run brand-dev /v1/brand/retrieve --query 'domain={company_domain}'
+orth run context-dev /v1/brand/retrieve --query 'domain={company_domain}'
 ```
 
 ### 4. Find Decision Makers
@@ -137,6 +148,26 @@ orth run scrapegraph /v1/smartscraper --body '{
 ```
 
 If `/about` returns 422, fall back to the homepage URL.
+
+**Enterprise fallback** — only when the per-company Fiber profile search AND the `/about` + homepage scrapes all return empty. Common at large public companies (ManpowerGroup, ASGN, etc.) where C-suite info lives in press releases, annual reports, and proxy filings rather than indexable LinkedIn profiles or `/about` pages.
+
+Run both in parallel:
+
+```bash
+# 1. Web search for the named exec (pulls from press releases, 10-Ks, news)
+orth run scrapegraph /v1/searchscraper --body '{
+  "user_prompt": "Who is the {title} at {company_name}? Return name, title, and LinkedIn URL.",
+  "num_results": 5
+}'
+
+# 2. Fiber NL profile search resolved by domain instead of name
+orth run fiber /v1/natural-language-search/profiles --body '{
+  "query": "{title} at the company with website {company_domain}",
+  "pageSize": 5
+}'
+```
+
+If both still return empty, the company belongs in **Lower Priority** with `Decision Maker: — (enterprise — research manually via investor-relations page)`. Don't fabricate a decision maker.
 
 ### 5. Enrich Contacts
 
@@ -208,7 +239,27 @@ orth run tomba /v1/email-verifier --query 'email={email}'
 orth run fiber /v1/validate-email/single --body '{"email": "{email}"}'
 ```
 
-Take the consensus. Label each email as verified/unverified. Collect both work and personal emails.
+**Consensus rules** — count each service's positive/negative vote, then label:
+
+- `Verified (3/3)` — all three return positive (deliverable / valid).
+- `Verified (2/3)` — two of three positive. Safe to use; the third often disagrees on catch-all domains.
+- `Risky (1/3)` — only one positive. Show the email but flag it; do not call it verified.
+- `Unverified` — zero positive. Drop the email or label clearly.
+- `Accept-all` — when any service returns "accept_all" / "catch_all", record it as a separate flag rather than a positive vote (catch-all domains accept anything, so the result tells you nothing about the specific mailbox). A row with 1 positive + 1 accept-all + 1 negative is `Risky (1/3)`, not `Verified (2/3)`.
+
+Collect both work and personal emails. When both exist, prefer the work email for the primary contact field and surface the personal one in `Notes:`.
+
+**Person-level location check** — only when the user specified a location filter. Without this step, global execs at multinationals (e.g. a "COO, Randstad Enterprise" with a `@randstad.de` mailbox) slip into US-only lists.
+
+For each decision maker, downgrade to **Lower Priority** with an explanatory note when **any** of these are true:
+
+- LinkedIn `location` (returned by Fiber profile search) is outside the user's region.
+- Verified email's domain ccTLD doesn't match the user's region (`.de`, `.uk`, `.in`, `.com.au`, etc. for a US-only query) **AND** the person's title contains a global/regional scope keyword (`Global`, `International`, `EMEA`, `APAC`, `LATAM`, `EU`, `UK`, `Worldwide`).
+- Sixtyfour `enrich-lead` returns a `location` field outside the region.
+
+Don't silently drop them — surface in Lower Priority with `Notes: LinkedIn location: {country}; verified email is {.cctld} domain — may not be the {region}-specific decision maker.` The user may still want global execs at multinationals; let them decide.
+
+When the email ccTLD is foreign but the title shows no global scope (e.g. "COO" not "Global COO"), it's almost certainly the wrong entity at a smaller firm — drop the email but keep the LinkedIn URL with a flag.
 
 ### 6. Hiring / Intent Signals
 
@@ -260,6 +311,56 @@ Note: Fiber job-search with searchParams filters can return 400 errors. Attempt 
 
 **Growth signals:** Check Fiber company data (from Step 4 kitchen-sink results) for headcount growth percentage. Companies growing >20% YoY are additional high-priority signals.
 
+### 6b. Quantitative Signals (when user asks for counts)
+
+**Trigger this mode** when the request includes thresholds on counts: `≥N job postings`, `more than N {role}`, `fewer than N {role}`, `at least N openings`, `<10 recruiters`, `10+ openings`, etc. Step 6's boolean "is this company hiring?" check isn't enough — the user wants the actual count to filter on.
+
+Two primitives, run per company in parallel:
+
+**(a) Job-posting count per company:**
+
+```bash
+# Scrapegraph searchscraper to enumerate open postings
+orth run scrapegraph /v1/searchscraper --body '{
+  "user_prompt": "List every open job posting at {company_name} with title and location. Include all roles.",
+  "num_results": 25
+}'
+
+# Tavily to find the careers page, then smartscraper to count listings
+orth run tavily /search --body '{
+  "query": "{company_name} careers open positions",
+  "max_results": 5
+}'
+
+orth run scrapegraph /v1/smartscraper --body '{
+  "website_url": "{careers_page_url}",
+  "user_prompt": "List every open job posting on this page with title and location. Return as a JSON array."
+}'
+
+# Optional supplemental — Fiber job-search filtered by company
+orth run fiber /v1/job-search --body '{
+  "searchParams": {"company_id": "{fiber_company_id}"},
+  "pageSize": 50
+}'
+```
+
+Take `count(distinct postings)` from the union (dedup by title + location). Apply the user's threshold (e.g. `≥10`).
+
+**(b) Employees-by-title count per company:**
+
+```bash
+orth run fiber /v1/natural-language-search/profiles --body '{
+  "query": "{title_keyword_1} or {title_keyword_2} at {company_name}",
+  "pageSize": 30
+}'
+```
+
+For the perfectly.so case, `title_keyword_1` = "Recruiter", `title_keyword_2` = "Talent Acquisition". Count returned profiles. Apply the user's threshold (e.g. `<10`).
+
+**Critical caveat:** Fiber profile counts are a *floor*, not exact — only public LinkedIn profiles are indexed. A company showing "4 recruiters" via Fiber may have 7 in reality (some with private profiles, some not on LinkedIn). Always describe results as "≥4 recruiters found on LinkedIn" rather than "exactly 4." For thresholds like `<10`, this is usually fine; for tight thresholds (`<3`), warn the user that floor counts are unreliable.
+
+**Output:** add a "Quant Signal" column in the High Priority table populated with `{posting_count} postings, ≥{recruiter_count} recruiters` so the threshold logic is auditable on the result.
+
 ### 7. Competitive Intel (Optional)
 
 **Only run if the user mentioned their product/company.** Research what the user sells and check prospects for competing solutions.
@@ -296,19 +397,21 @@ Output a prioritized table with **full URLs** (not markdown links — users need
 Found {N} companies with {M} decision makers identified.
 
 ### High Priority — Hiring Signal Detected
-| # | Company | Website | Employees | Decision Maker | Title | Email | Email Status | Phone | Signal |
-|---|---------|---------|-----------|---------------|-------|-------|-------------|-------|--------|
-| 1 | Acme Staffing | https://acmestaffing.com | 250 | Jane Smith | COO | jane@acme.com | Verified | (555) 123-4567 | Hiring Scheduling Coordinator |
+| # | Company | Website | Employees (source) | Decision Maker | Title | Email | Email Status | Phone | Signal | Quant Signal |
+|---|---------|---------|--------------------|---------------|-------|-------|-------------|-------|--------|--------------|
+| 1 | Acme Staffing | https://acmestaffing.com | 250 (Fiber) | Jane Smith | COO | jane@acme.com | Verified (3/3) | (555) 123-4567 | Hiring Scheduling Coordinator | 12 postings, ≥4 recruiters |
 
 ### Medium Priority — Matches ICP, No Signal Detected
-| # | Company | Website | Employees | Decision Maker | Title | Email | Email Status | Phone | Notes |
-|---|---------|---------|-----------|---------------|-------|-------|-------------|-------|-------|
-| 5 | Beta Corp | https://betacorp.com | 180 | John Doe | VP Ops | john@beta.com | Verified | — | Growing 25% YoY |
+| # | Company | Website | Employees (source) | Decision Maker | Title | Email | Email Status | Phone | Notes |
+|---|---------|---------|--------------------|---------------|-------|-------|-------------|-------|-------|
+| 5 | Beta Corp | https://betacorp.com | 180 (Multiple) | John Doe | VP Ops | john@beta.com | Verified (2/3) | — | Growing 25% YoY |
 
 ### Lower Priority — Limited Data or Below Target Size
-| # | Company | Website | Employees | Decision Maker | Title | Email | Phone | Notes |
-|---|---------|---------|-----------|---------------|-------|-------|-------|-------|
-| 10 | Small Co | https://smallco.com | 85 | — | — | — | — | Below 100 employee threshold |
+| # | Company | Website | Employees (source) | Decision Maker | Title | Email | Phone | Notes |
+|---|---------|---------|--------------------|---------------|-------|-------|-------|-------|
+| 10 | Small Co | https://smallco.com | 85 (Scrapegraph) | — | — | — | — | Below 100 employee threshold |
+| 11 | Globex | https://globex.com | 5,000 (Fiber) | Maria Schmidt | COO, EMEA | maria.schmidt@globex.de | Risky (1/3) | — | LinkedIn location: Germany; .de domain — may not be the US decision maker |
+| 12 | MegaCorp | https://megacorp.com | 28,000 (Fiber) | — | — | — | — | Enterprise — research manually via investor-relations page |
 
 ### Summary
 - **Companies found**: {N}
@@ -343,7 +446,7 @@ Found {N} companies with {M} decision makers identified.
 | **Sixtyfour** | `/find-email` | AI email finder |
 | **Sixtyfour** | `/find-phone` | AI phone finder |
 | **Sixtyfour** | `/enrich-lead` | AI deep enrichment |
-| **Brand.dev** | `/v1/brand/retrieve` | Company overview/context |
+| **Context.dev** | `/v1/brand/retrieve` | Company overview/context |
 
 ## Examples
 
@@ -468,3 +571,6 @@ orth run fiber /v1/natural-language-search/profiles --body '{
 - **Hunter email-verifier is fast and reliable** — Even when Hunter email-finder returns null, Hunter email-verifier is excellent for verifying emails found by Sixtyfour. Every email verified came back with score 89-100
 - **Include title variations** — Search for "COO OR Chief Operating Officer OR Head of Operations" to catch different title formats at the same level
 - **Filter Fiber company results by industry** — Use `li_industries`, `crunchbase_categories`, or keywords in `short_description` to filter out irrelevant companies from Fiber NL results
+- **Quantitative profile counts are a floor, not exact** — When using Step 6b to count employees by title (e.g. "fewer than 10 recruiters"), Fiber only sees public LinkedIn profiles. Real headcount is usually higher. Describe results as "≥N found on LinkedIn" and warn the user when their threshold is tight (`<3`)
+- **Surface headcount source on every row** — Show employee count alongside its source: `8,000+ (Fiber)`, `Est. 100+ (Scrapegraph)`. Without source attribution, "Est. 100+" looks like a guess and undermines the whole result
+- **Verify person-level location, not just company location** — A multinational like Randstad has US presence but a global exec may have a `.de` mailbox. Always check LinkedIn location, email ccTLD, and Sixtyfour location against the user's region filter — surface mismatches in Lower Priority with a note rather than silently including or dropping them

--- a/skills/orthogonal-targeted-prospecting/SKILL.md
+++ b/skills/orthogonal-targeted-prospecting/SKILL.md
@@ -30,9 +30,9 @@ Run 2-3 search strategies **in parallel**:
 **Strategy A — Scrapegraph searchscraper** (primary — most targeted results):
 
 ```bash
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "top {industry} companies in {location} with company name, website, employee count, and headquarters",
-  "num_results": 15
+orth run scrapegraphai /api/search --body '{
+  "query": "top {industry} companies in {location} with company name, website, employee count, and headquarters",
+  "numResults": 15
 }'
 ```
 
@@ -87,7 +87,7 @@ Merge results from all strategies. For each company, extract:
 - **Employee count** (primary size proxy — revenue data is often unavailable)
 - **Headcount source** — track which API the count came from. One of:
   - `Fiber` — from `/v1/natural-language-search/companies` structured `employee_count`
-  - `Context.dev` — from `/v1/brand/retrieve`
+  - `Brand.dev` — from `/v1/brand/retrieve`
   - `Scrapegraph (web estimate)` — from `searchscraper` prose; least authoritative
   - `LinkedIn (kitchen-sink)` — from Fiber `/v1/kitchen-sink/company` if available
   - `Multiple` — when ≥2 sources agree within 20%
@@ -95,12 +95,12 @@ Merge results from all strategies. For each company, extract:
 - **LinkedIn company URL** (if returned by Fiber/Nyne)
 - **Description / industry tags**
 
-Deduplicate by domain first, then by normalized company name. Apply user's size filters — use employee count as revenue proxy when revenue is unavailable (100+ employees ≈ $10M+ revenue as rough heuristic). When two sources disagree on headcount, prefer Fiber > LinkedIn > Context.dev > Scrapegraph and label `headcount_source` accordingly. Surface the source in the final output (Step 8) so the user can judge confidence.
+Deduplicate by domain first, then by normalized company name. Apply user's size filters — use employee count as revenue proxy when revenue is unavailable (100+ employees ≈ $10M+ revenue as rough heuristic). When two sources disagree on headcount, prefer Fiber > LinkedIn > Brand.dev > Scrapegraph and label `headcount_source` accordingly. Surface the source in the final output (Step 8) so the user can judge confidence.
 
-Enrich top companies with Context.dev for industry context:
+Enrich top companies with Brand.dev for industry context:
 
 ```bash
-orth run context-dev /v1/brand/retrieve --query 'domain={company_domain}'
+orth run brand-dev /v1/brand/retrieve --query 'domain={company_domain}'
 ```
 
 ### 4. Find Decision Makers
@@ -141,9 +141,9 @@ orth run nyne /person/search -d '{"query": "{title} at {company_name} {location}
 **Fallback — Scrapegraph website scrape** (scrape the company's leadership page):
 
 ```bash
-orth run scrapegraph /v1/smartscraper --body '{
-  "website_url": "https://{company_domain}/about",
-  "user_prompt": "Extract names, titles, and any contact info for the leadership team. Identify anyone with these titles: {target_titles}"
+orth run scrapegraphai /api/extract --body '{
+  "url": "https://{company_domain}/about",
+  "prompt": "Extract names, titles, and any contact info for the leadership team. Identify anyone with these titles: {target_titles}"
 }'
 ```
 
@@ -155,9 +155,9 @@ Run both in parallel:
 
 ```bash
 # 1. Web search for the named exec (pulls from press releases, 10-Ks, news)
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "Who is the {title} at {company_name}? Return name, title, and LinkedIn URL.",
-  "num_results": 5
+orth run scrapegraphai /api/search --body '{
+  "query": "Who is the {title} at {company_name}? Return name, title, and LinkedIn URL.",
+  "numResults": 5
 }'
 
 # 2. Fiber NL profile search resolved by domain instead of name
@@ -280,9 +280,9 @@ When the email ccTLD is foreign but the title shows no global scope (e.g. "COO" 
 **Primary — Scrapegraph searchscraper for hiring signals:**
 
 ```bash
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "{industry} companies hiring {signal_role} in {location}, list company name, job title, and location",
-  "num_results": 15
+orth run scrapegraphai /api/search --body '{
+  "query": "{industry} companies hiring {signal_role} in {location}, list company name, job title, and location",
+  "numResults": 15
 }'
 ```
 
@@ -299,9 +299,9 @@ orth run tavily /search --body '{
 Then scrape top job board results for company names:
 
 ```bash
-orth run scrapegraph /v1/smartscraper --body '{
-  "website_url": "{job_board_url}",
-  "user_prompt": "Extract all company names hiring for {signal_role}, with job title and location"
+orth run scrapegraphai /api/extract --body '{
+  "url": "{job_board_url}",
+  "prompt": "Extract all company names hiring for {signal_role}, with job title and location"
 }'
 ```
 
@@ -333,9 +333,9 @@ Two primitives, run per company in parallel:
 
 ```bash
 # Scrapegraph searchscraper to enumerate open postings
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "List every open job posting at {company_name} with title and location. Include all roles.",
-  "num_results": 25
+orth run scrapegraphai /api/search --body '{
+  "query": "List every open job posting at {company_name} with title and location. Include all roles.",
+  "numResults": 25
 }'
 
 # Tavily to find the careers page, then smartscraper to count listings
@@ -344,9 +344,9 @@ orth run tavily /search --body '{
   "max_results": 5
 }'
 
-orth run scrapegraph /v1/smartscraper --body '{
-  "website_url": "{careers_page_url}",
-  "user_prompt": "List every open job posting on this page with title and location. Return as a JSON array."
+orth run scrapegraphai /api/extract --body '{
+  "url": "{careers_page_url}",
+  "prompt": "List every open job posting on this page with title and location. Return as a JSON array."
 }'
 
 # Optional supplemental — Fiber job-search filtered by company
@@ -379,21 +379,21 @@ For the perfectly.so case, `title_keyword_1` = "Recruiter", `title_keyword_2` = 
 
 ```bash
 # Research user's product
-orth run scrapegraph /v1/smartscraper --body '{
-  "website_url": "https://{user_company_domain}",
-  "user_prompt": "What does this company sell? Describe the product in one sentence."
+orth run scrapegraphai /api/extract --body '{
+  "url": "https://{user_company_domain}",
+  "prompt": "What does this company sell? Describe the product in one sentence."
 }'
 
 # Find competitors
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "competitors and alternatives to {user_product} for {industry}",
-  "num_results": 5
+orth run scrapegraphai /api/search --body '{
+  "query": "competitors and alternatives to {user_product} for {industry}",
+  "numResults": 5
 }'
 
 # Check each prospect's website for competing products (parallel)
-orth run scrapegraph /v1/smartscraper --body '{
-  "website_url": "https://{prospect_domain}",
-  "user_prompt": "Does this company use or mention: {competitor_1}, {competitor_2}, {competitor_3}? Check page content, footer, and embedded widgets."
+orth run scrapegraphai /api/extract --body '{
+  "url": "https://{prospect_domain}",
+  "prompt": "Does this company use or mention: {competitor_1}, {competitor_2}, {competitor_3}? Check page content, footer, and embedded widgets."
 }'
 ```
 
@@ -447,8 +447,8 @@ Found {N} companies with {M} decision makers identified.
 | **Fiber** | `/v1/validate-email/single` | Email verification |
 | **Nyne** | `/company/search` | Async company search by industry |
 | **Nyne** | `/person/search` | Async person search by company + role |
-| **Scrapegraph** | `/v1/searchscraper` | Web search for companies + hiring signals |
-| **Scrapegraph** | `/v1/smartscraper` | Scrape websites for leadership/competitive intel |
+| **ScrapeGraphAI** | `/api/search` | Web search + scrape for companies + hiring signals |
+| **ScrapeGraphAI** | `/api/extract` | LLM extraction from a URL for leadership / competitive intel |
 | **Tavily** | `/search` | Supplemental web search for job boards |
 | **Hunter** | `/v2/email-finder` | Find email by name + domain |
 | **Hunter** | `/v2/email-verifier` | Email verification |
@@ -458,7 +458,7 @@ Found {N} companies with {M} decision makers identified.
 | **Sixtyfour** | `/find-email` | AI email finder |
 | **Sixtyfour** | `/find-phone` | AI phone finder |
 | **Sixtyfour** | `/enrich-lead` | AI deep enrichment |
-| **Context.dev** | `/v1/brand/retrieve` | Company overview/context |
+| **Brand.dev** | `/v1/brand/retrieve` | Company overview/context |
 
 ## Examples
 
@@ -475,9 +475,9 @@ orth run fiber /v1/natural-language-search/companies --body '{
 
 orth run nyne /company/search -d '{"query": "staffing recruiting firms US 100+ employees"}'
 
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "top staffing and recruiting companies in the US with company name, website, employee count, and headquarters",
-  "num_results": 15
+orth run scrapegraphai /api/search --body '{
+  "query": "top staffing and recruiting companies in the US with company name, website, employee count, and headquarters",
+  "numResults": 15
 }'
 
 # Step 4: Find COOs (parallel, per company)
@@ -492,9 +492,9 @@ orth run sixtyfour /find-email --body '{"lead": {"first_name": "{first}", "last_
 orth run sixtyfour /find-phone --body '{"lead": {"first_name": "{first}", "last_name": "{last}", "company": "{company}"}}'
 
 # Step 6: Hiring signals
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "staffing companies hiring Scheduling Coordinator or Recruiting Coordinator in the US, list company name, job title, and location",
-  "num_results": 15
+orth run scrapegraphai /api/search --body '{
+  "query": "staffing companies hiring Scheduling Coordinator or Recruiting Coordinator in the US, list company name, job title, and location",
+  "numResults": 15
 }'
 ```
 
@@ -516,9 +516,9 @@ orth run fiber /v1/natural-language-search/profiles --body '{
 }'
 
 # Hiring signal
-orth run scrapegraph /v1/searchscraper --body '{
-  "user_prompt": "fintech companies hiring DevOps Engineer or Site Reliability Engineer in the US, list company name and job title",
-  "num_results": 15
+orth run scrapegraphai /api/search --body '{
+  "query": "fintech companies hiring DevOps Engineer or Site Reliability Engineer in the US, list company name and job title",
+  "numResults": 15
 }'
 ```
 

--- a/skills/orthogonal-targeted-prospecting/SKILL.md
+++ b/skills/orthogonal-targeted-prospecting/SKILL.md
@@ -203,7 +203,17 @@ orth run sixtyfour /find-phone --body '{
 
 Sixtyfour find-phone had a 100% hit rate in testing (10/10 prospects).
 
-**Deep enrichment** (fire early, don't block — takes 30-60s):
+**Deep enrichment** — conditional fallback, takes 30-60s:
+
+This call is the slowest in the enrichment phase. **Only fire it when `find-email` OR `find-phone` returned null** for a given prospect — when both succeeded, the data is already in hand and `enrich-lead` is pure dead weight. Skipping it on the common path saves ~30s per prospect.
+
+Run pattern:
+1. Fire `find-email` + `find-phone` in parallel (already done above; these are fast).
+2. Once both return, check the results.
+3. If both succeeded with valid data → **skip** `enrich-lead` entirely.
+4. If either is null/missing → fire `enrich-lead` now to fill the gap. Use its `work_email` / `personal_email` / `phone` fields.
+
+When fired, the call:
 
 ```bash
 orth run sixtyfour /enrich-lead --body '{
@@ -220,6 +230,8 @@ orth run sixtyfour /enrich-lead --body '{
   }
 }'
 ```
+
+(If you specifically need the `bio` or `title` fields and the cheap finders don't surface them, fire `enrich-lead` regardless — but for a contact-info-only run, the conditional skip is the right default.)
 
 **Fiber kitchen-sink enrichment** (if LinkedIn URL available — may return 400):
 


### PR DESCRIPTION
## Summary

Hardens `orthogonal-targeted-prospecting` ahead of a public LinkedIn/X demo and rebrands `brand-dev` references to `context-dev`.

- **Accuracy:** person-level location enforcement (no more `@randstad.de` leaks on US queries), enterprise decision-maker fallback (handles ManpowerGroup / ASGN-style large companies honestly), source attribution on headcount counts, and explicit triple-verification consensus rules so `Verified` never silently includes accept-all domains.
- **New capability:** Step 6b "Quantitative Signals" — supports queries like "10+ job postings AND <10 recruiters" by counting postings (Scrapegraph + Tavily + Fiber) and counting employees-by-title (Fiber profile search). Counts are floors, not exact, and documented as such.
- **More volume:** default `Max results` 15 → 25; the existing "Scaling Up" sub-region parallel search now runs automatically at `Max results ≥ 20` instead of being opt-in.
- **Rebrand:** `brand-dev` → `context-dev` (CLI alias) and `Brand.dev` → `Context.dev` (display) throughout this skill. The `/v1/brand/retrieve` endpoint is unchanged — same API, new brand identifier.

## Why

The customer-driven demo query (COOs at US staffing firms hiring Coordinators, $10M+ rev, 100+ FTEs) surfaced three on-camera-embarrassing failure modes in the previous run: a global exec at Randstad slipped in with a `@randstad.de` mailbox; ManpowerGroup and ASGN had no decision maker identified; and several rows showed "Est. 100+" headcounts with no source. All three are now fixed. The quantitative-signals mode unblocks a separate prospect (perfectly.so) whose ICP filter requires count thresholds the skill couldn't compute.

## Test plan

- [ ] Re-run the staffing query: `Find COOs / Heads of Operations at US staffing & recruiting firms with 100+ FTEs and $10M+ revenue that are actively hiring Scheduling or Recruiting Coordinators` — confirm Tatiana Ohm now lands in Lower Priority with a location-mismatch note (or is dropped), and ManpowerGroup / ASGN either get a decision maker via the new Scrapegraph fallback or carry an explicit "research manually" note.
- [ ] Run the perfectly.so query: `Find companies with 10+ open job postings AND fewer than 10 recruiters in-house` — confirm the new Quant Signal column populates with `{posting_count} postings, ≥{recruiter_count} recruiters`.
- [ ] Confirm output table renders the headcount source as a parenthetical (`8,000+ (Fiber)` vs `Est. 100+ (Scrapegraph)`).
- [ ] Confirm at least one `Verified (2/3)` and one `Risky (1/3)` label appear on a real run.
- [ ] Confirm `orth run context-dev /v1/brand/retrieve` works against the live Orthogonal CLI (CLI accepts both `brand-dev` and `context-dev` per the rebrand plan).
