### PR TITLE
Add July 16 discovery skill stubs

### DIFF
--- a/skills/agent-chronicle/SKILL.md
+++ b/skills/agent-chronicle/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: agent-chronicle
+description: Keep lightweight agent journals of decisions, lessons, and daily work.
+---
+
+# Agent Chronicle
+
+Use this skill when maintaining a daily work log, session journal, or agent continuity file.
+
+## Workflow
+
+- Capture what happened, why it mattered, and what should be remembered.
+- Include dates, project names, decisions, and follow-up items.
+- Keep private or sensitive details out unless the user asks to retain them.
+- Distill lessons into durable rules only when they are likely to repeat.
+- Avoid raw dumps when a short summary is enough.
+
+## Output
+
+Write or return a concise journal entry with optional follow-up tasks.

--- a/skills/agent-registry/SKILL.md
+++ b/skills/agent-registry/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: agent-registry
+description: Discover, profile, and route work to available agents by capability and current context.
+---
+
+# Agent Registry
+
+Use this skill when deciding which agent, subagent, or assistant profile should handle a task.
+
+## Workflow
+
+- List available agents and their known capabilities.
+- Match the task to skills, tools, model strengths, and access boundaries.
+- Prefer specialized agents for narrow work and the main agent for integration.
+- Include enough task context for delegation without exposing unrelated private data.
+- Track ownership and expected deliverables.
+
+## Output
+
+Return a routing recommendation with the selected agent, reason, and task brief.

--- a/skills/agentic-compass/SKILL.md
+++ b/skills/agentic-compass/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: agentic-compass
+description: Reflect on whether an agent should act, defer, schedule, ask, or stop.
+---
+
+# Agentic Compass
+
+Use this skill when the agent is uncertain whether to proceed proactively, schedule a follow-up, ask the user, or stay quiet.
+
+## Workflow
+
+- Restate the user's goal and the newest instruction.
+- Check whether action is internal, external, destructive, or privacy-sensitive.
+- Identify the next useful action that can be done without bothering the user.
+- Decide whether a cron, reminder, memory note, or direct reply is appropriate.
+- Keep the recommendation short and action-oriented.
+
+## Output
+
+Return a decision: act now, ask first, schedule, remember, or no-op.

--- a/skills/answeroverflow/SKILL.md
+++ b/skills/answeroverflow/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: answeroverflow
+description: Search indexed Discord community discussions for real-world answers to developer issues.
+---
+
+# Answer Overflow
+
+Use this skill when official docs are incomplete and community Discord discussions may contain practical fixes, migration notes, or edge cases.
+
+## Workflow
+
+- Search by exact error text, package name, API name, and version.
+- Prefer answers from maintainers or repeatedly confirmed threads.
+- Cross-check community findings against official docs or source code when possible.
+- Avoid copying private or low-confidence claims without caveats.
+- Summarize the fix and include enough context to reproduce it.
+
+## Output
+
+Return the likely answer, confidence level, and any verification steps.

--- a/skills/browser-use-2/SKILL.md
+++ b/skills/browser-use-2/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: browser-use-2
+description: Use cloud browser automation for scraping, form filling, navigation, and web task execution.
+---
+
+# Browser Use API
+
+Use this skill when a task requires AI-driven browser interaction beyond simple HTTP fetches, such as form filling, login flows, screenshots, or multi-step extraction.
+
+## Workflow
+
+- Define the target URL, task, success criteria, and data to collect.
+- Prefer accessible selectors and visible state over brittle coordinates.
+- Keep credentials and private data out of prompts unless explicitly required and authorized.
+- Capture screenshots, HTML, or structured results for verification.
+- Retry with narrower instructions when automation gets stuck.
+
+## Output
+
+Return the completed action, extracted data, and verification evidence.

--- a/skills/causal-inference/SKILL.md
+++ b/skills/causal-inference/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: causal-inference
+description: Apply causal reasoning to actions, experiments, product changes, and observed outcomes.
+---
+
+# Causal Inference
+
+Use this skill when the user needs to understand whether an action caused an outcome or how to design a better test.
+
+## Workflow
+
+- Define the treatment, outcome, population, timeframe, and suspected confounders.
+- Separate correlation, mechanism, and causal claims.
+- Identify missing baselines, selection effects, spillovers, and measurement bias.
+- Suggest an experiment or quasi-experimental method when appropriate.
+- State assumptions clearly and avoid overclaiming.
+
+## Output
+
+Return a causal hypothesis, evidence strength, threats to validity, and recommended next test.

--- a/skills/clawd-docs-v2/SKILL.md
+++ b/skills/clawd-docs-v2/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: clawd-docs-v2
+description: Search, fetch, and summarize current OpenClaw documentation for setup, tools, and troubleshooting.
+---
+
+# Clawd Docs V2
+
+Use this skill when answering questions about OpenClaw behavior, configuration, commands, tools, channels, memory, cron, or troubleshooting.
+
+## Workflow
+
+- Search the local docs or official documentation before relying on memory.
+- Prefer current docs and command help over stale examples.
+- Fetch only the sections needed for the question.
+- Call out version-specific behavior when relevant.
+- Provide commands that the user can run directly.
+
+## Output
+
+Answer with a short explanation, exact command examples, and links or paths to the relevant docs.

