### PR TITLE
Add daily discovery skill stubs for 2026-07-22

### DIFF
--- a/skills/adhd-daily-planner/SKILL.md
+++ b/skills/adhd-daily-planner/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: adhd-daily-planner
+description: Build ADHD-friendly daily plans with realistic time, breaks, and activation steps.
+---
+
+# ADHD Daily Planner
+
+Use this skill when the user wants a daily plan, has too many tasks, feels stuck, or asks for ADHD-friendly planning.
+
+## Workflow
+
+1. List commitments, deadlines, energy level, and unavoidable constraints.
+2. Choose a small set of must-do tasks and define visible finish lines.
+3. Add buffers, breaks, meals, travel, and task-switching friction.
+4. Turn the first task into a two-minute activation step.
+5. Review the day and carry forward only what still matters.
+
+## Guardrails
+
+- Avoid dense schedules with no recovery time.
+- Do not shame unfinished tasks.
+- Keep plans easy to scan and adjust.

--- a/skills/app-store-changelog/SKILL.md
+++ b/skills/app-store-changelog/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: app-store-changelog
+description: Draft user-facing App Store release notes from commits, PRs, and shipped changes.
+---
+
+# App Store Changelog
+
+Use this skill when preparing App Store or TestFlight release notes.
+
+## Workflow
+
+1. Find the previous release tag, build, or comparison point.
+2. Collect user-visible changes from commits, PRs, issues, and product notes.
+3. Group changes into improvements, fixes, and notable additions.
+4. Rewrite into concise user-facing release notes.
+5. Exclude internal refactors, secrets, and unlaunched work.
+
+## Guardrails
+
+- Do not mention unreleased or internal features unless approved.
+- Avoid technical commit language in user-facing notes.
+- Keep platform review language accurate.

--- a/skills/bbc-news/SKILL.md
+++ b/skills/bbc-news/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: bbc-news
+description: Fetch and summarize BBC News headlines, sections, regions, and RSS feeds.
+---
+
+# BBC News
+
+Use this skill when the user asks for BBC News headlines, UK news, world news, section summaries, or BBC RSS feed digests.
+
+## Workflow
+
+1. Clarify region, section, topic, and recency.
+2. Fetch current BBC News feed or article metadata.
+3. Summarize headlines with source links and timestamps.
+4. Group stories by theme when returning a digest.
+5. Cross-check breaking or high-stakes stories with another source when needed.
+
+## Guardrails
+
+- Do not present stale headlines as current.
+- Keep summaries short and clearly attributed.
+- Avoid copying article text beyond brief excerpts.

--- a/skills/clawddocs/SKILL.md
+++ b/skills/clawddocs/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: clawddocs
+description: Navigate Clawdbot and OpenClaw docs, config, tools, and troubleshooting paths.
+---
+
+# Clawdocs
+
+Use this skill when the user asks about Clawdbot, OpenClaw docs, configuration, tools, skills, nodes, sessions, or troubleshooting.
+
+## Workflow
+
+1. Identify the product surface, version, and environment.
+2. Search official docs or local docs before answering.
+3. Provide the shortest working path, with commands or config snippets when useful.
+4. Separate confirmed behavior from inference.
+5. Capture any local convention that should be remembered.
+
+## Guardrails
+
+- Do not expose private workspace paths or secrets in shared contexts.
+- Prefer official docs and local installed docs over stale memory.
+- Ask before making external account or integration changes.

--- a/skills/decision-trees/SKILL.md
+++ b/skills/decision-trees/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: decision-trees
+description: Build decision trees for complex choices, tradeoffs, risks, and uncertain outcomes.
+---
+
+# Decision Trees
+
+Use this skill when the user needs structured decision analysis across options, uncertain outcomes, probabilities, costs, or tradeoffs.
+
+## Workflow
+
+1. Define the decision, options, constraints, and success criteria.
+2. Identify uncertain events and estimate probabilities when possible.
+3. Map outcomes, costs, benefits, reversibility, and information value.
+4. Compare expected value and downside risk.
+5. Recommend the next decision or the cheapest useful experiment.
+
+## Guardrails
+
+- Make assumptions visible.
+- Do not hide qualitative factors behind fake precision.
+- Treat high-stakes personal, legal, medical, or financial choices carefully.

