### PR TITLE
Add 2026-07-24 discovery skill stubs

### DIFF
--- a/skills/chart-image/SKILL.md
+++ b/skills/chart-image/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: chart-image
+description: Create publication-quality chart images from structured data or analysis outputs.
+---
+
+# Chart Image
+
+Use this skill when turning data into a chart image for reports, posts, docs, or presentations.
+
+## Stub Scope
+
+- Pick chart types that match the data and comparison being made.
+- Label axes, units, sources, and date ranges clearly.
+- Avoid misleading scales, decorative clutter, and inaccessible color-only encodings.
+
+## Future Implementation Notes
+
+- Add scripts for line, bar, area, scatter, and small-multiple chart generation.
+- Add export workflows for PNG, SVG, and transparent-background variants.

--- a/skills/clawdbot-backup/SKILL.md
+++ b/skills/clawdbot-backup/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: clawdbot-backup
+description: Back up, restore, migrate, and verify Clawdbot configuration, skills, memory, and settings.
+---
+
+# Clawdbot Backup
+
+Use this skill when safeguarding or moving Clawdbot configuration, skills, commands, and local state.
+
+## Stub Scope
+
+- Prefer recoverable backups and manifests before modifying live configuration.
+- Exclude secrets or store them through approved secret-management paths.
+- Verify restore steps on a copy when possible.
+
+## Future Implementation Notes
+
+- Add backup manifests, archive commands, restore checks, and migration workflows.
+- Add git-based backup patterns with secret scanning.

--- a/skills/comfy-cli/SKILL.md
+++ b/skills/comfy-cli/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: comfy-cli
+description: Install, run, update, and troubleshoot ComfyUI instances and custom nodes from the CLI.
+---
+
+# Comfy CLI
+
+Use this skill when setting up ComfyUI, launching servers, installing nodes, or managing models.
+
+## Stub Scope
+
+- Track environment, GPU, Python, model paths, and custom node versions.
+- Keep generated files and downloaded models in predictable directories.
+- Capture logs when debugging startup, dependency, or workflow failures.
+
+## Future Implementation Notes
+
+- Add comfy-cli install, launch, model download, and custom node recipes.
+- Add workflows for workflow JSON validation and common dependency fixes.

--- a/skills/content-ideas-generator/SKILL.md
+++ b/skills/content-ideas-generator/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: content-ideas-generator
+description: Generate structured content ideas and post outlines from notes, references, or source material.
+---
+
+# Content Ideas Generator
+
+Use this skill when brainstorming posts, newsletters, threads, articles, or editorial angles.
+
+## Stub Scope
+
+- Extract concrete claims, tensions, examples, and audience hooks from the source material.
+- Keep private context out of public-facing ideas unless explicitly approved.
+- Produce concise options with clear angles rather than generic topic lists.
+
+## Future Implementation Notes
+
+- Add templates for social posts, essays, newsletters, launch posts, and technical explainers.
+- Add scoring rubrics for novelty, credibility, and audience fit.

--- a/skills/duckdb-en/SKILL.md
+++ b/skills/duckdb-en/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: duckdb-en
+description: Analyze CSV, Parquet, JSON, and local datasets with DuckDB SQL from the CLI.
+---
+
+# DuckDB CLI
+
+Use this skill when querying local files, converting tabular data, or doing lightweight analytical SQL.
+
+## Stub Scope
+
+- Prefer DuckDB SQL over ad hoc parsing for structured data.
+- Inspect schema and sample rows before writing transformations.
+- Keep output bounded and reproducible.
+
+## Future Implementation Notes
+
+- Add recipes for CSV, Parquet, JSON, joins, aggregations, exports, and profiling.
+- Add safe patterns for large files and repeatable analysis scripts.

--- a/skills/elevenlabs-agents/SKILL.md
+++ b/skills/elevenlabs-agents/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: elevenlabs-agents
+description: Create, inspect, update, and deploy ElevenLabs conversational voice agents.
+---
+
+# ElevenLabs Agents
+
+Use this skill when working with ElevenLabs voice agents, voices, prompts, tools, or deployment settings.
+
+## Stub Scope
+
+- Keep voice, transcript, and caller data private.
+- Confirm before changing live agent behavior or phone-facing settings.
+- Test prompts and tool calls in a non-production context when possible.
+
+## Future Implementation Notes
+
+- Add CLI and API recipes for listing, creating, updating, and testing agents.
+- Add prompt, voice, latency, and escalation checklists.

--- a/skills/fast-browser-use/SKILL.md
+++ b/skills/fast-browser-use/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: fast-browser-use
+description: High-throughput browser automation for scraping, multi-tab workflows, and precise DOM extraction.
+---
+
+# Fast Browser Use
+
+Use this skill when browser automation needs speed, reliability, concurrent tabs, or structured extraction.
+
+## Stub Scope
+
+- Prefer deterministic selectors and accessibility snapshots over visual guessing.
+- Keep sessions isolated when scraping or testing unrelated sites.
+- Capture enough page state to debug failures without leaking private content.
+
+## Future Implementation Notes
+
+- Add setup and command examples for fast-browser-use.
+- Add patterns for login checks, retries, rate limits, screenshots, and export formats.

