### PR TITLE
Add daily discovery skill stubs for 2026-07-26

### DIFF
--- a/skills/1password/SKILL.md
+++ b/skills/1password/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: 1password
+description: Use the 1Password CLI for secret lookup, injection, account checks, and secure command execution.
+---
+
+# 1Password
+
+Use when work involves `op`, 1Password vaults, signing in, reading secret references, injecting environment variables, or running commands with secrets.
+
+Prefer scoped, read-only secret access. Never print secret values. Confirm the active account, vault, and item path before using secrets in commands.

--- a/skills/dont-hack-me/SKILL.md
+++ b/skills/dont-hack-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: dont-hack-me
+description: Run quick OpenClaw security self-checks for gateway exposure, auth, permissions, and risky config.
+---
+
+# Dont Hack Me
+
+Use when checking whether an OpenClaw or Clawdbot install has dangerous defaults, exposed gateways, missing auth, broad DM policy, weak tokens, or unsafe tool grants.
+
+Report concrete risks and exact remediation commands. Do not disclose tokens or private config values.

--- a/skills/elevenlabs-stt/SKILL.md
+++ b/skills/elevenlabs-stt/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: elevenlabs-stt
+description: Transcribe audio using ElevenLabs speech-to-text models such as Scribe.
+---
+
+# ElevenLabs STT
+
+Use when transcription should run through ElevenLabs speech-to-text, especially for audio workflows already using ElevenLabs voices.
+
+Check language, diarization, timestamp, and privacy needs before upload. Preserve low-confidence segments for review.

--- a/skills/elevenlabs-voices/SKILL.md
+++ b/skills/elevenlabs-voices/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: elevenlabs-voices
+description: Generate high-quality ElevenLabs voices, sound effects, batches, and multilingual TTS.
+---
+
+# ElevenLabs Voices
+
+Use for polished voice synthesis, character voices, sound effects, batch audio, voice design, or multilingual spoken output.
+
+Confirm the voice/persona and usage context. Do not clone or imitate a real person's voice without explicit permission.

--- a/skills/gemini-stt/SKILL.md
+++ b/skills/gemini-stt/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: gemini-stt
+description: Transcribe audio files using Gemini or Vertex AI speech-capable models.
+---
+
+# Gemini STT
+
+Use when speech-to-text should run through Gemini or Vertex AI, especially for multilingual audio or Google Cloud workflows.
+
+Check model availability, file size limits, and privacy requirements before upload. Return a transcript plus uncertainty notes for unclear sections.

--- a/skills/healthkit-sync/SKILL.md
+++ b/skills/healthkit-sync/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: healthkit-sync
+description: Sync, inspect, and summarize Apple HealthKit data through a local HealthKit sync CLI.
+---
+
+# HealthKit Sync
+
+Use when the user asks about Apple Health, steps, workouts, heart rate, sleep, trends, or pairing an iOS health-sync device.
+
+Check local CLI availability and device pairing first. Treat health data as private, summarize only the requested window, and avoid medical conclusions.

--- a/skills/hetzner-cloud/SKILL.md
+++ b/skills/hetzner-cloud/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: hetzner-cloud
+description: Manage Hetzner Cloud servers, volumes, firewalls, networks, DNS, snapshots, and SSH access.
+---
+
+# Hetzner Cloud
+
+Use when working with Hetzner Cloud infrastructure through `hcloud` or the Hetzner API.
+
+Verify project context before mutations. Prefer dry runs or read-only inspection first, and summarize resource names, IDs, regions, and expected impact.

--- a/skills/invoice-generator/SKILL.md
+++ b/skills/invoice-generator/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: invoice-generator
+description: Create professional PDF invoices from structured company, client, line item, tax, and payment data.
+---
+
+# Invoice Generator
+
+Use when the user asks to create an invoice, billing document, payment request, or invoice PDF from structured details.
+
+Validate totals, dates, currency, tax, and payment terms. Do not invent legal or tax details when they are missing.

--- a/skills/mlx-whisper/SKILL.md
+++ b/skills/mlx-whisper/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: mlx-whisper
+description: Run local Apple Silicon optimized Whisper transcription with MLX.
+---
+
+# MLX Whisper
+
+Use on Apple Silicon Macs when local, private, fast speech-to-text is preferred over cloud transcription.
+
+Check model size and expected runtime. Keep intermediate audio and transcript files local unless the user asks to share them.

--- a/skills/openai-tts/SKILL.md
+++ b/skills/openai-tts/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: openai-tts
+description: Generate spoken audio from text using OpenAI text-to-speech models.
+---
+
+# OpenAI TTS
+
+Use when creating narration, voice notes, previews, accessibility audio, or spoken versions of written content with OpenAI audio speech APIs.
+
+Confirm voice, tone, format, and destination before generating. Avoid impersonation or deceptive voice use.

