### PR TITLE
Add July 27 discovery skill stubs

### DIFF
--- a/skills/alpha-finder/SKILL.md
+++ b/skills/alpha-finder/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: alpha-finder
+description: Research prediction-market opportunities across Polymarket and Kalshi with probabilities, sentiment, and risk notes.
+---
+
+# Alpha Finder
+
+Use this skill when the user asks for research prediction-market opportunities across Polymarket and Kalshi with probabilities, sentiment, and risk notes.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/base-trader/SKILL.md
+++ b/skills/base-trader/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: base-trader
+description: Autonomous crypto trading on Base via Bankr, with portfolio checks, strategy notes, and explicit trade approvals.
+---
+
+# Base Trader
+
+Use this skill when the user asks for autonomous crypto trading on Base via Bankr, with portfolio checks, strategy notes, and explicit trade approvals.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/compose-gen/SKILL.md
+++ b/skills/compose-gen/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: compose-gen
+description: Generate Docker Compose files by scanning project structure, services, ports, dependencies, and runtime needs.
+---
+
+# Compose Gen
+
+Use this skill when the user asks for generate Docker Compose files by scanning project structure, services, ports, dependencies, and runtime needs.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/cryptocurrency-trader/SKILL.md
+++ b/skills/cryptocurrency-trader/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: cryptocurrency-trader
+description: Analyze crypto markets, risk, positions, and execution plans with approval gates for any live trading.
+---
+
+# Cryptocurrency Trader
+
+Use this skill when the user asks for analyze crypto markets, risk, positions, and execution plans with approval gates for any live trading.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/dockerfile-gen/SKILL.md
+++ b/skills/dockerfile-gen/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: dockerfile-gen
+description: Generate optimized Dockerfiles for projects based on language, build steps, runtime, and deployment constraints.
+---
+
+# Dockerfile Gen
+
+Use this skill when the user asks for generate optimized Dockerfiles for projects based on language, build steps, runtime, and deployment constraints.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/exa-web-search-free/SKILL.md
+++ b/skills/exa-web-search-free/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: exa-web-search-free
+description: Free Exa MCP web and code search for current docs, company research, and source-backed answers without an API key.
+---
+
+# Exa Web Search Free
+
+Use this skill when the user asks for free Exa MCP web and code search for current docs, company research, and source-backed answers without an API key.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/food-order/SKILL.md
+++ b/skills/food-order/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: food-order
+description: Reorder meals, inspect order history, and track delivery status while requiring explicit confirmation before purchase.
+---
+
+# Food Order
+
+Use this skill when the user asks for reorder meals, inspect order history, and track delivery status while requiring explicit confirmation before purchase.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/game-theory/SKILL.md
+++ b/skills/game-theory/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: game-theory
+description: Analyze strategic incentives, mechanism design, tokenomics, governance, and adversarial protocol behavior.
+---
+
+# Game Theory
+
+Use this skill when the user asks for analyze strategic incentives, mechanism design, tokenomics, governance, and adversarial protocol behavior.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/gemini-image-simple/SKILL.md
+++ b/skills/gemini-image-simple/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: gemini-image-simple
+description: Generate and edit images with Gemini using a minimal Python standard-library workflow.
+---
+
+# Gemini Image Simple
+
+Use this skill when the user asks for generate and edit images with Gemini using a minimal Python standard-library workflow.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/hevy/SKILL.md
+++ b/skills/hevy/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: hevy
+description: Query Hevy workout history, routines, exercises, and training progress for fitness summaries and planning.
+---
+
+# Hevy
+
+Use this skill when the user asks for query Hevy workout history, routines, exercises, and training progress for fitness summaries and planning.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/human-optimized-frontend/SKILL.md
+++ b/skills/human-optimized-frontend/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: human-optimized-frontend
+description: Create frontend interfaces optimized for visual quality, motion, usability, accessibility, and domain fit.
+---
+
+# Human Optimized Frontend
+
+Use this skill when the user asks for create frontend interfaces optimized for visual quality, motion, usability, accessibility, and domain fit.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/market-news-analyst/SKILL.md
+++ b/skills/market-news-analyst/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: market-news-analyst
+description: Analyze market-moving news, macro events, earnings, commodities, and likely equity impacts.
+---
+
+# Market News Analyst
+
+Use this skill when the user asks for analyze market-moving news, macro events, earnings, commodities, and likely equity impacts.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/miniflux-news/SKILL.md
+++ b/skills/miniflux-news/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: miniflux-news
+description: Fetch unread Miniflux RSS items, triage feeds, and summarize important articles from a self-hosted reader.
+---
+
+# Miniflux News
+
+Use this skill when the user asks for fetch unread Miniflux RSS items, triage feeds, and summarize important articles from a self-hosted reader.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/munger-observer/SKILL.md
+++ b/skills/munger-observer/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: munger-observer
+description: Review decisions and plans through Charlie Munger-style mental models, bias checks, and inversion.
+---
+
+# Munger Observer
+
+Use this skill when the user asks for review decisions and plans through Charlie Munger-style mental models, bias checks, and inversion.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/news-aggregator-skill/SKILL.md
+++ b/skills/news-aggregator-skill/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: news-aggregator-skill
+description: Fetch, filter, and summarize news from multiple sources for briefings, monitoring, and trend discovery.
+---
+
+# News Aggregator Skill
+
+Use this skill when the user asks for fetch, filter, and summarize news from multiple sources for briefings, monitoring, and trend discovery.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/newsletter-creation-curation/SKILL.md
+++ b/skills/newsletter-creation-curation/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: newsletter-creation-curation
+description: Curate sources, draft newsletter issues, and recommend cadence, sections, and automation workflows.
+---
+
+# Newsletter Creation Curation
+
+Use this skill when the user asks for curate sources, draft newsletter issues, and recommend cadence, sections, and automation workflows.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/perry-workspaces/SKILL.md
+++ b/skills/perry-workspaces/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: perry-workspaces
+description: Create and manage isolated Perry coding workspaces with agent access, repo setup, and progress monitoring.
+---
+
+# Perry Workspaces
+
+Use this skill when the user asks for create and manage isolated Perry coding workspaces with agent access, repo setup, and progress monitoring.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/stock-evaluator-v3/SKILL.md
+++ b/skills/stock-evaluator-v3/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: stock-evaluator-v3
+description: Evaluate stock ideas with fundamentals, valuation, technical context, catalysts, and buy/hold/sell notes.
+---
+
+# Stock Evaluator V3
+
+Use this skill when the user asks for evaluate stock ideas with fundamentals, valuation, technical context, catalysts, and buy/hold/sell notes.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/travel-concierge/SKILL.md
+++ b/skills/travel-concierge/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: travel-concierge
+description: Find accommodation contact details and travel logistics from lodging platforms and public booking data.
+---
+
+# Travel Concierge
+
+Use this skill when the user asks for find accommodation contact details and travel logistics from lodging platforms and public booking data.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.