--- a/skills/focus-deep-work/SKILL.md
+++ b/skills/focus-deep-work/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: focus-deep-work
+description: Run deep work sessions with goals, timers, distraction capture, and reviews.
+---
+
+# Focus Deep Work
+
+Use this skill when the user wants help starting, protecting, or reviewing a focused work session.
+
+## Workflow
+
+1. Define one concrete outcome for the session.
+2. Pick a realistic timebox and remove obvious distractions.
+3. Capture interruptions in a parking lot instead of switching tasks.
+4. Check progress at the end of the timebox.
+5. Record what was finished, what blocked progress, and the next start point.
+
+## Guardrails
+
+- Keep the setup short so it does not become procrastination.
+- Do not moralize missed sessions.
+- Prefer small restarts over elaborate productivity systems.

--- a/skills/gsc/SKILL.md
+++ b/skills/gsc/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: gsc
+description: Analyze Google Search Console queries, pages, CTR, indexing, and sitemap data.
+---
+
+# Google Search Console
+
+Use this skill when the user asks about Google Search Console, organic search performance, search queries, URL inspection, indexing, sitemap health, CTR opportunities, or SEO reporting from GSC data.
+
+## Workflow
+
+1. Confirm the property, date range, country, device, and page/query filters.
+2. Pull search analytics for clicks, impressions, CTR, and average position.
+3. Segment by page, query, device, and country to find practical opportunities.
+4. Inspect important URLs for indexing, canonical, coverage, and sitemap status.
+5. Summarize actions as content updates, technical fixes, or monitoring items.
+
+## Guardrails
+
+- Do not invent GSC data when access is missing.
+- Separate ranking opportunity from indexing or crawl problems.
+- Keep recommendations tied to observed metrics.

--- a/skills/heurist-mesh/SKILL.md
+++ b/skills/heurist-mesh/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: heurist-mesh
+description: Analyze Web3 tokens, markets, wallets, and crypto signals through Heurist Mesh.
+---
+
+# Heurist Mesh
+
+Use this skill when the user asks for Web3 or crypto intelligence that can be served by Heurist Mesh.
+
+## Workflow
+
+1. Identify the chain, token, wallet, protocol, or market question.
+2. Fetch current data from Heurist Mesh or the configured provider.
+3. Cross-check volatile prices, liquidity, and contract identifiers.
+4. Separate factual market data from interpretation.
+5. Summarize risks, confidence, and next checks.
+
+## Guardrails
+
+- Do not provide financial advice.
+- Verify token addresses before discussing a specific asset.
+- Call out stale or thin-liquidity data.

--- a/skills/hn-digest/SKILL.md
+++ b/skills/hn-digest/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: hn-digest
+description: Fetch, filter, and summarize Hacker News stories by rank, topic, or discussion signal.
+---
+
+# HN Digest
+
+Use this skill when the user asks for Hacker News front page, top stories, topic-specific HN items, or discussion summaries.
+
+## Workflow
+
+1. Clarify topic filters, story count, and whether comments matter.
+2. Fetch current HN story metadata and URLs.
+3. Filter for relevance, novelty, score, and comment signal.
+4. Summarize each item in one or two sentences.
+5. Highlight themes, controversies, and follow-up links.
+
+## Guardrails
+
+- Use current data for live HN requests.
+- Distinguish article content from comment sentiment.
+- Avoid summarizing unread linked articles as if fully reviewed.

--- a/skills/humanizer/SKILL.md
+++ b/skills/humanizer/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: humanizer
+description: Rewrite AI-sounding text into natural, specific, human prose.
+---
+
+# Humanizer
+
+Use this skill when the user wants text to sound less generic, less AI-written, more natural, or more like a real person.
+
+## Workflow
+
+1. Identify the audience, channel, desired tone, and any phrases to preserve.
+2. Remove filler, vague claims, repetitive structure, and over-polished transitions.
+3. Add specificity, concrete nouns, and natural rhythm.
+4. Preserve the meaning and constraints of the original.
+5. Return the revised text with a brief note if important meaning changed.
+
+## Guardrails
+
+- Do not fabricate personal experience.
+- Do not hide deception or misrepresentation.
+- Keep professional text professional when the context calls for it.

