### PR TITLE
Add July 19 discovery skill stubs

### DIFF
--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: apple-mail
+description: Search, triage, draft, and summarize Apple Mail messages from local mail data.
+---
+
+# Apple Mail
+
+Use this skill when the user wants to work with Apple Mail messages, mailboxes, drafts, search results, or local email triage.
+
+## Workflow
+
+1. Confirm the mailbox, sender, date range, or search intent.
+2. Search mail with the safest local Apple Mail or indexed-message interface available.
+3. Summarize threads before taking action.
+4. Ask before sending, deleting, archiving, or moving messages.
+
+## Notes
+
+- Do not expose private message bodies unless the user asks for them.
+- Prefer concise thread summaries over raw dumps.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: apple-notes
+description: Search, summarize, organize, and draft Apple Notes content.
+---
+
+# Apple Notes
+
+Use this skill when the user wants to find, summarize, create, or organize notes stored in Apple Notes.
+
+## Workflow
+
+1. Clarify the note topic, folder, or date range.
+2. Search notes using the local Apple Notes interface or index.
+3. Summarize matching notes and call out ambiguity.
+4. Ask before editing or deleting existing notes.
+
+## Notes
+
+- Preserve original note structure when updating content.
+- Keep private note content out of shared contexts.

--- a/skills/apple-reminders/SKILL.md
+++ b/skills/apple-reminders/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: apple-reminders
+description: Create, search, update, and complete Apple Reminders tasks and lists.
+---
+
+# Apple Reminders
+
+Use this skill when the user wants to manage reminders, task lists, due dates, recurring reminders, or completions in Apple Reminders.
+
+## Workflow
+
+1. Identify the target list, task, due date, and recurrence.
+2. Search before creating possible duplicates.
+3. Confirm destructive changes or ambiguous completions.
+4. Report the exact reminder list and due date after changes.
+
+## Notes
+
+- Prefer specific dates and times over vague relative phrases.
+- Do not mark reminders complete unless the user clearly asked.

--- a/skills/arxiv-watcher/SKILL.md
+++ b/skills/arxiv-watcher/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: arxiv-watcher
+description: Track arXiv papers, authors, topics, abstracts, and new-paper alerts.
+---
+
+# arXiv Watcher
+
+Use this skill when the user wants to monitor arXiv topics, find new papers, summarize abstracts, or build recurring literature alerts.
+
+## Workflow
+
+1. Convert the request into arXiv categories, authors, keywords, or IDs.
+2. Search arXiv and sort results by recency and relevance.
+3. Summarize methods, claims, limitations, and links.
+4. For recurring monitoring, store the query and last checked timestamp.
+
+## Notes
+
+- Distinguish preprints from peer-reviewed publications.
+- Preserve paper IDs and exact publication dates.

--- a/skills/asana/SKILL.md
+++ b/skills/asana/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: asana
+description: Manage Asana tasks, projects, comments, assignments, and due dates.
+---
+
+# Asana
+
+Use this skill when the user wants to inspect, create, update, or summarize Asana tasks, projects, sections, comments, or assignments.
+
+## Workflow
+
+1. Identify the workspace, project, task, assignee, and due date.
+2. Search existing tasks before creating new ones.
+3. Summarize relevant task context before updating it.
+4. Confirm broad edits, deletes, or bulk status changes.
+
+## Notes
+
+- Preserve project conventions for task names and sections.
+- Include task URLs when reporting changes.

--- a/skills/assemblyai-transcribe/SKILL.md
+++ b/skills/assemblyai-transcribe/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: assemblyai-transcribe
+description: Transcribe, summarize, and analyze audio or video with AssemblyAI.
+---
+
+# AssemblyAI Transcribe
+
+Use this skill when the user wants speech-to-text, speaker labels, summaries, chapters, or transcript analysis from audio or video files.
+
+## Workflow
+
+1. Confirm the media source, language, and desired transcript format.
+2. Upload or reference the media through the approved AssemblyAI path.
+3. Poll until transcription completes.
+4. Return the transcript, summary, speaker notes, or timestamps requested.
+
+## Notes
+
+- Do not upload private recordings without clear user intent.
+- Preserve timestamps for meeting notes and clips.

--- a/skills/attio/SKILL.md
+++ b/skills/attio/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: attio
+description: Search and update Attio CRM records, lists, notes, and company relationships.
+---
+
+# Attio
+
+Use this skill when the user wants to manage Attio companies, people, lists, notes, opportunities, or CRM enrichment.
+
+## Workflow
+
+1. Identify the workspace object, record, list, or pipeline view.
+2. Search before creating or updating records.
+3. Summarize existing CRM context and proposed changes.
+4. Ask before making bulk edits or changing relationship data.
+
+## Notes
+
+- Keep field names aligned with the workspace schema.
+- Avoid overwriting human-entered notes without confirmation.

