### PR TITLE
Add July 14 discovery skill stubs

### DIFF
--- a/skills/a11y-checker/SKILL.md
+++ b/skills/a11y-checker/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: a11y-checker
+description: Audit web pages and UI changes for accessibility issues, WCAG risks, keyboard traps, and screen reader regressions.
+---
+
+# Accessibility Checker
+
+Use this skill when asked to review a page, component, or design for accessibility, or when frontend changes need an accessibility pass before shipping.
+
+## Checklist
+
+- Identify the target URL, local route, or changed component.
+- Run automated checks with the available accessibility toolchain, such as axe, Lighthouse, Playwright accessibility snapshots, or the project test suite.
+- Manually check keyboard navigation, focus order, visible focus states, labels, form errors, color contrast, headings, landmarks, and dynamic announcements.
+- Report issues with severity, affected element, reproduction steps, and a concrete fix.
+
+## Output
+
+Keep the result actionable:
+
+- What was checked.
+- Blocking issues.
+- Non-blocking improvements.
+- Tests or manual checks performed.

--- a/skills/actual-budget/SKILL.md
+++ b/skills/actual-budget/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: actual-budget
+description: Work with Actual Budget exports or APIs to inspect budgets, accounts, transactions, payees, and category health.
+---
+
+# Actual Budget
+
+Use this skill when the user asks to analyze an Actual Budget file, reconcile transactions, summarize spending, or prepare budget changes.
+
+## Workflow
+
+- Confirm whether data is coming from a local export, synced Actual instance, or user-provided CSV.
+- Avoid changing financial records unless explicitly asked.
+- Normalize accounts, dates, payees, categories, transfers, and cleared status before analysis.
+- Flag anomalies such as duplicate transactions, uncategorized spend, negative category balances, or unusual month-over-month changes.
+
+## Deliverables
+
+- Spending summary by category and account.
+- Suggested category moves or cleanup actions.
+- Clear note of any assumptions and unverified data.

--- a/skills/assemblyai-transcribe/SKILL.md
+++ b/skills/assemblyai-transcribe/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: assemblyai-transcribe
+description: Transcribe and analyze audio or video with AssemblyAI, including speaker labels, summaries, chapters, and entities.
+---
+
+# AssemblyAI Transcription
+
+Use this skill when the user provides audio or video and wants a transcript, summary, speaker diarization, chapters, or audio intelligence.
+
+## Workflow
+
+- Locate the media file or URL and confirm it is safe to upload.
+- Submit the file to AssemblyAI when credentials and network access are available.
+- Request speaker labels, summaries, chapters, entities, or sentiment only when useful.
+- Poll until the transcription job completes.
+- Return the transcript and a concise summary, preserving timestamps when requested.
+
+## Safety
+
+Audio can contain private information. Do not upload sensitive media without explicit user intent.

--- a/skills/attio/SKILL.md
+++ b/skills/attio/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: attio
+description: Manage Attio CRM records, companies, people, lists, notes, and relationship workflows.
+---
+
+# Attio
+
+Use this skill when the user asks to work with Attio CRM data, enrich records, create list views, update notes, or prepare account research.
+
+## Workflow
+
+- Clarify the object type: person, company, deal, list, note, or task.
+- Search before creating new records to avoid duplicates.
+- Preserve source URLs and evidence for any enrichment.
+- Do not send outreach or mutate CRM data unless the user explicitly asks.
+
+## Common Tasks
+
+- Find a company or person.
+- Add research notes.
+- Update lifecycle or owner fields.
+- Build a targeted list for review.

--- a/skills/bitwarden/SKILL.md
+++ b/skills/bitwarden/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: bitwarden
+description: Use Bitwarden CLI safely for vault search, secret lookup, item metadata, and credential hygiene checks.
+---
+
+# Bitwarden
+
+Use this skill when the user asks to find a credential, audit vault entries, check for duplicate items, or prepare secure credential handling steps.
+
+## Rules
+
+- Never print passwords, recovery codes, private keys, or tokens into chat.
+- Prefer item names, usernames, URI domains, and metadata over secret values.
+- Ask before modifying, deleting, exporting, or sharing vault data.
+- Use `bw` only after confirming the session is unlocked or the user provided an approved workflow.
+
+## Common Tasks
+
+- Search vault items by name or URI.
+- Confirm whether a credential exists.
+- Check duplicate or stale entries.
+- Provide steps for the human to retrieve a secret locally.

