### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/ask-matt/SKILL.md
+++ b/skills/ask-matt/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: ask-matt
+description: Apply TypeScript and developer education style guidance inspired by Matt Pocock's public teaching.
+---
+
+# Ask Matt
+
+Use this skill when the user wants advice in the style of practical TypeScript education: clear examples, precise types, and direct tradeoffs.
+
+## Workflow
+
+1. Clarify the TypeScript, React, or library design problem.
+2. Show the minimal example that captures the issue.
+3. Explain the type-level and runtime behavior separately.
+4. Prefer simple, explicit types over clever type gymnastics.
+5. Give a practical recommendation and one alternative when useful.
+
+Do not imply access to private advice or unpublished material.

--- a/skills/codebase-design/SKILL.md
+++ b/skills/codebase-design/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: codebase-design
+description: Design code organization for new features, modules, and repo structure.
+---
+
+# Codebase Design
+
+Use this skill when planning where code should live and how new pieces should fit into an existing repository.
+
+## Workflow
+
+1. Inspect the current folder structure, naming, imports, and test layout.
+2. Identify the nearest existing pattern for the requested change.
+3. Decide boundaries for data access, business logic, UI, API, and shared utilities.
+4. Propose files and interfaces before implementing broad changes.
+5. Keep the design easy to review in small commits.
+
+Choose boring consistency unless the existing structure is actively causing harm.

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: diagnose
+description: Systematically diagnose errors, flaky behavior, failed commands, and regressions.
+---
+
+# Diagnose
+
+Use this skill when something is broken and the user needs root-cause analysis, not guesswork.
+
+## Workflow
+
+1. Capture the exact symptom, expected behavior, environment, and reproduction path.
+2. Gather the most relevant logs, stack traces, versions, and recent changes.
+3. Form a short hypothesis list ranked by likelihood and impact.
+4. Run the smallest checks that can eliminate or confirm each hypothesis.
+5. Apply the fix, then verify the original symptom is gone.
+
+Prefer evidence over confidence.

--- a/skills/diagnosing-bugs/SKILL.md
+++ b/skills/diagnosing-bugs/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: diagnosing-bugs
+description: Reproduce, isolate, and fix software bugs with a disciplined debugging loop.
+---
+
+# Diagnosing Bugs
+
+Use this skill when a user reports a bug, failing test, regression, production issue, or confusing behavior.
+
+## Workflow
+
+1. Reproduce the bug or identify why it cannot yet be reproduced.
+2. Narrow the failing path with logs, tests, breakpoints, or smaller examples.
+3. Find the first point where actual behavior diverges from expected behavior.
+4. Fix the cause instead of only masking the symptom.
+5. Add or update a regression test when the risk warrants it.
+
+Document residual uncertainty if the bug cannot be fully reproduced.

--- a/skills/domain-modeling/SKILL.md
+++ b/skills/domain-modeling/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: domain-modeling
+description: Model entities, relationships, invariants, and business language for software design.
+---
+
+# Domain Modeling
+
+Use this skill when designing data models, workflows, permissions, state machines, or business logic.
+
+## Workflow
+
+1. Collect the nouns, verbs, roles, states, and events in the domain.
+2. Define entities, value objects, relationships, and ownership boundaries.
+3. Capture invariants and rules that must always hold.
+4. Map ambiguous language to precise terms.
+5. Validate the model with realistic examples and edge cases.
+
+Prefer a model that matches user language over a clever generic abstraction.

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: firebase-auth-basics
+description: Implement and debug Firebase Authentication setup, flows, rules, and client integration.
+---
+
+# Firebase Auth Basics
+
+Use this skill when working with Firebase Authentication in web or mobile apps.
+
+## Workflow
+
+1. Confirm the Firebase project, SDK version, platform, and sign-in providers.
+2. Check initialization, auth state handling, redirects or popups, and emulator usage.
+3. Review security rules and backend token verification where user data is protected.
+4. Handle edge cases such as account linking, persistence, email verification, and provider errors.
+5. Verify the flow with local emulator tests or a minimal manual sign-in path.
+
+Use official Firebase docs for current platform details.

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: grill-me
+description: Challenge plans, code, product ideas, and written arguments with direct critical feedback.
+---
+
+# Grill Me
+
+Use this skill when the user asks for a hard critique, a second opinion, or wants assumptions pressure-tested before they commit to a direction.
+
+## Workflow
+
+1. Identify the claim, plan, artifact, or decision being evaluated.
+2. State the strongest version of what is good about it.
+3. List the highest-risk flaws, missing evidence, weak assumptions, and likely failure modes.
+4. Separate must-fix issues from taste or strategy preferences.
+5. End with the smallest set of changes that would materially improve the work.
+
+Keep the tone direct but useful. Do not perform theatrical harshness.