--- a/skills/azure-cli/SKILL.md
+++ b/skills/azure-cli/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: azure-cli
+description: Operate Azure resources with Azure CLI, subscriptions, groups, and deployments.
+---
+
+# Azure CLI
+
+Use this skill when the user wants to inspect, create, deploy, or troubleshoot Azure resources from the command line.
+
+## Workflow
+
+1. Check the active account, tenant, subscription, and resource group.
+2. Prefer read-only inspection before mutation.
+3. Use Azure CLI commands with explicit subscription and resource group flags.
+4. Summarize resource IDs, regions, costs, and changed settings.
+
+## Notes
+
+- Ask before deleting resources or changing public exposure.
+- Do not print secrets, connection strings, or access tokens.

--- a/skills/bitwarden/SKILL.md
+++ b/skills/bitwarden/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: bitwarden
+description: Search and manage Bitwarden items, vault metadata, and secure secret references.
+---
+
+# Bitwarden
+
+Use this skill when the user wants to find, reference, organize, or update Bitwarden vault items through approved local tooling.
+
+## Workflow
+
+1. Confirm the item, collection, folder, or secret purpose.
+2. Search by metadata first and avoid revealing secret values.
+3. Use secure references for commands whenever possible.
+4. Ask before creating, editing, moving, or deleting vault items.
+
+## Notes
+
+- Never paste passwords, tokens, or recovery codes into chat.
+- Prefer item names and field labels over raw secret values.

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: browser-use
+description: Drive browser-use agents for web navigation, extraction, and task automation.
+---
+
+# Browser Use
+
+Use this skill when the user wants an agentic browser workflow for navigating sites, filling forms, extracting data, or validating web interactions.
+
+## Workflow
+
+1. Define the target site, task, credentials boundary, and stopping condition.
+2. Use browser-use for multi-step navigation and observation.
+3. Capture important URLs, states, and extracted records.
+4. Ask before submitting forms, purchasing, posting, or sending messages.
+
+## Notes
+
+- Prefer deterministic selectors and explicit checkpoints.
+- Keep credentials and session cookies out of summaries.

--- a/skills/cloudflare/SKILL.md
+++ b/skills/cloudflare/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: cloudflare
+description: Manage Cloudflare DNS, Workers, Pages, zones, rules, and cache operations.
+---
+
+# Cloudflare
+
+Use this skill when the user wants to inspect or change Cloudflare zones, DNS records, Workers, Pages projects, firewall rules, redirects, or cache settings.
+
+## Workflow
+
+1. Identify the account, zone, domain, and resource type.
+2. Inspect current settings before making changes.
+3. Apply the smallest scoped update through the approved Cloudflare interface.
+4. Verify propagation, deployment status, or effective rules.
+
+## Notes
+
+- Ask before deleting DNS records or changing proxy/security mode.
+- Do not expose API tokens or origin credentials.

--- a/skills/confluence/SKILL.md
+++ b/skills/confluence/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: confluence
+description: Search, summarize, create, and update Confluence pages and spaces.
+---
+
+# Confluence
+
+Use this skill when the user wants to find docs, summarize spaces, draft pages, update pages, or inspect Confluence knowledge bases.
+
+## Workflow
+
+1. Identify the space, page, label, owner, or topic.
+2. Search and summarize relevant pages with links and freshness.
+3. Draft changes in the user's requested structure.
+4. Ask before publishing edits to existing pages.
+
+## Notes
+
+- Preserve page hierarchy and existing formatting conventions.
+- Call out stale or conflicting docs.

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: deep-research
+description: Plan and execute multi-source research with claims, citations, and synthesis.
+---
+
+# Deep Research
+
+Use this skill when the user asks for thorough research that requires source discovery, comparison, evidence tracking, and synthesis.
+
+## Workflow
+
+1. Clarify the research question, decision, audience, and freshness requirements.
+2. Gather primary and reputable secondary sources.
+3. Track claims, uncertainty, dates, and disagreements.
+4. Produce a concise synthesis with source-backed conclusions.
+
+## Notes
+
+- Separate facts, judgments, and recommendations.
+- Prefer primary sources when accuracy matters.

--- a/skills/digital-ocean/SKILL.md
+++ b/skills/digital-ocean/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: digital-ocean
+description: Manage DigitalOcean droplets, apps, databases, domains, and deployments.
+---
+
+# DigitalOcean
+
+Use this skill when the user wants to inspect, deploy, scale, or troubleshoot DigitalOcean infrastructure.
+
+## Workflow
+
+1. Identify the project, region, resource, and environment.
+2. Inspect current resource state before mutation.
+3. Use doctl or the approved API path with explicit resource IDs.
+4. Verify health, logs, DNS, and deployment state after changes.
+
+## Notes
+
+- Ask before destroying resources, resizing databases, or opening ports.
+- Avoid exposing tokens, SSH keys, and database credentials.