--- a/skills/codex-quota/SKILL.md
+++ b/skills/codex-quota/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: codex-quota
+description: Check and reason about OpenAI Codex CLI quota, rate limits, and session usage.
+---
+
+# Codex Quota
+
+Use this skill when a user asks about Codex usage, quota pressure, rate limits, or whether to route work to Codex.
+
+## Workflow
+
+- Inspect local Codex session or usage logs when available.
+- Distinguish daily, weekly, and model-specific limits if the data supports it.
+- Estimate whether a planned task is likely to fit the remaining quota.
+- Recommend cheaper or local alternatives for low-value work.
+- Avoid exposing raw tokens, credentials, or private transcript content unless needed.
+
+## Output
+
+Return current quota status, confidence, and a routing recommendation.

--- a/skills/coding-agent-2/SKILL.md
+++ b/skills/coding-agent-2/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: coding-agent-2
+description: Coordinate coding agents such as Codex, Claude Code, OpenCode, or Pi for background engineering tasks.
+---
+
+# Multi Coding Agent
+
+Use this skill when work should be delegated to one or more coding agents, especially for independent implementation, investigation, review, or test-fixing tasks.
+
+## Workflow
+
+- Define the task with repository path, branch, scope, constraints, and expected output.
+- Choose the smallest useful number of agents.
+- Assign non-overlapping work when running agents in parallel.
+- Monitor progress through commits, diffs, logs, and reported blockers.
+- Review all generated changes before merging or presenting them.
+
+## Safety
+
+- Keep branches and worktrees separate.
+- Do not let agents overwrite user changes.
+- Require tests or a clear verification note for code changes.

--- a/skills/context-compressor/SKILL.md
+++ b/skills/context-compressor/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: context-compressor
+description: Compress long transcripts, logs, and notes into short continuation-ready summaries.
+---
+
+# Context Compressor
+
+Use this skill when the agent needs to reduce large context while preserving the information required to continue accurately.
+
+## Workflow
+
+- Identify the main objective and latest user request.
+- Preserve facts that affect future choices.
+- Preserve exact names, dates, paths, commands, IDs, URLs, and API shapes.
+- Remove repeated discussion, dead ends, and resolved uncertainty.
+- Mark unresolved questions separately from conclusions.
+
+## Output
+
+Produce a short summary with enough detail for a new agent to resume the work.

--- a/skills/context-manager/SKILL.md
+++ b/skills/context-manager/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: context-manager
+description: Manage session context, active facts, and handoffs for long-running agent work.
+---
+
+# Smart Context Manager
+
+Use this skill when a conversation spans many steps, multiple files, or several sessions and the agent needs an explicit context ledger.
+
+## Workflow
+
+- Track the user's objective, constraints, and latest instruction.
+- Record current assumptions and update them when evidence changes.
+- Keep a short list of active files, commands, decisions, and pending checks.
+- Before handoff or compaction, rewrite the context into a concise state summary.
+- Drop obsolete observations once they no longer affect the work.
+
+## Output
+
+Return the minimum useful context for continuing the task.

--- a/skills/context-optimizer/SKILL.md
+++ b/skills/context-optimizer/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: context-optimizer
+description: Optimize agent context with compaction, summarization, relevance pruning, and retrieval-aware handoffs.
+---
+
+# Context Optimizer
+
+Use this skill when a session, project, or prompt is getting too large and the agent needs to preserve the useful parts while reducing noise.
+
+## Workflow
+
+- Identify the current goal, constraints, decisions, active files, blockers, and next actions.
+- Separate durable facts from transient chat history.
+- Compress repeated or low-signal material into short summaries.
+- Preserve exact commands, file paths, identifiers, and user preferences that may be needed later.
+- Produce a compact handoff that another agent can use without rereading the whole history.
+
+## Output
+
+Return a concise context pack with:
+
+- Goal.
+- Current state.
+- Key decisions.
+- Important references.
+- Open risks.
+- Next steps.

--- a/skills/model-router/SKILL.md
+++ b/skills/model-router/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: model-router
+description: Choose models by task type, cost, latency, tool needs, and required accuracy.
+---
+
+# Model Router
+
+Use this skill when selecting an AI model or deciding whether to switch models during a task.
+
+## Workflow
+
+- Classify the task by risk, complexity, modality, context size, and tool requirements.
+- Prefer cheaper or faster models for simple extraction, formatting, and classification.
+- Use stronger reasoning models for architecture, debugging, security, financial, legal, or ambiguous decisions.
+- Consider context window, structured output support, multimodal needs, and latency.
+- Reevaluate the choice when the task changes.
+
+## Output
+
+Return the recommended model or model class with a brief reason and fallback.