--- a/skills/finance-news/SKILL.md
+++ b/skills/finance-news/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: finance-news
+description: Summarize market news, portfolio headlines, tickers, catalysts, and price-moving events.
+---
+
+# Finance News
+
+Use this skill when the user asks for market headlines, stock news, portfolio briefings, or finance alerts.
+
+## Stub Scope
+
+- Verify current market data and publication dates before summarizing.
+- Separate reported facts, analyst opinion, and inferred market impact.
+- Avoid personalized financial advice unless framed as general information.
+
+## Future Implementation Notes
+
+- Add source ranking for filings, exchange data, company IR, and reputable finance outlets.
+- Add morning and evening briefing templates.

--- a/skills/git-essentials/SKILL.md
+++ b/skills/git-essentials/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: git-essentials
+description: Practical Git workflows for status checks, branches, commits, diffs, recovery, and collaboration.
+---
+
+# Git Essentials
+
+Use this skill when a task involves everyday Git operations or explaining safe Git workflows.
+
+## Stub Scope
+
+- Inspect status before editing, committing, rebasing, or switching branches.
+- Avoid destructive commands unless the user explicitly asks for them.
+- Prefer small, readable commits with verified diffs.
+
+## Future Implementation Notes
+
+- Add command recipes for branching, staging, bisecting, reflog recovery, and conflict handling.
+- Add PR-oriented workflows for feature branches and review fixes.

--- a/skills/github-action-gen/SKILL.md
+++ b/skills/github-action-gen/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: github-action-gen
+description: Generate and maintain GitHub Actions workflows for CI, tests, linting, releases, and deploys.
+---
+
+# GitHub Action Generator
+
+Use this skill when creating or changing GitHub Actions workflows.
+
+## Stub Scope
+
+- Infer language, package manager, test commands, and deployment conventions from the repo.
+- Prefer least-privilege permissions, pinned major versions, caching, and clear job names.
+- Validate YAML and run local checks when practical.
+
+## Future Implementation Notes
+
+- Add templates for Node, Python, Go, Rust, Docker, Playwright, and release workflows.
+- Add common fixes for secrets, matrix builds, concurrency, and artifact upload.

--- a/skills/gitload/SKILL.md
+++ b/skills/gitload/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gitload
+description: Download, inspect, and copy selected files or folders from GitHub repositories.
+---
+
+# Gitload
+
+Use this skill when the user wants to fetch files, folders, examples, or code from a GitHub repository.
+
+## Stub Scope
+
+- Prefer official repository contents, release artifacts, or raw file URLs.
+- Respect licenses and avoid copying more code than the task requires.
+- Keep fetched code isolated until reviewed.
+
+## Future Implementation Notes
+
+- Add GitHub archive, sparse checkout, gh api, and raw download recipes.
+- Add workflows for copying only selected paths into a target project.

--- a/skills/lancedb-memory/SKILL.md
+++ b/skills/lancedb-memory/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: lancedb-memory
+description: Manage local LanceDB-backed agent memory, indexes, retrieval quality, and maintenance workflows.
+---
+
+# LanceDB Memory
+
+Use this skill when setting up, querying, tuning, or maintaining local LanceDB memory for an agent.
+
+## Stub Scope
+
+- Treat memory contents as private and summarize only what is needed.
+- Prefer bounded searches, clear filters, and source references when retrieving memories.
+- Check index freshness, embedding model consistency, and storage paths before changing data.
+
+## Future Implementation Notes
+
+- Add setup commands for common LanceDB memory layouts.
+- Add workflows for deduplication, compaction, re-embedding, and retrieval evaluation.

--- a/skills/linux-service-triage/SKILL.md
+++ b/skills/linux-service-triage/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: linux-service-triage
+description: Diagnose Linux service failures using logs, systemd, PM2, ports, permissions, and reverse proxies.
+---
+
+# Linux Service Triage
+
+Use this skill when a server process, daemon, app, or reverse-proxied service is failing or unreachable.
+
+## Stub Scope
+
+- Start with service status, recent logs, ports, disk, memory, and process health.
+- Check config files, permissions, environment variables, DNS, TLS, and proxy routing.
+- Keep restart and mutation steps explicit and scoped.
+
+## Future Implementation Notes
+
+- Add systemd, PM2, Docker, Nginx, Caddy, and DNS triage command sequences.
+- Add escalation templates for recurring crashes and resource exhaustion.

--- a/skills/my-tesla/SKILL.md
+++ b/skills/my-tesla/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: my-tesla
+description: Control and inspect Tesla vehicles through Owner API tooling with explicit action confirmation.
+---
+
+# My Tesla
+
+Use this skill when checking Tesla vehicle status, climate, charging, location, lock state, or commands.
+
+## Stub Scope
+
+- Confirm before sending state-changing vehicle commands.
+- Treat vehicle location, identifiers, and telemetry as private.
+- Prefer read-only status checks before taking action.
+
+## Future Implementation Notes
+
+- Add teslapy setup, authentication, vehicle selection, and common command examples.
+- Add safety checks for climate, charging, lock/unlock, honk, flash, and remote start.