--- a/skills/docker-essentials/SKILL.md
+++ b/skills/docker-essentials/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: docker-essentials
+description: Inspect, build, run, debug, and clean up Docker containers and images.
+---
+
+# Docker Essentials
+
+Use this skill when the user wants help with Dockerfiles, images, containers, Compose services, logs, volumes, networks, or local registry workflows.
+
+## Workflow
+
+1. Inspect Docker context, running containers, and Compose files.
+2. Reproduce failures with targeted commands.
+3. Make the smallest Dockerfile or Compose change needed.
+4. Verify builds, startup, health checks, and logs.
+
+## Notes
+
+- Ask before pruning volumes or deleting named data.
+- Prefer reproducible commands over one-off local state.

--- a/skills/domain-dns-ops/SKILL.md
+++ b/skills/domain-dns-ops/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: domain-dns-ops
+description: Diagnose and update domains, DNS records, propagation, SPF, DKIM, and DMARC.
+---
+
+# Domain DNS Ops
+
+Use this skill when the user wants domain setup, DNS debugging, email authentication, redirects, certificates, or propagation checks.
+
+## Workflow
+
+1. Identify the domain, registrar, DNS host, and desired record state.
+2. Inspect current DNS records from multiple resolvers.
+3. Plan minimal record changes with exact names, types, and values.
+4. Verify propagation and dependent service health.
+
+## Notes
+
+- Ask before changing MX, NS, or production records.
+- Use exact TTLs and record targets in summaries.

--- a/skills/firecrawl-deep-research/SKILL.md
+++ b/skills/firecrawl-deep-research/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: firecrawl-deep-research
+description: Run Firecrawl-powered web research, crawling, extraction, and source synthesis.
+---
+
+# Firecrawl Deep Research
+
+Use this skill when the user wants current web research that benefits from crawling multiple pages, extracting structured content, and synthesizing evidence.
+
+## Workflow
+
+1. Define the research question, source scope, and freshness requirements.
+2. Use Firecrawl search, crawl, or extract workflows for relevant sites.
+3. Deduplicate sources and track claims with URLs.
+4. Produce a synthesis with uncertainty and next steps.
+
+## Notes
+
+- Respect robots, rate limits, and site terms.
+- Prefer official and primary pages for company or product facts.

--- a/skills/firecrawl-lead-gen/SKILL.md
+++ b/skills/firecrawl-lead-gen/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: firecrawl-lead-gen
+description: Find and enrich leads from websites, directories, and public web data with Firecrawl.
+---
+
+# Firecrawl Lead Gen
+
+Use this skill when the user wants to build lead lists from websites, directories, search results, or market maps using Firecrawl.
+
+## Workflow
+
+1. Define the ideal customer profile, geography, source types, and exclusion rules.
+2. Crawl or extract structured data from target pages.
+3. Normalize companies, people, URLs, contact signals, and evidence.
+4. Deduplicate and rank leads before handing them off.
+
+## Notes
+
+- Keep source URLs for every lead.
+- Respect opt-out, privacy, and anti-spam requirements.

--- a/skills/firecrawl-market-research/SKILL.md
+++ b/skills/firecrawl-market-research/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: firecrawl-market-research
+description: Crawl competitor sites, directories, and content to build market research briefs.
+---
+
+# Firecrawl Market Research
+
+Use this skill when the user wants market maps, competitor research, category analysis, pricing scans, or customer-segment research using Firecrawl.
+
+## Workflow
+
+1. Clarify the market, geography, segment, and decision being supported.
+2. Crawl source lists, competitor pages, directories, and review sites.
+3. Extract positioning, pricing, features, customers, and proof points.
+4. Summarize patterns, gaps, and recommended follow-up research.
+
+## Notes
+
+- Separate observed facts from strategic interpretation.
+- Include dates for time-sensitive pricing or positioning.

--- a/skills/obsidian-skills/SKILL.md
+++ b/skills/obsidian-skills/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: obsidian-skills
+description: Work with Obsidian vaults, Markdown notes, Bases, Canvas, links, and local knowledge graphs.
+---
+
+# Obsidian Skills
+
+Use this skill when the user wants to search, summarize, create, or reorganize an Obsidian vault or Obsidian-native files.
+
+## Workflow
+
+1. Identify the vault, folder, tags, links, or note pattern.
+2. Search Markdown, Canvas, Bases, and frontmatter with structured tools when possible.
+3. Preserve links, aliases, tags, and frontmatter during edits.
+4. Summarize changed notes and unresolved backlinks.
+
+## Notes
+
+- Ask before bulk-moving or rewriting notes.
+- Keep personal vault content private outside direct user contexts.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the July 19 Daily Skills Discovery batch
- Sources: skills.sh and sundial-org/awesome-openclaw-skills
- Avoids picks already posted in memory/discovery-posts.md and existing orthogonal-sh/skills entries

Linear: ORT-2379

## Test Plan
- Verified all 20 SKILL.md files exist under skills/<name>/SKILL.md
- No runtime tests needed for markdown stubs