--- a/skills/grill-with-docs/SKILL.md
+++ b/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: grill-with-docs
+description: Critique implementation plans or code against official docs and source-backed evidence.
+---
+
+# Grill With Docs
+
+Use this skill when a user wants a critique that depends on current framework, library, API, or platform behavior.
+
+## Workflow
+
+1. Identify the technologies and versions involved.
+2. Prefer official docs, source code, release notes, and standards over blog posts.
+3. Compare the proposed approach with documented behavior and supported patterns.
+4. Call out unsupported APIs, stale assumptions, migration hazards, and version mismatches.
+5. Cite or link the specific docs that support the critique when the surface allows links.
+
+If the docs are unclear, say what is uncertain and suggest a small verification step.

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: handoff
+description: Prepare concise handoff notes for another engineer, agent, or future session.
+---
+
+# Handoff
+
+Use this skill when work needs to continue in another session, another agent, a PR review, or a teammate handoff.
+
+## Workflow
+
+1. Summarize the goal and current state.
+2. List files, branches, commands, tickets, and relevant links.
+3. Explain what has been tried and what is still unknown.
+4. State the next action in a way someone else can pick up immediately.
+5. Include verification status and any known risks.
+
+Do not include private context unless the target is allowed to see it.

--- a/skills/improve-codebase-architecture/SKILL.md
+++ b/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: improve-codebase-architecture
+description: Review a codebase structure and propose scoped architectural improvements.
+---
+
+# Improve Codebase Architecture
+
+Use this skill when asked to improve architecture, reduce coupling, clarify boundaries, or make a codebase easier to extend.
+
+## Workflow
+
+1. Read the existing module layout, entry points, tests, and dependency direction.
+2. Identify current boundaries, shared abstractions, and places where responsibilities leak.
+3. Prioritize changes that reduce concrete maintenance pain.
+4. Avoid broad rewrites unless the user explicitly asks for them.
+5. Propose or implement small, reviewable steps with clear behavior preservation.
+
+Favor local conventions over generic architecture patterns.

--- a/skills/prototype/SKILL.md
+++ b/skills/prototype/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: prototype
+description: Build a small disposable prototype to test feasibility or product feel.
+---
+
+# Prototype
+
+Use this skill when the user wants to test an idea quickly before committing to a production implementation.
+
+## Workflow
+
+1. Define the question the prototype must answer.
+2. Choose the smallest implementation that can answer it.
+3. Build in an isolated file, branch, fixture, or throwaway project when possible.
+4. Verify the prototype with a focused run, screenshot, or example.
+5. Report the verdict, limitations, and whether the idea should move to production.
+
+Do not mistake prototype code for production code.

--- a/skills/resolving-merge-conflicts/SKILL.md
+++ b/skills/resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: resolving-merge-conflicts
+description: Resolve merge conflicts by preserving intent from both sides and verifying behavior.
+---
+
+# Resolving Merge Conflicts
+
+Use this skill when a merge, rebase, cherry-pick, or patch application produces conflicts.
+
+## Workflow
+
+1. Inspect both sides of each conflict and the common surrounding code.
+2. Identify the intent of each change before editing.
+3. Resolve with the smallest combined change that preserves intended behavior.
+4. Run formatting and targeted tests for the conflicted area.
+5. Review the final diff to catch accidental deletions or duplicated logic.
+
+Never discard one side just to make the conflict disappear.

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: tdd
+description: Drive changes with failing tests first, then implementation and cleanup.
+---
+
+# TDD
+
+Use this skill when the user asks for test-driven development, red-green-refactor, or a cautious workflow for behavior changes.
+
+## Workflow
+
+1. Define the behavior in one or more focused tests before editing production code.
+2. Run the targeted test and confirm it fails for the expected reason.
+3. Implement the smallest production change that satisfies the test.
+4. Run the targeted tests again, then expand to nearby suites when risk warrants it.
+5. Refactor only after the behavior is covered and passing.
+
+Keep tests readable and behavior-oriented.