--- a/skills/octolens/SKILL.md
+++ b/skills/octolens/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: octolens
+description: Query Octolens for brand mentions, source filters, keyword tracking, and mention analysis.
+---
+
+# Octolens
+
+Use this skill when tracking brand, product, competitor, or keyword mentions across online sources.
+
+## Stub Scope
+
+- Preserve source links, timestamps, platform, author, and query filters.
+- Separate raw mentions from sentiment, prioritization, and recommended follow-up.
+- Avoid public engagement without explicit approval.
+
+## Future Implementation Notes
+
+- Add Octolens authentication, query, pagination, and export examples.
+- Add workflows for daily digests, competitor monitoring, and response triage.

--- a/skills/pinak-frontend-guru/SKILL.md
+++ b/skills/pinak-frontend-guru/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: pinak-frontend-guru
+description: Deep frontend UI, UX, accessibility, and React performance audit persona.
+---
+
+# Pinak Frontend Guru
+
+Use this skill when a user wants a rigorous frontend audit or wants an interface to feel more polished.
+
+## Stub Scope
+
+- Review layout density, hierarchy, interaction states, responsiveness, and accessibility.
+- Inspect React state, render paths, memoization, network waterfalls, and expensive effects.
+- Ground suggestions in the existing design system before proposing new patterns.
+
+## Future Implementation Notes
+
+- Add audit templates for visual quality, usability, accessibility, and performance.
+- Add Playwright screenshot and interaction verification workflows.

--- a/skills/social-gen/SKILL.md
+++ b/skills/social-gen/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: social-gen
+description: Draft platform-aware social posts, captions, variants, and publishing-ready copy.
+---
+
+# Social Gen
+
+Use this skill when drafting social media copy for LinkedIn, X, Slack, Reddit, or other platforms.
+
+## Stub Scope
+
+- Match platform norms, length, tone, and formatting constraints.
+- Do not publish externally without explicit user approval.
+- Avoid exposing private work, conversations, or customer details.
+
+## Future Implementation Notes
+
+- Add templates for announcements, technical notes, founder updates, and short commentary.
+- Add final review checklists for privacy, claims, links, and call to action.

--- a/skills/style-guide-generator/SKILL.md
+++ b/skills/style-guide-generator/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: style-guide-generator
+description: Generate design-system style guides from websites, screenshots, codebases, or brand references.
+---
+
+# Style Guide Generator
+
+Use this skill when extracting or creating a visual style guide for a product, website, or app.
+
+## Stub Scope
+
+- Capture typography, color, spacing, components, imagery, interaction states, and accessibility notes.
+- Distinguish observed style from recommended improvements.
+- Prefer existing code tokens and components when analyzing a repo.
+
+## Future Implementation Notes
+
+- Add templates for token tables, component inventories, and implementation notes.
+- Add screenshot-driven extraction and design QA workflows.

--- a/skills/swiftui-view-refactor/SKILL.md
+++ b/skills/swiftui-view-refactor/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: swiftui-view-refactor
+description: Refactor SwiftUI views for clearer structure, state ownership, layout, and Observation usage.
+---
+
+# SwiftUI View Refactor
+
+Use this skill when asked to clean up, restructure, or review SwiftUI view code.
+
+## Stub Scope
+
+- Preserve behavior and public view APIs unless the user asks for a redesign.
+- Separate state, layout, subviews, and side effects using local project conventions.
+- Check accessibility, previews, dynamic type, and animation side effects when relevant.
+
+## Future Implementation Notes
+
+- Add SwiftUI refactor checklists for Observation, navigation, async tasks, and previews.
+- Add examples for extracting subviews without over-fragmenting the file.

--- a/skills/video-subtitles/SKILL.md
+++ b/skills/video-subtitles/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: video-subtitles
+description: Generate, translate, edit, and burn SRT subtitles for video or audio files.
+---
+
+# Video Subtitles
+
+Use this skill when creating subtitles, captions, transcript timing, translations, or burned-in captions.
+
+## Stub Scope
+
+- Preserve source media and write outputs to clearly named derivative files.
+- Verify timing, language, and encoding before finalizing subtitles.
+- Use ffmpeg for muxing, burning, clipping, or audio extraction when needed.
+
+## Future Implementation Notes
+
+- Add Whisper, SRT cleanup, translation, and ffmpeg burn-in command recipes.
+- Add quality checks for timing drift, line length, and speaker labels.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the 2026-07-24 daily discovery sweep.
- Sources: skills.sh and sundial-org/awesome-openclaw-skills.
- Linear: ORT-2409 https://linear.app/orthogonalsh/issue/ORT-2409/add-daily-discovery-skill-stubs-for-2026-07-24

Reviewers: @christianpickettcode @berasogut

## Test Plan
- Checked each new stub for frontmatter and description length.
- No runtime tests, documentation-only skill stubs.