### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/apple-remind-me/SKILL.md
+++ b/skills/apple-remind-me/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: apple-remind-me
+description: Create and manage Apple Reminders from natural language on macOS.
+---
+
+# Apple Remind Me
+
+Use this skill when a user asks to create, inspect, update, or complete reminders in Apple Reminders.
+
+## Stub Scope
+
+- Parse reminder text, list names, due dates, priorities, and recurrence.
+- Prefer a recoverable confirmation step for ambiguous reminders.
+- Use macOS-native automation or a dedicated reminders CLI when available.
+
+## Future Implementation Notes
+
+- Document the preferred CLI or JXA bridge.
+- Add examples for quick capture, due today, recurring reminders, and list cleanup.
+- Include timezone and relative-date handling rules.

--- a/skills/core-pa-admin-exec-support/SKILL.md
+++ b/skills/core-pa-admin-exec-support/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: core-pa-admin-exec-support
+description: Produce executive-support plans, prioritized tasks, communication drafts, and meeting follow-ups.
+---
+
+# Core PA Admin Exec Support
+
+Use this skill when a user wants personal assistant or executive assistant help with triage, planning, communication, or follow-up preparation.
+
+## Stub Scope
+
+- Turn messy inputs into priorities, next actions, owners, and suggested messages.
+- Draft emails, meeting follow-ups, agendas, and handoff notes.
+- Ask before sending anything externally.
+
+## Future Implementation Notes
+
+- Add templates for inbox triage, meeting prep, travel admin, and weekly planning.
+- Add optional calendar, email, and task-system adapters.

--- a/skills/cron-writer/SKILL.md
+++ b/skills/cron-writer/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cron-writer
+description: Convert natural-language schedules into cron expressions with timezone and edge-case checks.
+---
+
+# Cron Writer
+
+Use this skill when a user asks for a cron expression or wants to verify a schedule.
+
+## Stub Scope
+
+- Ask or infer timezone when needed.
+- Return the cron expression, plain-English interpretation, and next few run times.
+- Flag impossible, ambiguous, or daylight-saving-sensitive schedules.
+
+## Future Implementation Notes
+
+- Add examples for standard cron, Quartz cron, GitHub Actions, and systemd timers.
+- Add validation commands for local cron parsers.

--- a/skills/defi/SKILL.md
+++ b/skills/defi/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: defi
+description: Research DeFi protocols, swaps, yields, positions, risks, and on-chain market context.
+---
+
+# DeFi
+
+Use this skill when a user asks about decentralized finance protocols, wallet positions, swaps, liquidity, or yield opportunities.
+
+## Stub Scope
+
+- Separate factual protocol data from interpretation.
+- Highlight smart contract, liquidity, bridge, oracle, governance, and counterparty risks.
+- Treat trading and yield output as informational, not financial advice.
+
+## Future Implementation Notes
+
+- Add supported chains and data-provider commands.
+- Add wallet-read and quote workflows with explicit confirmation before transactions.

--- a/skills/dexcom/SKILL.md
+++ b/skills/dexcom/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: dexcom
+description: Read Dexcom CGM glucose data, trends, and alerts for personal health tracking.
+---
+
+# Dexcom
+
+Use this skill when a user asks about Dexcom CGM readings, glucose trends, or recent alerts.
+
+## Stub Scope
+
+- Retrieve readings only through authorized user-connected accounts.
+- Present timestamps, units, trend arrows, and data freshness.
+- Avoid diagnosis or treatment advice; tell users to follow clinician guidance.
+
+## Future Implementation Notes
+
+- Add authentication setup and API or CLI examples.
+- Add safety language for urgent highs, lows, and stale readings.

--- a/skills/get-focus-mode/SKILL.md
+++ b/skills/get-focus-mode/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: get-focus-mode
+description: Read the current macOS Focus mode and use it to adjust notification or work behavior.
+---
+
+# Get Focus Mode
+
+Use this skill when a user asks whether Focus mode is on, or when an automation should adapt to macOS Focus state.
+
+## Stub Scope
+
+- Check current Focus state through supported macOS automation.
+- Use Focus state as context for whether to notify, delay, or stay quiet.
+- Do not override Focus mode unless explicitly requested.
+
+## Future Implementation Notes
+
+- Add Shortcuts, defaults, or JXA command examples.
+- Add patterns for quiet hours and notification batching.

--- a/skills/gotify/SKILL.md
+++ b/skills/gotify/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gotify
+description: Send self-hosted push notifications through Gotify for task completions and alerts.
+---
+
+# Gotify
+
+Use this skill when a user asks to send a Gotify push notification or wants alerts from long-running jobs.
+
+## Stub Scope
+
+- Send short, actionable notifications with title, message, and priority.
+- Use Gotify tokens from environment or configured secret references.
+- Avoid leaking sensitive details into push notification text.
+
+## Future Implementation Notes
+
+- Add curl examples for the Gotify message API.
+- Add patterns for build completion, monitoring alerts, and reminder handoffs.