--- a/skills/japanese-tutor/SKILL.md
+++ b/skills/japanese-tutor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: japanese-tutor
+description: Tutor Japanese vocabulary, grammar, reading, writing, and conversation practice.
+---
+
+# Japanese Tutor
+
+Use this skill when the user wants Japanese language tutoring, grammar explanations, vocabulary drills, reading help, translation practice, roleplay, or study planning.
+
+## Workflow
+
+1. Identify the learner's level, target skill, and preferred output style.
+2. Explain concepts with concise examples in kana, kanji, romaji only when useful, and English glosses.
+3. Provide short drills with answers hidden until requested.
+4. Correct mistakes gently and explain the pattern behind the correction.
+5. Track recurring weak spots and suggest a small next exercise.
+
+## Guardrails
+
+- Do not overuse romaji for learners practicing Japanese script.
+- Distinguish literal translations from natural phrasing.
+- Ask before creating a long study plan.

--- a/skills/literature-review/SKILL.md
+++ b/skills/literature-review/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: literature-review
+description: Plan and write literature reviews from scholarly search, screening, and synthesis.
+---
+
+# Literature Review
+
+Use this skill when the user asks for academic literature search, source screening, evidence synthesis, related work, or a literature review draft.
+
+## Workflow
+
+1. Clarify the research question, field, timeframe, and inclusion criteria.
+2. Search scholarly sources such as Semantic Scholar, OpenAlex, Crossref, PubMed, or arXiv.
+3. Screen papers by relevance, method, venue, and citation context.
+4. Group findings by theme, agreement, disagreement, and gaps.
+5. Draft a synthesis with citations and clear limits.
+
+## Guardrails
+
+- Do not cite papers that were not checked.
+- Separate abstracts from full-text findings.
+- Avoid overstating consensus from a small sample.

--- a/skills/molt-registry/SKILL.md
+++ b/skills/molt-registry/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: molt-registry
+description: Verify Moltbook identity registry entries and reputation metadata.
+---
+
+# Molt Registry
+
+Use this skill when the user asks to verify a Moltbook identity, inspect registry status, manage profile metadata, or reason about agent reputation.
+
+## Workflow
+
+1. Identify the handle, profile, or registry entry to inspect.
+2. Fetch registry metadata from the available trusted source.
+3. Compare claimed identity, keys, profile links, and reputation signals.
+4. Summarize confidence and any mismatches.
+5. Ask before changing registry metadata.
+
+## Guardrails
+
+- Do not treat unverified claims as identity proof.
+- Do not publish registry changes without explicit approval.
+- Keep private identifiers out of public summaries.

--- a/skills/moltbook/SKILL.md
+++ b/skills/moltbook/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: moltbook
+description: Draft, browse, and analyze Moltbook posts, replies, submolts, and engagement.
+---
+
+# Moltbook
+
+Use this skill when the user asks to work with Moltbook posts, replies, submolts, feeds, engagement, or agent social activity.
+
+## Workflow
+
+1. Clarify whether the task is private drafting, browsing, analysis, or posting.
+2. Check recent posts before suggesting duplicates.
+3. Match the submolt and tone to the content.
+4. Draft short, specific posts or replies.
+5. Ask for approval before posting externally unless prior instructions explicitly allow it.
+
+## Guardrails
+
+- Keep private work and conversations out of public posts.
+- Avoid spammy cross-posting.
+- Do not impersonate the user.

--- a/skills/openai-image-gen/SKILL.md
+++ b/skills/openai-image-gen/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: openai-image-gen
+description: Generate and iterate bitmap image prompts with OpenAI image models.
+---
+
+# OpenAI Image Gen
+
+Use this skill when the user asks to generate, revise, or batch-create raster images with OpenAI image models.
+
+## Workflow
+
+1. Clarify aspect ratio, style, subject, output count, and constraints.
+2. Draft a prompt that names the subject, composition, medium, lighting, palette, and exclusions.
+3. Generate images with the available image tool or provide an API-ready request.
+4. Review outputs against the brief and propose focused revisions.
+5. Save prompt variants and final asset notes when useful.
+
+## Guardrails
+
+- Do not use this for vector icons or repo-native SVG edits.
+- Preserve brand, likeness, and safety constraints.
+- Make iteration prompts specific rather than starting over blindly.

--- a/skills/pinch-to-post/SKILL.md
+++ b/skills/pinch-to-post/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: pinch-to-post
+description: Automate WordPress and WooCommerce content, media, products, orders, and SEO metadata.
+---
+
+# Pinch To Post
+
+Use this skill when the user asks to manage WordPress posts, pages, WooCommerce products, orders, inventory, comments, media, or SEO metadata through APIs.
+
+## Workflow
+
+1. Clarify the site, content type, status, and approval requirements.
+2. Fetch existing content before creating duplicates.
+3. Draft or update content with slug, excerpt, taxonomy, media, and SEO fields.
+4. Preview or stage changes when possible.
+5. Ask before publishing, deleting, or changing live commerce data.
+
+## Guardrails
+
+- Never publish externally without explicit approval.
+- Protect credentials and customer data.
+- Keep inventory and order edits auditable.