--- a/skills/bluesky/SKILL.md
+++ b/skills/bluesky/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: bluesky
+description: Search, draft, schedule, or inspect Bluesky posts, profiles, feeds, and moderation context.
+---
+
+# Bluesky
+
+Use this skill when the user asks to research Bluesky activity, draft posts, inspect a profile, or interact with AT Protocol data.
+
+## Workflow
+
+- Separate read-only research from posting or liking.
+- For public data, gather profile, post, thread, feed, and label context.
+- For outbound posts, draft first and ask before publishing unless the user already authorized posting.
+- Keep private work and user context out of public posts.
+
+## Output
+
+- Link or handle.
+- Relevant post or feed context.
+- Suggested reply or post text when requested.

--- a/skills/brave-search/SKILL.md
+++ b/skills/brave-search/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: brave-search
+description: Search the web with Brave Search, using freshness filters, result snippets, and source-aware synthesis.
+---
+
+# Brave Search
+
+Use this skill when the user asks for web research and Brave Search is the preferred or available search provider.
+
+## Workflow
+
+- Choose web, news, image, or local search based on the request.
+- Use freshness filters for current topics.
+- Open primary sources before making claims.
+- Prefer official docs, repos, standards, and original announcements for technical or time-sensitive facts.
+- Cite or list sources when the answer depends on web evidence.
+
+## Good Uses
+
+- Current news checks.
+- Competitive research.
+- API and library documentation discovery.
+- Finding primary sources.

--- a/skills/caldav-calendar/SKILL.md
+++ b/skills/caldav-calendar/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: caldav-calendar
+description: Inspect and manage CalDAV calendars, events, availability, and recurring schedule data.
+---
+
+# CalDAV Calendar
+
+Use this skill when the user asks to work with CalDAV calendars, ICS data, recurring events, or availability across non-Google calendar servers.
+
+## Workflow
+
+- Identify the calendar server, principal URL, calendar collection, and timezone.
+- Read events before making changes.
+- Preserve UID, recurrence rules, attendees, alarms, and timezone metadata.
+- Ask before creating, updating, deleting, or inviting attendees.
+
+## Common Tasks
+
+- List upcoming events.
+- Check availability.
+- Parse or generate ICS.
+- Diagnose sync issues.

--- a/skills/canva/SKILL.md
+++ b/skills/canva/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: canva
+description: Prepare Canva design briefs, asset lists, brand kits, and export handoff instructions.
+---
+
+# Canva
+
+Use this skill when the user asks to create, edit, brief, or organize Canva designs.
+
+## Workflow
+
+- Clarify deliverable type: social post, presentation, flyer, one-pager, ad, thumbnail, or brand asset.
+- Gather dimensions, audience, brand constraints, copy, assets, and export format.
+- Draft concise layout instructions and asset requirements.
+- If API or CLI access is available, use it for folders, templates, exports, or asset uploads.
+
+## Output
+
+- Design brief.
+- Copy blocks.
+- Asset checklist.
+- Export settings.

--- a/skills/cloudflare-workers-best-practices/SKILL.md
+++ b/skills/cloudflare-workers-best-practices/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: cloudflare-workers-best-practices
+description: Build, test, deploy, and debug Cloudflare Workers, Pages Functions, bindings, Durable Objects, KV, D1, and R2.
+---
+
+# Cloudflare Workers Best Practices
+
+Use this skill when working with Cloudflare Workers or related edge runtime services.
+
+## Workflow
+
+- Inspect `wrangler.toml`, bindings, compatibility date, environment overrides, and deployment scripts.
+- Keep runtime code compatible with the Workers environment.
+- Use local or preview deployments for verification when available.
+- Treat secrets, KV, D1, R2, Queues, and Durable Objects as explicit bindings.
+
+## Watch For
+
+- Node-only APIs in edge code.
+- Missing environment bindings.
+- Cache behavior differences.
+- Durable Object migration requirements.