--- a/skills/teach/SKILL.md
+++ b/skills/teach/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: teach
+description: Explain technical concepts through examples, checks for understanding, and practical exercises.
+---
+
+# Teach
+
+Use this skill when the user asks to learn a concept, library, workflow, or codebase area.
+
+## Workflow
+
+1. Ask what level the explanation should target if it is unclear.
+2. Start from the user's immediate goal.
+3. Explain the core idea with a minimal example.
+4. Add one or two common mistakes and how to recognize them.
+5. Offer a short exercise or next experiment when useful.
+
+Keep the explanation grounded in what the user can do next.

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: to-issues
+description: Convert plans, PRDs, bugs, or notes into actionable GitHub or Linear issues.
+---
+
+# To Issues
+
+Use this skill when a user wants messy notes split into trackable implementation tasks.
+
+## Workflow
+
+1. Identify independent units of work and their dependencies.
+2. Write each issue with a clear title, context, acceptance criteria, and verification notes.
+3. Separate discovery tasks from implementation tasks.
+4. Keep issue scope small enough to review and ship.
+5. Add labels, owners, milestones, or project metadata when available and requested.
+
+Avoid creating external issues unless the user or workflow explicitly asks for that action.

--- a/skills/to-prd/SKILL.md
+++ b/skills/to-prd/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: to-prd
+description: Turn rough product ideas into a concise product requirements document.
+---
+
+# To PRD
+
+Use this skill when a user gives an idea, feature request, customer problem, or messy notes and wants a product requirements document.
+
+## Workflow
+
+1. Identify the user, problem, goal, and non-goals.
+2. Convert fuzzy ideas into explicit requirements and acceptance criteria.
+3. Capture open questions separately from decisions.
+4. Include constraints, dependencies, analytics, rollout notes, and risks when relevant.
+5. Keep the document short enough to guide implementation.
+
+Prefer clear requirements over product theater.

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: triage
+description: Sort bugs, tasks, alerts, or feedback into clear priority and next action.
+---
+
+# Triage
+
+Use this skill when the user gives a queue of issues, logs, alerts, bugs, support messages, or ideas and needs order imposed on it.
+
+## Workflow
+
+1. Group items by type, impact, urgency, owner, and dependency.
+2. Identify duplicates and items that need more information.
+3. Assign a priority with a brief reason.
+4. Recommend the next concrete action for each high-priority item.
+5. Keep lower-priority items visible without letting them dominate the plan.
+
+Optimize for deciding what to do next, not for perfect taxonomy.

--- a/skills/wayfinder/SKILL.md
+++ b/skills/wayfinder/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: wayfinder
+description: Explore an unfamiliar repo, docs set, or problem space and map the path forward.
+---
+
+# Wayfinder
+
+Use this skill when the user drops into unfamiliar territory and needs orientation before action.
+
+## Workflow
+
+1. Identify the question that needs orientation.
+2. Scan the most relevant files, docs, commands, or source lists.
+3. Build a short map of key concepts, entry points, and dependencies.
+4. Point out traps, missing context, and likely next files to inspect.
+5. Recommend the first useful action.
+
+Keep the map compact enough to act on.

--- a/skills/write-a-skill/SKILL.md
+++ b/skills/write-a-skill/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: write-a-skill
+description: Draft practical SKILL.md files with clear triggers, workflows, and safety notes.
+---
+
+# Write A Skill
+
+Use this skill when creating or improving an agent skill file.
+
+## Workflow
+
+1. Define the exact trigger: when the agent should use the skill.
+2. Capture requirements, tools, inputs, outputs, and safety constraints.
+3. Write concise frontmatter with a useful description.
+4. Add a workflow that teaches decisions, not just commands.
+5. Include examples only when they reduce ambiguity.
+
+Keep skills reusable, specific, and short enough to load cheaply.

--- a/skills/zoom-out/SKILL.md
+++ b/skills/zoom-out/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: zoom-out
+description: Step back from details to clarify goals, tradeoffs, and the bigger decision.
+---
+
+# Zoom Out
+
+Use this skill when a conversation is stuck in implementation details, local optimization, or conflicting tactical choices.
+
+## Workflow
+
+1. Restate the broader goal in plain language.
+2. Identify the real decision being made.
+3. Separate constraints from preferences.
+4. Compare the main options by tradeoff, reversibility, and cost of being wrong.
+5. Recommend a path or a small test that resolves the uncertainty.
+
+Use this to regain perspective without ignoring the practical work.


### PR DESCRIPTION
Linear: ORT-2357

## Summary
- Add 20 SKILL.md stubs from daily discovery sources
- Cover critique, TDD, triage, handoff, PRD, debugging, architecture, domain modeling, and Firebase Auth basics

## Sources
- skills.sh leaderboard and trend lists
- sundial-org/awesome-openclaw-skills

## Verification
- Checked SKILL.md frontmatter shape for all added stubs
- Ran git diff --check

@christianpickettcode @berasogut