### PR TITLE
Add July 17 discovery skill stubs

### DIFF
--- a/skills/adaptive-suite/SKILL.md
+++ b/skills/adaptive-suite/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: adaptive-suite
+description: Adapt agent workflows across coding, research, analysis, planning, and free-resource discovery.
+---
+
+# Adaptive Suite
+
+Use this skill when a task spans multiple domains and the agent needs to adapt its workflow as new context appears.
+
+## Workflow
+
+- Clarify the task goal, constraints, available tools, and success criteria.
+- Break the work into domain-specific tracks such as coding, business analysis, planning, research, or data review.
+- Prefer free, open-source, or already-available resources before suggesting paid services.
+- Reassess the plan when new context changes the likely best path.
+- Capture durable findings and next actions in a compact handoff.
+

--- a/skills/adversarial-prompting/SKILL.md
+++ b/skills/adversarial-prompting/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: adversarial-prompting
+description: Stress-test plans and solutions with adversarial critique, failure modes, and ranked fixes.
+---
+
+# Adversarial Prompting
+
+Use this skill for complex or high-stakes decisions where a first plausible answer is not enough.
+
+## Workflow
+
+- Generate two or more viable approaches.
+- Identify assumptions, edge cases, failure modes, and incentives for each approach.
+- Propose fixes or mitigations for the strongest objections.
+- Compare residual risk, cost, reversibility, and implementation effort.
+- Recommend the best option with the tradeoffs made explicit.
+

--- a/skills/agent-orchestrator/SKILL.md
+++ b/skills/agent-orchestrator/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: agent-orchestrator
+description: Decompose large tasks, coordinate sub-agents, and consolidate their results into one answer.
+---
+
+# Agent Orchestrator
+
+Use this skill when a task is large enough to benefit from parallel or specialized agent work.
+
+## Workflow
+
+- Define the overall goal, deliverables, constraints, and owner.
+- Split the task into independent subtasks with clear inputs and outputs.
+- Assign subtasks to appropriate agents or local work streams.
+- Track dependencies, blockers, and shared files.
+- Merge results, resolve contradictions, and deliver one coherent summary.
+

--- a/skills/ai-code-review/SKILL.md
+++ b/skills/ai-code-review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ai-code-review
+description: Review staged or proposed code changes for bugs, regressions, security issues, and missing tests.
+---
+
+# AI Code Review
+
+Use this skill when reviewing code changes before a commit, push, or pull request.
+
+## Workflow
+
+- Inspect the diff, surrounding code, and relevant tests.
+- Prioritize concrete bugs, regressions, security risks, and contract breaks.
+- Check for missing or weak tests proportional to the risk of the change.
+- Avoid style commentary unless it hides a real maintainability problem.
+- Report findings first with file and line references, then residual risk.
+

--- a/skills/api-designer/SKILL.md
+++ b/skills/api-designer/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: api-designer
+description: Design REST, GraphQL, or OpenAPI contracts with clear resources, errors, pagination, and versioning.
+---
+
+# API Designer
+
+Use this skill when designing or revising an API contract.
+
+## Workflow
+
+- Model resources, relationships, actions, and lifecycle states.
+- Choose REST, GraphQL, webhook, or async patterns based on client needs.
+- Define authentication, authorization, idempotency, pagination, filtering, and rate limits.
+- Specify error shapes, status codes, validation behavior, and versioning.
+- Produce a concise contract outline or OpenAPI-oriented specification.
+

--- a/skills/architecture-designer/SKILL.md
+++ b/skills/architecture-designer/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: architecture-designer
+description: Plan system architecture, scalability choices, module boundaries, and ADR-style tradeoffs.
+---
+
+# Architecture Designer
+
+Use this skill when designing a new system, reviewing an existing architecture, or making a durable technical decision.
+
+## Workflow
+
+- Clarify goals, constraints, expected scale, data flows, and failure tolerance.
+- Identify major components, ownership boundaries, and integration points.
+- Compare architecture options using cost, complexity, operability, and reversibility.
+- Call out security, reliability, observability, and migration concerns.
+- Record the recommendation as a short architecture decision with consequences.
+

--- a/skills/auth-checker/SKILL.md
+++ b/skills/auth-checker/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: auth-checker
+description: Audit authentication flows, sessions, tokens, password policy, and account recovery for security gaps.
+---
+
+# Auth Checker
+
+Use this skill when reviewing authentication or account security behavior.
+
+## Workflow
+
+- Map login, signup, logout, session refresh, password reset, and account recovery flows.
+- Check token storage, expiration, rotation, replay resistance, and revocation.
+- Review password, MFA, rate limiting, lockout, and abuse protections.
+- Verify authorization boundaries are not confused with authentication checks.
+- Return prioritized findings with exploitability and recommended fixes.
+