--- a/skills/confluence/SKILL.md
+++ b/skills/confluence/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: confluence
+description: Search, summarize, draft, and update Confluence pages while preserving page hierarchy and source context.
+---
+
+# Confluence
+
+Use this skill when the user asks to find internal docs, summarize Confluence pages, draft documentation, or update a workspace page.
+
+## Workflow
+
+- Search by space, title, label, or CQL when available.
+- Read pages before summarizing or editing.
+- Preserve page hierarchy, links, labels, and existing formatting conventions.
+- Ask before publishing updates unless the user explicitly authorized the edit.
+
+## Output
+
+- Relevant page links or titles.
+- Summary of what changed or what was found.
+- Open questions for stale or conflicting docs.

--- a/skills/docker-essentials/SKILL.md
+++ b/skills/docker-essentials/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: docker-essentials
+description: Diagnose and operate Docker images, containers, Compose stacks, volumes, networks, and local dev environments.
+---
+
+# Docker Essentials
+
+Use this skill when Docker is part of the task, especially for local setup, failing containers, Compose services, image builds, or reproducible dev environments.
+
+## Workflow
+
+- Inspect `Dockerfile`, Compose files, environment files, and service logs.
+- Prefer non-destructive commands before pruning or removing resources.
+- Verify image build context, port mappings, volumes, health checks, and dependency ordering.
+- Capture exact commands and results needed to reproduce the issue.
+
+## Safety
+
+Ask before deleting volumes, pruning images, stopping unrelated containers, or exposing ports publicly.

--- a/skills/fastify-best-practices/SKILL.md
+++ b/skills/fastify-best-practices/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: fastify-best-practices
+description: Design, test, and debug Fastify services, plugins, schemas, hooks, routes, and performance-sensitive APIs.
+---
+
+# Fastify Best Practices
+
+Use this skill when working on a Fastify server or API.
+
+## Workflow
+
+- Inspect plugin registration order, encapsulation boundaries, schemas, hooks, and decorators.
+- Prefer JSON schema validation and typed route contracts where the project supports them.
+- Keep handlers thin and move reusable logic into plugins or services.
+- Test routes with Fastify injection or the repo's existing HTTP test harness.
+
+## Watch For
+
+- Async plugin registration mistakes.
+- Decorator availability across scopes.
+- Missing response schemas.
+- Leaky shared state.

--- a/skills/firecrawl-deep-research/SKILL.md
+++ b/skills/firecrawl-deep-research/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: firecrawl-deep-research
+description: Run Firecrawl-backed deep research over websites, docs, company pages, and public web sources.
+---
+
+# Firecrawl Deep Research
+
+Use this skill when the user needs web research that benefits from crawling, extraction, structured pages, or multi-source synthesis.
+
+## Workflow
+
+- Define the research question and target domains.
+- Crawl or scrape pages with freshness and depth appropriate to the task.
+- Deduplicate sources and prefer primary pages over scraped mirrors.
+- Extract structured facts, quotes, pricing, docs, or company details.
+- Summarize with source links and confidence notes.
+
+## Good Uses
+
+- Company research.
+- Documentation audits.
+- Market maps.
+- Competitive intelligence.

--- a/skills/google-forms/SKILL.md
+++ b/skills/google-forms/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: google-forms
+description: Create, inspect, and summarize Google Forms, questions, responses, quizzes, and survey exports.
+---
+
+# Google Forms
+
+Use this skill when the user asks to create or analyze a Google Form, quiz, intake flow, or response spreadsheet.
+
+## Workflow
+
+- Clarify whether the task is form creation, response analysis, or form cleanup.
+- For new forms, define sections, question types, validation, required fields, and confirmation copy.
+- For responses, summarize trends, anomalies, missing fields, and export needs.
+- Ask before sharing, publishing, or changing collection settings.
+
+## Output
+
+- Form outline or update plan.
+- Response summary.
+- CSV or Sheets handoff notes when needed.