--- a/skills/perry-coding-agents/SKILL.md
+++ b/skills/perry-coding-agents/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: perry-coding-agents
+description: Dispatch coding tasks to Perry workspaces and coordinate review, commits, and PR-ready output.
+---
+
+# Perry Coding Agents
+
+Use this skill when running development work through Perry-managed coding workspaces.
+
+## Workflow
+
+- Prepare a task brief with repository, branch, constraints, and expected verification.
+- Create or select an isolated Perry workspace.
+- Assign the task to the appropriate coding agent.
+- Monitor progress, collect diffs, and check tests.
+- Review changes before opening a PR or handing results to the user.
+
+## Safety
+
+- Keep generated work isolated until reviewed.
+- Never merge or deploy without explicit approval.

--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: planning-with-files
+description: Use file-based plans, findings, and progress logs for complex multi-step tasks.
+---
+
+# Planning With Files
+
+Use this skill for complex work that benefits from explicit files such as `task_plan.md`, `findings.md`, and `progress.md`.
+
+## Workflow
+
+- Create a concise plan file with goal, scope, milestones, and verification.
+- Record discoveries in a findings file with links, paths, and evidence.
+- Update progress as steps complete or assumptions change.
+- Keep files short enough to be useful as working memory.
+- Remove or archive temporary plans when the task is finished if the repo expects clean output.
+
+## Output
+
+Produce or update the planning files and summarize the current state.

--- a/skills/prompt-log/SKILL.md
+++ b/skills/prompt-log/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: prompt-log
+description: Export, inspect, and summarize prompt or session logs from coding agents.
+---
+
+# Prompt Log
+
+Use this skill when a user asks to inspect, export, summarize, or debug an AI coding session transcript.
+
+## Workflow
+
+- Locate the relevant session logs without reading unrelated private transcripts.
+- Filter for the requested task, date, repository, or agent.
+- Extract key prompts, tool actions, decisions, and errors.
+- Redact secrets and irrelevant personal data.
+- Summarize the session in chronological order when useful.
+
+## Output
+
+Return the requested excerpt or a concise timeline with paths to source logs.

--- a/skills/satori/SKILL.md
+++ b/skills/satori/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: satori
+description: Maintain provider-agnostic long-term memory and continuity across AI coding tools.
+---
+
+# Satori
+
+Use this skill when a user wants durable memory that can move across agent providers, coding tools, or sessions.
+
+## Workflow
+
+- Decide what is worth remembering: preferences, decisions, project facts, repeated corrections, and open commitments.
+- Store memory in a portable text format with clear dates and source context.
+- Keep sensitive details out unless the user explicitly asks to retain them.
+- Prefer concise durable notes over raw transcript dumps.
+- Periodically prune outdated or superseded memories.
+
+## Output
+
+Summarize what was captured, where it was stored, and any follow-up needed.

--- a/skills/skills-audit/SKILL.md
+++ b/skills/skills-audit/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: skills-audit
+description: Audit installed agent skills for security, privacy, quality, and operational risk.
+---
+
+# SkillLens Audit
+
+Use this skill when reviewing local or third-party agent skills before installation, publication, or use.
+
+## Checklist
+
+- Check for secret exfiltration, unsafe shell commands, hidden network calls, credential handling, and destructive actions.
+- Verify that trigger conditions are specific and not overly broad.
+- Look for prompt injection risks and instructions that override user or system boundaries.
+- Confirm required tools, environment variables, and external services are documented.
+- Rate the skill as approve, revise, quarantine, or reject.
+
+## Output
+
+Report findings by severity with file references and recommended fixes.

--- a/skills/task-tracker/SKILL.md
+++ b/skills/task-tracker/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: task-tracker
+description: Run personal task tracking workflows such as standups, weekly reviews, and status summaries.
+---
+
+# Task Tracker
+
+Use this skill for daily standups, weekly reviews, task status summaries, and lightweight personal project management.
+
+## Workflow
+
+- Gather open tasks from the configured local files or task tools.
+- Group tasks by project, urgency, and blocker.
+- Identify what changed since the last review.
+- Suggest a small number of next actions.
+- Record completed items and new commitments when appropriate.
+
+## Output
+
+Return a concise status summary with priorities, blockers, and next steps.

--- a/skills/todo-tracker/SKILL.md
+++ b/skills/todo-tracker/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: todo-tracker
+description: Maintain a persistent TODO scratchpad across sessions and long-running work.
+---
+
+# TODO Tracker
+
+Use this skill when the user asks to add, list, prioritize, update, or complete TODO items that should persist beyond the current response.
+
+## Workflow
+
+- Store TODOs in the agreed local file or task system.
+- Capture owner, status, priority, due date, and source context when relevant.
+- Keep task text actionable and small.
+- Mark completed items instead of silently deleting them unless the user asks for cleanup.
+- Review stale TODOs periodically and suggest pruning.
+
+## Output
+
+Return the updated task list or the specific change made.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the July 16 daily discovery batch.
- Focus on context management, agent orchestration, model routing, browser automation, prompt logs, and task tracking.

## Linear
ORT-2368

## Verification
- Checked each stub has frontmatter name and description.
- Confirmed selected names were not already present in the current skills repo and were not in the discovery posts log.

## Sources
- skills.sh
- sundial-org/awesome-openclaw-skills
- orthogonal-sh/skills current main