--- a/skills/habit-flow/SKILL.md
+++ b/skills/habit-flow/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: habit-flow
+description: Log atomic habits naturally, track streaks, and provide lightweight habit coaching.
+---
+
+# Habit Flow
+
+Use this skill when a user wants a more conversational habit tracker with natural-language logging.
+
+## Stub Scope
+
+- Convert messages like "I meditated today" into structured habit entries.
+- Track streaks, misses, notes, and next suggested action.
+- Keep coaching practical and nonjudgmental.
+
+## Future Implementation Notes
+
+- Add a storage schema and reporting examples.
+- Add integrations for reminders and weekly reviews.

--- a/skills/habit-tracker/SKILL.md
+++ b/skills/habit-tracker/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: habit-tracker
+description: Track habits, streaks, completions, reminders, and lightweight progress reviews.
+---
+
+# Habit Tracker
+
+Use this skill when a user wants to create, log, review, or adjust habits.
+
+## Stub Scope
+
+- Define habits with cadence, trigger, minimum viable action, and success criteria.
+- Log completions and misses without overcomplicating the system.
+- Review streaks, friction, and next adjustments.
+
+## Future Implementation Notes
+
+- Add storage guidance for local JSON, SQLite, or a task app.
+- Add check-in templates and weekly review prompts.

--- a/skills/meshy-ai/SKILL.md
+++ b/skills/meshy-ai/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: meshy-ai
+description: Generate and manage Meshy AI 2D and 3D assets through the Meshy API.
+---
+
+# Meshy AI
+
+Use this skill when a user wants to create 3D models or asset drafts with Meshy AI.
+
+## Stub Scope
+
+- Capture prompt, style, reference images, output format, and licensing needs.
+- Start async generation jobs and poll for completion.
+- Save outputs with clear filenames and provenance.
+
+## Future Implementation Notes
+
+- Add Meshy API command examples for text-to-3D and image-to-3D.
+- Add download and conversion steps for common asset formats.

--- a/skills/multi-llm/SKILL.md
+++ b/skills/multi-llm/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: multi-llm
+description: Route work across multiple LLMs based on task type, cost, latency, context, and tool needs.
+---
+
+# Multi LLM
+
+Use this skill when a user wants model fallback, model comparison, or explicit routing across providers.
+
+## Stub Scope
+
+- Classify the task by risk, context size, reasoning depth, latency, and tool requirements.
+- Recommend a primary model and fallback model.
+- Preserve user privacy and avoid sending sensitive context to unnecessary providers.
+
+## Future Implementation Notes
+
+- Add provider-specific command examples.
+- Add routing tables for coding, writing, research, extraction, and summarization.

--- a/skills/night-routine/SKILL.md
+++ b/skills/night-routine/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: night-routine
+description: Build evening wind-down routines, sleep prep, next-day planning, and habit checkouts.
+---
+
+# Night Routine
+
+Use this skill when a user wants help ending the day, preparing for sleep, or planning tomorrow with minimal friction.
+
+## Stub Scope
+
+- Capture wins, loose ends, tomorrow's top priorities, and shutdown tasks.
+- Suggest a short wind-down sequence matched to constraints and energy.
+- Avoid medical claims; focus on behavior design and practical routine support.
+
+## Future Implementation Notes
+
+- Add optional calendar, reminders, and habit tracker integrations.
+- Add templates for 5-minute, 20-minute, and full reset routines.

--- a/skills/office-quotes/SKILL.md
+++ b/skills/office-quotes/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: office-quotes
+description: Retrieve quotes from The Office for lightweight entertainment and generated quote cards.
+---
+
+# Office Quotes
+
+Use this skill when a user asks for a quote from The Office or wants a themed quote card.
+
+## Stub Scope
+
+- Return short quotes with character attribution when available.
+- Support random, character-specific, and episode-specific lookups.
+- Keep quoted text brief and avoid large copyrighted excerpts.
+
+## Future Implementation Notes
+
+- Add local quote database format and API fallback.
+- Add optional image-card generation workflow.

--- a/skills/personal-branding-authority/SKILL.md
+++ b/skills/personal-branding-authority/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: personal-branding-authority
+description: Founder and operator personal branding strategy, positioning, content themes, and authority-building plans.
+---
+
+# Personal Branding Authority
+
+Use this skill when a user wants to clarify their public positioning, build authority in a market, or turn expertise into a steady content and relationship system.
+
+## Stub Scope
+
+- Define audience, category, point of view, and proof points.
+- Turn raw experience into content pillars, post ideas, and interview angles.
+- Review profiles, bios, and landing pages for credibility and clarity.
+- Build a lightweight publishing cadence tied to business goals.
+
+## Future Implementation Notes
+
+- Add profile-audit checklists for LinkedIn, X, personal sites, and newsletters.
+- Add examples for founder, investor, engineer, and consultant positioning.
+- Optionally integrate with social scheduling and analytics skills.