--- a/skills/mastra/SKILL.md
+++ b/skills/mastra/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: mastra
+description: Build and debug Mastra agents, workflows, tools, memory, evals, and TypeScript agent applications.
+---
+
+# Mastra
+
+Use this skill when the user asks to build or troubleshoot a Mastra-based agent app.
+
+## Workflow
+
+- Inspect project package versions and Mastra configuration.
+- Identify agents, tools, workflows, memory stores, evals, and deployment target.
+- Prefer official Mastra APIs and local project patterns.
+- Add focused tests for tools, workflow branches, and agent behavior where practical.
+
+## Common Tasks
+
+- Add a tool or workflow.
+- Debug agent memory.
+- Wire model providers.
+- Prepare deployment notes.

--- a/skills/nextjs-app-router-patterns/SKILL.md
+++ b/skills/nextjs-app-router-patterns/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: nextjs-app-router-patterns
+description: Implement and debug Next.js App Router routes, layouts, server components, actions, caching, and metadata.
+---
+
+# Next.js App Router Patterns
+
+Use this skill when a task touches a Next.js App Router application.
+
+## Workflow
+
+- Identify whether the code runs in a server component, client component, route handler, middleware, or server action.
+- Respect existing data fetching, cache, revalidation, and auth patterns.
+- Keep client boundaries small and explicit.
+- Test affected routes with the repo's unit, integration, or Playwright setup.
+
+## Watch For
+
+- Accidental client-side secrets.
+- Stale cache or missing revalidation.
+- Hydration mismatches.
+- Metadata and layout regressions.

--- a/skills/playwright-testing/SKILL.md
+++ b/skills/playwright-testing/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: playwright-testing
+description: Write, run, and debug Playwright end-to-end tests, fixtures, locators, traces, screenshots, and browser flows.
+---
+
+# Playwright Testing
+
+Use this skill when implementing or debugging browser tests with Playwright.
+
+## Workflow
+
+- Inspect existing Playwright config, fixtures, test IDs, auth setup, and CI expectations.
+- Prefer user-visible locators and stable test IDs over brittle CSS selectors.
+- Run targeted tests with trace or screenshot output when debugging.
+- Verify responsive and accessibility-sensitive UI paths when relevant.
+
+## Common Commands
+
+- `npx playwright test`
+- `npx playwright test path/to/spec`
+- `npx playwright test --debug`
+- `npx playwright show-trace trace.zip`

--- a/skills/vitest/SKILL.md
+++ b/skills/vitest/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: vitest
+description: Add, run, and debug Vitest unit tests, mocks, fixtures, coverage, and watch-mode workflows.
+---
+
+# Vitest
+
+Use this skill when the repo uses Vitest or the user asks for JavaScript or TypeScript unit tests.
+
+## Workflow
+
+- Inspect existing test patterns, setup files, mock helpers, and aliases.
+- Add the narrowest useful test near the code under change.
+- Prefer behavior-focused assertions over implementation details.
+- Run targeted tests first, then broader suites when the change affects shared behavior.
+
+## Common Commands
+
+- `npm test`
+- `npm run test`
+- `npx vitest run path/to/test`
+- `npx vitest --coverage`

--- a/skills/writing-guidelines/SKILL.md
+++ b/skills/writing-guidelines/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: writing-guidelines
+description: Apply durable writing guidelines for clear, concise docs, product copy, release notes, and user-facing text.
+---
+
+# Writing Guidelines
+
+Use this skill when the user asks for writing, rewriting, documentation, product copy, release notes, or text that should follow a consistent voice.
+
+## Workflow
+
+- Identify the audience, medium, and action the text should create.
+- Preserve facts, constraints, names, and dates from the source material.
+- Remove filler, vague claims, and unnecessary formatting.
+- Match the user's requested voice without inventing facts.
+- For public or external copy, ask before publishing or sending.
+
+## Output
+
+- Clean final text.
+- Optional short note on major edits when useful.


### PR DESCRIPTION
Linear: ORT-2351

## Summary
- Adds 20 discovery skill stubs from skills.sh and sundial-org/awesome-openclaw-skills
- Covers accessibility, finance, transcription, CRM, search, calendars, docs, Docker, Firecrawl, Google Forms, Mastra, Fastify, Next.js, Vitest, Cloudflare Workers, Playwright, and writing workflows

## Validation
- Checked frontmatter starts correctly for all skill files
- Confirmed changes are limited to new skill directories

Reviewers: @christianpickettcode @berasogut