--- a/skills/changelog-gen/SKILL.md
+++ b/skills/changelog-gen/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: changelog-gen
+description: Generate release notes and changelog entries from commits, diffs, issues, or pull requests.
+---
+
+# Changelog Generator
+
+Use this skill when preparing release notes or a changelog.
+
+## Workflow
+
+- Gather commits, merged pull requests, issues, and notable manual changes for the release range.
+- Group changes into added, changed, fixed, deprecated, removed, and security sections when useful.
+- Rewrite implementation-heavy commit messages into user-facing release notes.
+- Flag breaking changes, migrations, and operational notes.
+- Keep the final changelog concise and scannable.
+

--- a/skills/ci-gen/SKILL.md
+++ b/skills/ci-gen/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ci-gen
+description: Generate CI workflows for linting, testing, building, caching, and deployment checks.
+---
+
+# CI Generator
+
+Use this skill when setting up or improving continuous integration.
+
+## Workflow
+
+- Detect the project language, package manager, test runner, build steps, and deployment targets.
+- Define the minimum checks needed before merge.
+- Add caching and dependency installation appropriate to the stack.
+- Separate fast pull request checks from slower scheduled or release jobs.
+- Document required secrets, permissions, and branch protection assumptions.
+

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: code-reviewer
+description: Perform senior-engineer code reviews focused on correctness, behavior, and maintainability.
+---
+
+# Code Reviewer
+
+Use this skill when asked to review a patch, branch, pull request, or design-level code change.
+
+## Workflow
+
+- Read the diff and enough surrounding code to understand the behavior.
+- Look first for correctness bugs, regressions, race conditions, data loss, and security issues.
+- Check whether tests cover the risky paths and expected failures.
+- Keep comments actionable and grounded in file and line references.
+- If no issues are found, state that clearly and mention remaining test gaps.
+

--- a/skills/config-guardian/SKILL.md
+++ b/skills/config-guardian/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: config-guardian
+description: Safely edit OpenClaw or service configuration with backups, validation, and rollback steps.
+---
+
+# Config Guardian
+
+Use this skill before changing configuration that can affect routing, models, agents, tools, credentials, or gateways.
+
+## Workflow
+
+- Identify the config file, desired change, and expected runtime effect.
+- Create a recoverable backup before editing.
+- Validate the current config before making changes.
+- Apply the smallest possible edit and avoid exposing secrets.
+- Validate after the change and prepare rollback steps before restart or deploy.
+

--- a/skills/context-recovery/SKILL.md
+++ b/skills/context-recovery/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: context-recovery
+description: Recover active work context after compaction, interruption, vague continuation, or missing session state.
+---
+
+# Context Recovery
+
+Use this skill when the user asks to continue prior work but the active context is incomplete.
+
+## Workflow
+
+- Identify the channel, repo, branch, issue, PR, or task hinted by the current message.
+- Search recent session history, memory files, plans, git state, and local notes as appropriate.
+- Reconstruct the goal, current state, decisions, blockers, and next actions.
+- Ask only if multiple plausible contexts remain.
+- Continue from the recovered state instead of restarting from scratch.
+

--- a/skills/cron-creator/SKILL.md
+++ b/skills/cron-creator/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: cron-creator
+description: Convert natural-language schedules into cron jobs, reminders, and recurring automation specs.
+---
+
+# Cron Creator
+
+Use this skill when creating or editing scheduled jobs from natural-language requests.
+
+## Workflow
+
+- Extract the task, schedule, timezone, destination, and stopping conditions.
+- Convert relative times into concrete schedule expressions.
+- Clarify ambiguity around weekdays, month boundaries, daylight saving time, and delivery channel.
+- Add the smallest reliable cron or scheduler entry.
+- Record what was created and how to pause, edit, or remove it.
+

--- a/skills/daily-review/SKILL.md
+++ b/skills/daily-review/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: daily-review
+description: Summarize a day from messages, calendar, commits, docs, tasks, and focus signals.
+---
+
+# Daily Review
+
+Use this skill when preparing an end-of-day review or performance recap.
+
+## Workflow
+
+- Gather the day's work from approved local sources such as commits, tasks, notes, calendar, and messages.
+- Separate accomplishments, open loops, blockers, decisions, and follow-ups.
+- Highlight patterns in focus, communication load, and unfinished commitments.
+- Avoid exposing private details beyond the intended audience.
+- Produce a short review with next-day priorities.
+

