### PR TITLE
feat: add July 11 discovery skill stubs

### DIFF
--- a/skills/agent-zero-bridge/SKILL.md
+++ b/skills/agent-zero-bridge/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: agent-zero-bridge
+description: Delegate autonomous coding or research tasks to Agent Zero. Use when the user asks to hand work to Agent Zero or A0.
+---
+
+# Agent Zero Bridge
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/DOWingard/agent-zero-bridge

--- a/skills/api-designer/SKILL.md
+++ b/skills/api-designer/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: api-designer
+description: Design REST or GraphQL APIs, OpenAPI specs, resources, versioning, pagination, and errors. Use when planning API architecture.
+---
+
+# API Designer
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/Veeramanikandanr48/api-designer

--- a/skills/byterover-headless/SKILL.md
+++ b/skills/byterover-headless/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: byterover-headless
+description: Query and curate project knowledge through the ByteRover CLI. Use when agents need headless knowledge retrieval or storage.
+---
+
+# ByteRover Headless
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/byteroverinc/byterover-headless

--- a/skills/codex-account-switcher/SKILL.md
+++ b/skills/codex-account-switcher/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: codex-account-switcher
+description: Capture and switch between multiple OpenAI Codex account logins. Use when managing separate Codex identities or quotas.
+---
+
+# Codex Account Switcher
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/odrobnik/codex-account-switcher

--- a/skills/flowmind/SKILL.md
+++ b/skills/flowmind/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: flowmind
+description: Manage FlowMind goals, tasks, notes, people, and tags through REST APIs. Use when asked to operate a FlowMind workspace.
+---
+
+# FlowMind
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/fancygobot/flowmind

--- a/skills/frontend-design-extractor/SKILL.md
+++ b/skills/frontend-design-extractor/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: frontend-design-extractor
+description: Extract reusable UI systems, tokens, styles, components, and page patterns from frontend repos. Use when analyzing app design systems.
+---
+
+# Frontend Design Extractor
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/Xsir0/frontend-design-extractor

--- a/skills/homey-cli/SKILL.md
+++ b/skills/homey-cli/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: homey-cli
+description: Control Homey smart home devices, zones, and flows through a CLI. Use when managing Homey lights, thermostats, sockets, or scenes.
+---
+
+# Homey CLI
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/KrauseFx/homey-cli

--- a/skills/linear-autopilot/SKILL.md
+++ b/skills/linear-autopilot/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: linear-autopilot
+description: Automate Linear task processing with git sync and notifications. Use for kanban-to-agent workflows driven by Linear.
+---
+
+# Linear Autopilot
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/vincentchan/linear-autopilot

--- a/skills/linearis/SKILL.md
+++ b/skills/linearis/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: linearis
+description: Manage Linear issues, comments, documents, cycles, and projects through a JSON-first CLI. Use for Linear workflow automation.
+---
+
+# Linearis
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/whoisnnamdi/linearis

--- a/skills/lmstudio-subagents/SKILL.md
+++ b/skills/lmstudio-subagents/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: lmstudio-subagents
+description: Offload summarization, extraction, classification, and draft work to local LM Studio models. Use to reduce paid model usage.
+---
+
+# LM Studio Subagents
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/t-sinclair2500/lmstudio-subagents

--- a/skills/local-rag-search/SKILL.md
+++ b/skills/local-rag-search/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: local-rag-search
+description: Search local or indexed web content with semantic ranking through a local RAG server. Use for current research with local retrieval.
+---
+
+# Local RAG Search
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/nkapila6/local-rag-search

--- a/skills/no-nonsense-tasks/SKILL.md
+++ b/skills/no-nonsense-tasks/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: no-nonsense-tasks
+description: Manage tasks in a local SQLite task tracker with statuses, tags, and descriptions. Use for lightweight local task lists.
+---
+
+# No Nonsense Tasks
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/dvjn/no-nonsense-tasks

--- a/skills/omnifocus/SKILL.md
+++ b/skills/omnifocus/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: omnifocus
+description: Manage OmniFocus tasks, projects, folders, due dates, and GTD workflows through automation. Use for OmniFocus task management.
+---
+
+# OmniFocus
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/Coyote-git/omnifocus

--- a/skills/paprika/SKILL.md
+++ b/skills/paprika/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: paprika
+description: Access Paprika recipes, meal plans, and grocery lists. Use when asked about Paprika recipe management or cooking plans.
+---
+
+# Paprika
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/mjrussell/paprika

--- a/skills/pi-orchestration/SKILL.md
+++ b/skills/pi-orchestration/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: pi-orchestration
+description: Orchestrate multiple AI models as workers through Pi Coding Agent. Use for multi-model worker planning or implementation.
+---
+
+# Pi Orchestration
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/dbhurley/pi-orchestration

--- a/skills/rssaurus-cli/SKILL.md
+++ b/skills/rssaurus-cli/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: rssaurus-cli
+description: Read feeds and feed items through the RSSaurus CLI. Use when asked to inspect RSS subscriptions or fetch article URLs.
+---
+
+# RSSaurus CLI
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/justinburdett/rssaurus-cli

--- a/skills/telegram-usage/SKILL.md
+++ b/skills/telegram-usage/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: telegram-usage
+description: Display OpenClaw Telegram session usage, quota, tokens, and context stats. Use when asked to inspect Telegram bot usage or session limits.
+---
+
+# Telegram Usage
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/c-drew/telegram-usage

--- a/skills/tinyfish/SKILL.md
+++ b/skills/tinyfish/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: tinyfish
+description: Use TinyFish or Mino web agents for scraping, extraction, and browser actions. Use when websites need automated extraction.
+---
+
+# TinyFish
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/simantak-dabhade/tinyfish

--- a/skills/twitter-search/SKILL.md
+++ b/skills/twitter-search/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: twitter-search
+description: Search and analyze Twitter data by keyword using API results. Use for social listening, tweet research, or Twitter trend analysis.
+---
+
+# Twitter Search
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/flyfoxCI/twitter-search

--- a/skills/whatdo/SKILL.md
+++ b/skills/whatdo/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: whatdo
+description: Discover activities using weather, showtimes, streaming, games, and group preferences. Use when planning what to do nearby.
+---
+
+# What Should We Do?
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://www.clawhub.com/ScotTFO/whatdo


### PR DESCRIPTION
## Summary
- Adds 20 SKILL.md stubs from the July 11 daily discovery batch
- Sources candidates from skills.sh and awesome-openclaw-skills
- Keeps each stub concise pending deeper vetting

Linear: ORT-2327

Reviewers: @christianpickettcode @berasogut