### PR TITLE
feat: add July 12 discovery skill stubs

### DIFF
--- a/skills/agentlens/SKILL.md
+++ b/skills/agentlens/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: agentlens
+description: Navigate and understand codebases through hierarchical documentation. Use when exploring new projects or locating modules and symbols.
+---
+
+# AgentLens
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/agentlens

--- a/skills/agnxi-search/SKILL.md
+++ b/skills/agnxi-search/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: agnxi-search
+description: Search the Agnxi directory for AI agent tools, MCP servers, and skills. Use when finding agent infrastructure or integration candidates.
+---
+
+# Agnxi Search
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/agnxi-search

--- a/skills/api-credentials-hygiene/SKILL.md
+++ b/skills/api-credentials-hygiene/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: api-credentials-hygiene
+description: Audit and harden API credential handling, env vars, rotation plans, least privilege, and auditability for integrations.
+---
+
+# API Credentials Hygiene
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/api-credentials-hygiene

--- a/skills/arxiv-watcher/SKILL.md
+++ b/skills/arxiv-watcher/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: arxiv-watcher
+description: Search and summarize ArXiv papers. Use for latest research, specific paper lookups, topic watches, and research digests.
+---
+
+# ArXiv Watcher
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/arxiv-watcher

--- a/skills/clawdbot-cost-tracker/SKILL.md
+++ b/skills/clawdbot-cost-tracker/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: clawdbot-cost-tracker
+description: Track AI model usage and estimate costs across sessions. Use for daily or weekly usage reports and spend monitoring.
+---
+
+# Clawdbot Cost Tracker
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/clawdbot-cost-tracker

--- a/skills/clawdbot-logs/SKILL.md
+++ b/skills/clawdbot-logs/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: clawdbot-logs
+description: Analyze OpenClaw logs and diagnostics for performance, response times, errors, sessions, token usage, and API failures.
+---
+
+# Clawdbot Logs
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/clawdbot-logs

--- a/skills/clawdbot-security/SKILL.md
+++ b/skills/clawdbot-security/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: clawdbot-security
+description: Audit and harden OpenClaw installations, exposed gateways, permissions, authentication, and configuration security.
+---
+
+# Clawdbot Security
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/clawdbot-security

--- a/skills/clawdhub/SKILL.md
+++ b/skills/clawdhub/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: clawdhub
+description: Search, install, update, and publish agent skills with the ClawdHub CLI. Use when managing skills from ClawdHub.
+---
+
+# ClawdHub
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/clawdhub

--- a/skills/cli-developer/SKILL.md
+++ b/skills/cli-developer/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: cli-developer
+description: Design and implement CLI tools, argument parsing, interactive prompts, help text, and command ergonomics.
+---
+
+# CLI Developer
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/cli-developer

--- a/skills/codebase-documenter/SKILL.md
+++ b/skills/codebase-documenter/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: codebase-documenter
+description: Write README files, architecture docs, API documentation, and codebase explanations for software projects.
+---
+
+# Codebase Documenter
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/codebase-documenter

--- a/skills/codemod-gen/SKILL.md
+++ b/skills/codemod-gen/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: codemod-gen
+description: Generate codemods for large-scale code changes and repeated refactors across many files.
+---
+
+# Codemod Gen
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/codemod-gen

--- a/skills/conventional-commits/SKILL.md
+++ b/skills/conventional-commits/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: conventional-commits
+description: Format commit messages using Conventional Commits. Use when creating commits or writing release-friendly commit summaries.
+---
+
+# Conventional Commits
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/conventional-commits

--- a/skills/cursor-agent/SKILL.md
+++ b/skills/cursor-agent/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: cursor-agent
+description: Use the Cursor CLI agent for software engineering tasks, background automation, and repository workflows.
+---
+
+# Cursor Agent
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/cursor-agent

--- a/skills/deepwiki/SKILL.md
+++ b/skills/deepwiki/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: deepwiki
+description: Query DeepWiki MCP for GitHub repository documentation, wiki structure, and AI-grounded repo questions.
+---
+
+# DeepWiki
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/deepwiki

--- a/skills/deepwork-tracker/SKILL.md
+++ b/skills/deepwork-tracker/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: deepwork-tracker
+description: Track deep work sessions locally and generate contribution-graph style summaries of focused work time.
+---
+
+# Deepwork Tracker
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/deepwork-tracker

--- a/skills/ggshield-scanner/SKILL.md
+++ b/skills/ggshield-scanner/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: ggshield-scanner
+description: Scan repositories, files, and staged changes for hardcoded secrets using GitGuardian ggshield.
+---
+
+# ggshield Scanner
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/ggshield-scanner

--- a/skills/github-pr/SKILL.md
+++ b/skills/github-pr/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: github-pr
+description: Fetch, preview, merge, and test GitHub pull requests locally before they are merged upstream.
+---
+
+# GitHub PR
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/github-pr

--- a/skills/opencode-acp-control/SKILL.md
+++ b/skills/opencode-acp-control/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: opencode-acp-control
+description: Control OpenCode through the Agent Client Protocol. Use to start sessions, send prompts, resume work, and manage updates.
+---
+
+# OpenCode ACP Control
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/opencode-acp-control

--- a/skills/skill-vetter/SKILL.md
+++ b/skills/skill-vetter/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: skill-vetter
+description: Vet agent skills before installation with security, provenance, dependency, and prompt-injection checks.
+---
+
+# Skill Vetter
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/skill-vetter

--- a/skills/tmux-agents/SKILL.md
+++ b/skills/tmux-agents/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: tmux-agents
+description: Manage background coding agents in tmux sessions. Use to spawn agents, check progress, and collect results.
+---
+
+# Tmux Agents
+
+Stub discovered from the OpenClaw skills ecosystem. Expand with setup steps, required commands, and examples after vetting the upstream skill.
+
+Source: https://github.com/sundial-org/awesome-openclaw-skills/tree/main/skills/tmux-agents


### PR DESCRIPTION
## Summary
- Add 20 July 12 discovery skill stubs from the OpenClaw skills ecosystem.
- Focus on agent operations, code workflow, security, research, and documentation skills.

## Linear
- ORT-2342

## Testing
- Checked the discovery post log for duplicate picks.
- Verified the branch only adds new SKILL.md stubs.