--- a/skills/openai-whisper/SKILL.md
+++ b/skills/openai-whisper/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: openai-whisper
+description: Transcribe local audio with Whisper CLI, including timestamps, language hints, and batch handling.
+---
+
+# OpenAI Whisper
+
+Use when transcribing local audio or video files with a local Whisper CLI.
+
+Check file duration, language, and output format before running long jobs. Preserve timestamps when they matter for review or editing.

--- a/skills/openrouter-transcribe/SKILL.md
+++ b/skills/openrouter-transcribe/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: openrouter-transcribe
+description: Transcribe audio through OpenRouter using audio-capable models such as Gemini or GPT audio models.
+---
+
+# OpenRouter Transcribe
+
+Use when the user wants transcription through OpenRouter or needs to compare audio-capable models behind one API.
+
+Select a model based on language, file length, budget, and accuracy needs. Record which model produced the transcript.

--- a/skills/secret-scanner/SKILL.md
+++ b/skills/secret-scanner/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: secret-scanner
+description: Scan codebases for leaked API keys, tokens, credentials, and secret-like values before sharing or pushing.
+---
+
+# Secret Scanner
+
+Use before commits, PRs, releases, or external sharing when leaked credentials are a concern.
+
+Run established scanners when available. Redact findings in chat, identify file paths and line numbers, and recommend rotation when a live credential may have been exposed.

--- a/skills/security-monitor/SKILL.md
+++ b/skills/security-monitor/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: security-monitor
+description: Monitor local agent security signals, unusual API calls, credential use, and intrusion indicators.
+---
+
+# Security Monitor
+
+Use when the user wants ongoing or point-in-time monitoring for suspicious agent activity, unexpected network calls, credential access, or gateway anomalies.
+
+Prefer local logs and least-privilege checks. Escalate only high-confidence issues and include timestamps, affected component, and suggested containment.

--- a/skills/security-reviewer/SKILL.md
+++ b/skills/security-reviewer/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: security-reviewer
+description: Review application code, infrastructure, and workflows for security vulnerabilities and hardening gaps.
+---
+
+# Security Reviewer
+
+Use for SAST-style reviews, authentication issues, authorization flaws, input validation, dependency risk, cloud exposure, and DevSecOps recommendations.
+
+Lead with exploitable findings, include file and line references when reviewing code, and separate confirmed bugs from hardening suggestions.

--- a/skills/send-me-my-files-r2/SKILL.md
+++ b/skills/send-me-my-files-r2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: send-me-my-files-r2
+description: Upload files to R2, S3, or compatible storage and create short-lived signed download URLs.
+---
+
+# Send Me My Files R2
+
+Use when the user needs temporary links for files, artifact handoff, or secure downloads backed by Cloudflare R2, AWS S3, or S3-compatible storage.
+
+Use short expirations by default. Do not upload private files externally unless the user explicitly asked for sharing.

--- a/skills/skillguard/SKILL.md
+++ b/skills/skillguard/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: skillguard
+description: Audit AgentSkill packages for credential theft, code execution, exfiltration, and prompt-injection risk.
+---
+
+# SkillGuard
+
+Use before installing or recommending third-party skills, especially from unfamiliar sources.
+
+Inspect `SKILL.md`, scripts, hooks, manifests, network calls, shell commands, and credential references. Classify risk and suggest sandboxing or rejection when behavior is ambiguous.

--- a/skills/songsee/SKILL.md
+++ b/skills/songsee/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: songsee
+description: Generate spectrograms and audio feature visualizations from local audio files.
+---
+
+# Songsee
+
+Use when the user wants to inspect audio visually, compare tracks, debug recordings, or produce spectrogram and feature-panel artifacts.
+
+Keep generated assets local unless sharing is requested. Mention sample rate, duration, and any preprocessing applied.

--- a/skills/test-master/SKILL.md
+++ b/skills/test-master/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: test-master
+description: Design and implement unit, integration, end-to-end, performance, and security testing strategies.
+---
+
+# Test Master
+
+Use when the user asks for test plans, coverage gaps, flaky-test triage, automation frameworks, or implementation of tests.
+
+Match the repo's existing test runner and style. Cover behavior first, then edge cases and regressions.

--- a/skills/voice-transcribe/SKILL.md
+++ b/skills/voice-transcribe/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: voice-transcribe
+description: Transcribe audio using OpenAI transcription models with vocabulary hints and cleanup rules.
+---
+
+# Voice Transcribe
+
+Use for speech-to-text tasks that need model-based transcription, speaker labels, domain vocabulary hints, or post-processing.
+
+Ask for or infer the target output shape: plain transcript, summary, timestamps, SRT, or action items. Treat voice recordings as private.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the daily discovery sweep
- Cover security, cloud, audio/STT/TTS, and invoice workflows
- Sources: skills.sh, sundial-org/awesome-openclaw-skills, current orthogonal-sh/skills main

Linear: ORT-2414

Reviewers: @christianpickettcode @berasogut