--- a/skills/veo3-video-gen/SKILL.md
+++ b/skills/veo3-video-gen/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: veo3-video-gen
+description: Generate and stitch short videos with Google Veo through the Gemini API from prompts and production notes.
+---
+
+# Veo3 Video Gen
+
+Use this skill when the user asks for generate and stitch short videos with Google Veo through the Gemini API from prompts and production notes.
+
+## Capabilities
+
+- Clarify the user's goal, scope, constraints, and risk tolerance before acting.
+- Gather the required local context, external documentation, or account state.
+- Produce concise recommendations, commands, drafts, or execution plans the user can inspect.
+- Call out assumptions, missing credentials, and follow-up checks clearly.
+
+## Requirements
+
+- Install any upstream CLI, MCP server, or SDK referenced by the source project.
+- Configure credentials through the user's normal secret manager or integration settings.
+- Prefer dry runs, read-only calls, and local previews before changing external state.
+
+## Safety
+
+Do not place trades, send orders, publish content, book travel, spend money, or modify production systems without explicit user approval.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the July 27 daily discovery pass
- Sources checked: skills.sh, sundial-org/awesome-openclaw-skills, and existing orthogonal-sh/skills main
- Filtered against memory/discovery-posts.md to avoid prior posted picks

## Linear
ORT-2415

## Testing
- Not run. Content-only skill stubs.