--- a/skills/database/SKILL.md
+++ b/skills/database/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: database
+description: Work with database schemas, migrations, queries, exports, backups, and performance investigations.
+---
+
+# Database
+
+Use this skill when planning or reviewing database work.
+
+## Workflow
+
+- Identify the database engine, environment, access constraints, and safety requirements.
+- Prefer read-only inspection before writes or migrations.
+- Review schemas, indexes, constraints, query plans, and data shape.
+- For changes, prepare reversible migrations and backup or rollback steps.
+- Never expose credentials or run destructive operations without explicit approval.
+

--- a/skills/deploy-agent/SKILL.md
+++ b/skills/deploy-agent/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: deploy-agent
+description: Coordinate build, test, release, deploy, verification, and rollback for application deployments.
+---
+
+# Deploy Agent
+
+Use this skill when deploying an application or preparing a release.
+
+## Workflow
+
+- Confirm the target environment, artifact, branch, version, and approval requirements.
+- Run or inspect build, test, lint, and migration checks before deployment.
+- Verify secrets, environment variables, permissions, and infrastructure dependencies.
+- Deploy in the established project workflow.
+- Confirm health checks, logs, smoke tests, and rollback readiness after release.
+

--- a/skills/diagram-gen/SKILL.md
+++ b/skills/diagram-gen/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: diagram-gen
+description: Generate architecture, sequence, flow, class, or data diagrams from code and notes.
+---
+
+# Diagram Generator
+
+Use this skill when the user needs a diagram for a system, workflow, data model, or codebase.
+
+## Workflow
+
+- Determine the diagram type and audience.
+- Read the relevant source files, docs, schemas, or process notes.
+- Extract components, relationships, states, and directional flows.
+- Generate Mermaid, SVG, Excalidraw, or another requested format.
+- Keep labels short and verify the diagram matches the source behavior.
+

--- a/skills/diff-summary/SKILL.md
+++ b/skills/diff-summary/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: diff-summary
+description: Summarize code diffs in plain English for reviews, handoffs, pull requests, and release notes.
+---
+
+# Diff Summary
+
+Use this skill when turning a git diff into a readable summary.
+
+## Workflow
+
+- Inspect the changed files and the surrounding intent.
+- Group related edits by behavior or user-visible outcome.
+- Call out tests, migrations, config changes, and breaking changes separately.
+- Avoid restating every file when a higher-level summary is clearer.
+- Include follow-up risks only when they matter.
+

--- a/skills/email-best-practices/SKILL.md
+++ b/skills/email-best-practices/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: email-best-practices
+description: Build reliable email flows with deliverability, consent, suppression, retries, and webhook handling.
+---
+
+# Email Best Practices
+
+Use this skill when implementing or debugging transactional or marketing email.
+
+## Workflow
+
+- Identify the email type, sender domain, provider, audience, and compliance requirements.
+- Check SPF, DKIM, DMARC, bounce handling, unsubscribe, and suppression behavior.
+- Design idempotent send logic, retries, templates, and event webhook processing.
+- Separate transactional and marketing flows when consent or deliverability requires it.
+- Test rendering, links, tracking, failure paths, and provider callbacks.
+

--- a/skills/error-handler-gen/SKILL.md
+++ b/skills/error-handler-gen/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: error-handler-gen
+description: Design consistent application error handling, middleware, status codes, and response shapes.
+---
+
+# Error Handler Generator
+
+Use this skill when setting up or refactoring error handling for an API or application.
+
+## Workflow
+
+- Identify expected error classes, framework conventions, and client needs.
+- Define consistent status codes, machine-readable codes, messages, and validation details.
+- Preserve useful logs and traces without leaking sensitive information.
+- Handle async failures, retries, idempotency conflicts, and upstream errors.
+- Add tests for common, boundary, and unexpected failure paths.
+


### PR DESCRIPTION
Linear: ORT-2374

## Summary
- Add 20 July 17 daily discovery skill stubs from skills.sh and sundial-org/awesome-openclaw-skills.
- Keep each stub scoped to reusable agent instructions with concise frontmatter.

## Skills
- adaptive-suite
- adversarial-prompting
- agent-orchestrator
- ai-code-review
- api-designer
- architecture-designer
- auth-checker
- changelog-gen
- ci-gen
- code-reviewer
- config-guardian
- context-recovery
- cron-creator
- daily-review
- database
- deploy-agent
- diagram-gen
- diff-summary
- email-best-practices
- error-handler-gen

## Testing
- Frontmatter sanity check across all SKILL.md files.