--- a/skills/pollinations/SKILL.md
+++ b/skills/pollinations/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: pollinations
+description: Generate text, images, audio, and video through Pollinations APIs.
+---
+
+# Pollinations
+
+Use this skill when the user asks to generate or prototype text, image, audio, video, or multimodal assets through Pollinations.
+
+## Workflow
+
+1. Clarify modality, prompt, style, dimensions, duration, and output format.
+2. Choose the Pollinations endpoint or provide an API-ready request.
+3. Generate or mock the asset request.
+4. Review the output against the brief.
+5. Iterate with targeted prompt changes.
+
+## Guardrails
+
+- Do not use generated media in ways that violate rights or likeness constraints.
+- Label generated assets when context requires it.
+- Prefer local or project-native assets when generation is unnecessary.

--- a/skills/save-money/SKILL.md
+++ b/skills/save-money/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: save-money
+description: Route work to cheaper models or tools based on task complexity and risk.
+---
+
+# Save Money
+
+Use this skill when the user wants to reduce LLM or automation cost while preserving quality.
+
+## Workflow
+
+1. Classify the task by risk, context size, reasoning depth, tool use, and output importance.
+2. Choose the cheapest model or tool that can reliably handle the task.
+3. Escalate only for high-risk, ambiguous, long-context, or user-facing work.
+4. Batch similar calls and reuse local context when possible.
+5. Report meaningful tradeoffs when cost savings may affect quality.
+
+## Guardrails
+
+- Do not downshift safety-critical, legal, financial, medical, or public-send work.
+- Prefer deterministic local tools for parsing, search, and formatting.
+- Track failed downshifts so future routing improves.

--- a/skills/stock-info-explorer/SKILL.md
+++ b/skills/stock-info-explorer/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: stock-info-explorer
+description: Explore stock quotes, charts, fundamentals, and company market data.
+---
+
+# Stock Info Explorer
+
+Use this skill when the user asks for stock quotes, market charts, fundamentals, moving averages, or company financial snapshots.
+
+## Workflow
+
+1. Confirm the ticker, exchange, and date range.
+2. Fetch current quote and historical data from an authoritative provider.
+3. Compute or display requested indicators only after validating data coverage.
+4. Summarize price action, fundamentals, and caveats separately.
+5. Cite data freshness for volatile values.
+
+## Guardrails
+
+- Do not give investment advice.
+- Use current finance data for live prices.
+- Be explicit when data is delayed or unavailable.

--- a/skills/swiftui-ui-patterns/SKILL.md
+++ b/skills/swiftui-ui-patterns/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: swiftui-ui-patterns
+description: Apply SwiftUI layout, navigation, state, accessibility, and component patterns.
+---
+
+# SwiftUI UI Patterns
+
+Use this skill when building or reviewing SwiftUI views, navigation, state flow, component structure, or accessibility.
+
+## Workflow
+
+1. Identify the target platform, iOS/macOS version, and design intent.
+2. Prefer native SwiftUI components and platform conventions.
+3. Keep state ownership clear with appropriate property wrappers and environment values.
+4. Check Dynamic Type, VoiceOver labels, contrast, and hit targets.
+5. Suggest focused code changes and previews for important states.
+
+## Guardrails
+
+- Do not introduce custom controls where native controls fit.
+- Keep view decomposition purposeful.
+- Avoid layout that depends on fixed screen sizes.


### PR DESCRIPTION
## Summary
- Add 20 new SKILL.md stubs from the daily skills discovery sweep
- Sources checked: skills.sh, sundial-org/awesome-openclaw-skills, orthogonal-sh/skills main, memory/discovery-posts.md
- Linear: ORT-2387

## Skills
- japanese-tutor
- openai-image-gen
- gsc
- save-money
- focus-deep-work
- adhd-daily-planner
- humanizer
- clawddocs
- app-store-changelog
- moltbook
- molt-registry
- swiftui-ui-patterns
- heurist-mesh
- stock-info-explorer
- literature-review
- decision-trees
- pollinations
- pinch-to-post
- hn-digest
- bbc-news

## Verification
- Checked each stub exists and has frontmatter

Reviewers: @christianpickettcode @berasogut