--- a/skills/prowlarr/SKILL.md
+++ b/skills/prowlarr/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: prowlarr
+description: Search and manage Prowlarr indexers, releases, health, and app sync.
+---
+
+# Prowlarr
+
+Use this skill when a user asks to search indexers, inspect Prowlarr health, manage indexers, or sync apps.
+
+## Stub Scope
+
+- Query releases with clear category and quality filters.
+- Inspect indexer status and sync issues.
+- Avoid copyrighted-content facilitation; keep workflows to lawful media management.
+
+## Future Implementation Notes
+
+- Add Prowlarr API endpoint examples.
+- Add safe configuration checks for indexers, apps, and API keys.

--- a/skills/recipe-to-list/SKILL.md
+++ b/skills/recipe-to-list/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: recipe-to-list
+description: Convert recipes from URLs, text, or images into organized shopping lists.
+---
+
+# Recipe To List
+
+Use this skill when a user wants ingredients from recipes turned into a grocery or task list.
+
+## Stub Scope
+
+- Extract ingredients, quantities, serving count, and pantry assumptions.
+- Merge duplicate ingredients and group by aisle or category.
+- Ask before adding items to an external list when confidence is low.
+
+## Future Implementation Notes
+
+- Add recipe URL scraping and OCR examples.
+- Add adapters for Todoist, Apple Reminders, and plain Markdown lists.

--- a/skills/technical-analyst/SKILL.md
+++ b/skills/technical-analyst/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: technical-analyst
+description: Analyze price charts, trend structure, levels, indicators, and risk scenarios.
+---
+
+# Technical Analyst
+
+Use this skill when a user provides charts or asks for technical analysis of stocks, crypto, indices, commodities, or forex.
+
+## Stub Scope
+
+- Identify trend, support, resistance, volume behavior, and visible patterns.
+- Explain bullish, bearish, and invalidation scenarios.
+- Keep analysis educational, not financial advice.
+
+## Future Implementation Notes
+
+- Add image-analysis workflow for uploaded charts.
+- Add optional market-data fetch flow for OHLCV candles and indicators.
+- Include risk disclosure and position-sizing guardrails.

--- a/skills/timesheet/SKILL.md
+++ b/skills/timesheet/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: timesheet
+description: Track time, projects, tasks, and summaries with a timesheet CLI or API.
+---
+
+# Timesheet
+
+Use this skill when a user wants to start, stop, correct, or summarize time tracking.
+
+## Stub Scope
+
+- Track project, task, start time, stop time, notes, and billable status.
+- Support daily and weekly summaries.
+- Make corrections explicit instead of silently rewriting history.
+
+## Future Implementation Notes
+
+- Add commands for the chosen timesheet CLI.
+- Add CSV export and invoice-prep examples.

--- a/skills/topydo/SKILL.md
+++ b/skills/topydo/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: topydo
+description: Manage todo.txt tasks with topydo, including projects, contexts, priorities, due dates, and recurrence.
+---
+
+# Topydo
+
+Use this skill when a user wants todo.txt compatible task management through the `topydo` CLI.
+
+## Stub Scope
+
+- Add, list, complete, prioritize, defer, and tag tasks.
+- Preserve todo.txt portability and plain-text editability.
+- Prefer JSON or parseable output when available.
+
+## Future Implementation Notes
+
+- Add command examples for topydo setup and common workflows.
+- Add safe edit rules for direct todo.txt manipulation.

--- a/skills/zoho/SKILL.md
+++ b/skills/zoho/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: zoho
+description: Work with Zoho CRM, Projects, Meeting, and workspace APIs for business operations.
+---
+
+# Zoho
+
+Use this skill when a user asks to manage Zoho leads, contacts, deals, tasks, projects, milestones, meetings, or recordings.
+
+## Stub Scope
+
+- Identify the relevant Zoho product and object type.
+- Use OAuth-backed API calls or official CLIs where configured.
+- Preserve field names, IDs, owners, and audit-sensitive changes.
+
+## Future Implementation Notes
+
+- Add setup notes for Zoho OAuth scopes.
+- Add examples for CRM search, deal updates, Projects tasks, and Meeting recordings.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the July 20 daily discovery pass
- Cover personal ops, reminders, habits, notifications, model routing, DeFi, Meshy, Zoho, and related workflows

Linear: ORT-2381

## Verification
- git diff --check
- Frontmatter first-line sanity check across skill files

Sources: skills.sh, sundial-org/awesome-openclaw-skills, orthogonal-sh/skills current main