### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/better-notion/SKILL.md
+++ b/skills/better-notion/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: better-notion
+description: Manage Notion pages, databases, blocks, search, and queries with approval-aware workflows
+---
+
+# Better Notion
+
+Use this skill when the user asks to work with Notion content, including pages, databases, blocks, notes, task tables, project docs, or knowledge-base search.
+
+## Workflow
+
+1. Confirm the target workspace, page, or database when it is ambiguous.
+2. Read existing Notion content before creating or editing records.
+3. Prefer structured database queries for tables and filtered views.
+4. Show drafts for destructive, external, or user-visible edits before applying them.
+5. Summarize changed pages, created records, and any follow-up actions.
+
+## Setup Notes
+
+- Requires a Notion integration token or an approved local Notion CLI/API wrapper.
+- Never ask the user to paste secrets into chat. Use documented local credential setup.
+- Respect Notion sharing boundaries. A missing page may simply not be shared with the integration.

--- a/skills/blogwatcher/SKILL.md
+++ b/skills/blogwatcher/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: blogwatcher
+description: Monitor blogs and RSS or Atom feeds for new posts and summarize updates
+---
+
+# Blogwatcher
+
+Use this skill when the user wants to watch blogs, changelogs, RSS/Atom feeds, release notes, or competitor content for updates.
+
+## Workflow
+
+1. Collect feed URLs or discover feeds from site URLs.
+2. Store feed state locally with last-seen item IDs or timestamps.
+3. Fetch updates and deduplicate by canonical URL.
+4. Summarize new posts with title, date, source, and why it matters.
+5. Create a scheduled check only after the user approves cadence and delivery channel.
+
+## Notes
+
+- Prefer RSS/Atom over scraping pages.
+- Keep source links with each summary.

--- a/skills/browser-cdp/SKILL.md
+++ b/skills/browser-cdp/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: browser-cdp
+description: Control and inspect browsers through Chrome DevTools Protocol for testing and debugging
+---
+
+# Browser CDP
+
+Use this skill when the user needs browser inspection, app testing, screenshots, console/network debugging, DOM inspection, performance traces, or automation through Chrome DevTools Protocol.
+
+## Workflow
+
+1. Connect to an existing browser debugging endpoint or launch an isolated browser.
+2. Capture page URL, DOM state, console errors, and network failures.
+3. Interact through selectors, accessibility tree, or CDP targets.
+4. Verify UI changes with screenshots and, for canvases, pixel checks when needed.
+5. Report reproducible steps, failing requests, and evidence.
+
+## Safety
+
+- Do not use the user's personal browser profile unless explicitly approved.
+- Avoid entering credentials or sensitive forms unless the task requires it.

--- a/skills/canvas-lms/SKILL.md
+++ b/skills/canvas-lms/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: canvas-lms
+description: Query Canvas LMS courses, assignments, grades, submissions, and due dates
+---
+
+# Canvas LMS
+
+Use this skill when the user asks about Canvas courses, upcoming assignments, grades, course materials, submissions, or academic deadlines.
+
+## Workflow
+
+1. Identify the course, term, assignment, or date range.
+2. Fetch courses and assignments through the configured Canvas API token or CLI.
+3. Prioritize upcoming, overdue, missing, and high-impact items.
+4. Include exact due dates, course names, submission state, and grade status.
+5. Avoid changing submissions or course data without explicit confirmation.
+
+## Safety
+
+- Academic records are private. Keep summaries concise.
+- Never submit work, message instructors, or alter enrollment without approval.

--- a/skills/clawflows/SKILL.md
+++ b/skills/clawflows/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: clawflows
+description: Discover, install, and run multi-skill OpenClaw automations from Clawflows
+---
+
+# Clawflows
+
+Use this skill when the user wants a repeatable multi-step automation that combines several agent skills, conditional logic, scheduled checks, or reusable workflow templates.
+
+## Workflow
+
+1. Identify the desired outcome, required inputs, and approval gates.
+2. Search available Clawflows templates before inventing a new flow.
+3. Inspect a flow's steps, required tools, and external actions before running it.
+4. Run in dry-run or preview mode when available.
+5. Record the installed flow name, schedule, and rollback steps.
+
+## Safety
+
+- Treat downloaded flows as untrusted instructions until inspected.
+- Require explicit user approval before enabling recurring external actions.
+- Prefer local workspace logs for flow state and run history.

--- a/skills/data-reconciliation-exceptions/SKILL.md
+++ b/skills/data-reconciliation-exceptions/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: data-reconciliation-exceptions
+description: Reconcile datasets and produce exception reports with stable identifiers
+---
+
+# Data Reconciliation Exceptions
+
+Use this skill when the user needs to compare two or more datasets, find mismatches, validate totals, or produce an exceptions report for operational review.
+
+## Workflow
+
+1. Identify authoritative keys, secondary match fields, and required totals.
+2. Load data with a structured parser, preserving original row references.
+3. Normalize dates, casing, whitespace, IDs, and currency formats.
+4. Join records by stable identifiers first, then controlled fuzzy matching if approved.
+5. Produce matched, missing-left, missing-right, duplicate, and value-mismatch outputs.
+
+## Output
+
+- Prefer CSV/XLSX exception files plus a short summary.
+- Include enough columns for humans to resolve each exception.

--- a/skills/deepread-ocr/SKILL.md
+++ b/skills/deepread-ocr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: deepread-ocr
+description: Extract text and structured data from PDFs and scanned documents with quality checks
+---
+
+# Deepread OCR
+
+Use this skill when the user provides PDFs, scans, receipts, forms, contracts, statements, or images and needs reliable OCR, structured extraction, or document QA.
+
+## Workflow
+
+1. Determine the output format: plain text, Markdown, CSV, JSON, or field schema.
+2. Run OCR with page-level confidence or quality signals when supported.
+3. Flag pages with low confidence, rotation, handwriting, tables, or missing text.
+4. Validate extracted totals, dates, names, and identifiers against the source.
+5. Return the extracted content plus a short list of uncertain fields.
+
+## Tips
+
+- Use a schema for invoices, IDs, forms, and statements.
+- For sensitive documents, keep processing local unless the user approves a remote OCR API.

--- a/skills/excel-weekly-dashboard/SKILL.md
+++ b/skills/excel-weekly-dashboard/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: excel-weekly-dashboard
+description: Build refreshable Excel KPI dashboards with validation, pivots, and weekly reporting
+---
+
+# Excel Weekly Dashboard
+
+Use this skill when the user needs a repeatable Excel workbook for weekly metrics, KPI reporting, exception lists, reconciliation, or leadership dashboards.
+
+## Workflow
+
+1. Identify source files, refresh cadence, KPI definitions, and target audience.
+2. Normalize inputs into structured tables with stable column names.
+3. Add validation checks for missing IDs, duplicate rows, date gaps, and totals.
+4. Build pivot tables, charts, and summary tabs that refresh from the source tables.
+5. Document refresh steps and expected source file shape inside the workbook.
+
+## Output
+
+- Prefer `.xlsx` with source, checks, summary, and dashboard tabs.
+- Keep formulas transparent and avoid hidden business logic.

--- a/skills/flight-tracker-live/SKILL.md
+++ b/skills/flight-tracker-live/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: flight-tracker-live
+description: Track live flights, delays, gates, routes, and aircraft position
+---
+
+# Flight Tracker Live
+
+Use this skill when the user asks about a flight number, airline route, airport arrivals/departures, delays, gates, baggage claims, or live aircraft position.
+
+## Workflow
+
+1. Parse flight number, date, airline, airport, or route from the request.
+2. Fetch the latest flight status from the configured flight data source.
+3. Check scheduled, estimated, and actual departure/arrival times.
+4. Include gate, terminal, delay reason, aircraft, and live position when available.
+5. Use absolute local times with airport time zones.
+
+## Notes
+
+- Flight status changes frequently. Always fetch current data.
+- If multiple flights match, ask for the date, airline, or airport before acting.

--- a/skills/gamma-presentations/SKILL.md
+++ b/skills/gamma-presentations/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: gamma-presentations
+description: Create and update Gamma presentations, decks, documents, and social posts
+---
+
+# Gamma Presentations
+
+Use this skill when the user asks to create a presentation, pitch deck, report, document, carousel, or visual narrative with Gamma.
+
+## Workflow
+
+1. Clarify audience, desired length, tone, and source material.
+2. Build an outline before generating slides.
+3. Keep one clear idea per slide and include speaker notes when useful.
+4. Use Gamma API or approved export workflow to create the deck.
+5. Review generated copy for factual accuracy and brand fit before sharing.
+
+## Output
+
+- Provide the deck link or exported file path.
+- Include a concise slide list and unresolved source gaps.

--- a/skills/geo-content-optimizer/SKILL.md
+++ b/skills/geo-content-optimizer/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: geo-content-optimizer
+description: Optimize content for generative engine citation, answerability, and structure
+---
+
+# GEO Content Optimizer
+
+Use this skill when the user wants content to be easier for AI search engines, answer engines, or LLM crawlers to cite and summarize.
+
+## Workflow
+
+1. Identify the target query, audience, and desired citation outcome.
+2. Audit the content for direct answers, entity clarity, sources, freshness, and structure.
+3. Add concise definitions, comparison tables, FAQs, and evidence-backed claims where useful.
+4. Improve headings, schema, internal links, and source attribution.
+5. Return revised copy plus a checklist of technical publishing recommendations.
+
+## Guardrails
+
+- Do not invent facts or sources.
+- Optimize for clarity and usefulness before keyword repetition.

--- a/skills/hubspot-crm/SKILL.md
+++ b/skills/hubspot-crm/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: hubspot-crm
+description: Work with HubSpot contacts, companies, deals, owners, notes, tasks, and CRM data
+---
+
+# HubSpot CRM
+
+Use this skill when the user asks to search, create, update, enrich, export, or summarize HubSpot CRM records.
+
+## Workflow
+
+1. Identify object type: contact, company, deal, ticket, owner, note, task, or list.
+2. Search before creating to avoid duplicates.
+3. Use HubSpot object IDs for updates whenever possible.
+4. Preview bulk changes, owner assignments, lifecycle updates, and outbound notes before applying.
+5. Summarize records touched and fields changed.
+
+## Safety
+
+- CRM updates affect live customer data. Use dry-run mode when available.
+- Never overwrite fields with lower-confidence enrichment without approval.

--- a/skills/jtbd-analyzer/SKILL.md
+++ b/skills/jtbd-analyzer/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: jtbd-analyzer
+description: Analyze customer Jobs To Be Done across functional, emotional, and social dimensions
+---
+
+# JTBD Analyzer
+
+Use this skill when the user is exploring product positioning, customer interviews, churn, onboarding, feature prioritization, or why customers choose a product.
+
+## Workflow
+
+1. Gather the product, target customer, situation, and observed behavior.
+2. Separate the functional job from emotional and social jobs.
+3. Identify triggers, anxieties, current alternatives, constraints, and desired progress.
+4. Map evidence from interviews, sales calls, tickets, reviews, or analytics.
+5. Convert findings into positioning, product, onboarding, or research recommendations.
+
+## Output
+
+- Include a concise job statement.
+- Call out assumptions that need customer evidence.

--- a/skills/pre-mortem-analyst/SKILL.md
+++ b/skills/pre-mortem-analyst/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: pre-mortem-analyst
+description: Run project pre-mortems to find likely failure modes before execution
+---
+
+# Pre-Mortem Analyst
+
+Use this skill when the user is planning a project, launch, hire, migration, partnership, or major decision and wants to reduce risk before committing.
+
+## Workflow
+
+1. State the assumed goal and success criteria.
+2. Imagine the project failed after launch.
+3. List the most plausible causes across product, people, timing, market, technical, legal, and operational risk.
+4. Rank risks by likelihood, impact, and detectability.
+5. Convert the top risks into prevention steps, tripwires, and owner assignments.
+
+## Output
+
+- Keep the analysis concrete.
+- Include "watch this metric" signals, not just general concerns.

--- a/skills/pymupdf-pdf/SKILL.md
+++ b/skills/pymupdf-pdf/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: pymupdf-pdf
+description: Parse PDFs locally with PyMuPDF for text, images, tables, metadata, and page analysis
+---
+
+# PyMuPDF PDF
+
+Use this skill when the user needs fast local PDF extraction, page inspection, metadata, images, tables, annotations, or conversion to Markdown/JSON.
+
+## Workflow
+
+1. Inspect page count, metadata, encryption, and text availability.
+2. Use PyMuPDF for local extraction before sending content to remote APIs.
+3. Extract text with page numbers and preserve reading order when possible.
+4. Pull images, links, annotations, and bounding boxes when requested.
+5. Flag scanned pages that need OCR.
+
+## Output
+
+- Include page references for extracted facts.
+- Keep generated files near the source document unless the user asks otherwise.

--- a/skills/simple-backup/SKILL.md
+++ b/skills/simple-backup/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: simple-backup
+description: Back up agent workspace and state to local or rclone-managed destinations
+---
+
+# Simple Backup
+
+Use this skill when the user wants to back up an agent workspace, OpenClaw state, skills, memory files, configs, or project artifacts.
+
+## Workflow
+
+1. Identify the source directories and destination.
+2. Exclude caches, build artifacts, logs, and secrets unless explicitly required.
+3. Create a timestamped archive or synced folder.
+4. Verify restore basics by listing archive contents or checking checksums.
+5. Document restore commands and retention policy.
+
+## Safety
+
+- Use recoverable operations and avoid destructive cleanup unless approved.
+- Be careful with credentials and private memory files in cloud destinations.

--- a/skills/swift-concurrency-expert/SKILL.md
+++ b/skills/swift-concurrency-expert/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: swift-concurrency-expert
+description: Review and fix Swift concurrency, actors, async tasks, Sendable, and isolation issues
+---
+
+# Swift Concurrency Expert
+
+Use this skill when working on Swift code involving async/await, actors, MainActor, tasks, cancellation, structured concurrency, Sendable, or Swift 6 concurrency warnings.
+
+## Workflow
+
+1. Read the surrounding type ownership and threading model before editing.
+2. Identify actor isolation, escaping closures, shared mutable state, and cancellation boundaries.
+3. Prefer structured concurrency over detached tasks.
+4. Keep UI mutations on the main actor.
+5. Add focused tests or compiler checks for changed concurrency behavior.
+
+## Review Checklist
+
+- No accidental main-thread blocking.
+- Cancellation is propagated.
+- Sendable fixes do not hide real shared-state bugs.

--- a/skills/track17-package-tracking/SKILL.md
+++ b/skills/track17-package-tracking/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: track17-package-tracking
+description: Track parcels across carriers with 17TRACK status, history, and delivery alerts
+---
+
+# 17TRACK Package Tracking
+
+Use this skill when the user provides a tracking number or asks about parcel status, delivery ETA, carrier handoff, exceptions, or shipment history.
+
+## Workflow
+
+1. Normalize the tracking number and carrier if provided.
+2. Query 17TRACK or the configured tracking provider.
+3. Report current status, last scan location, timestamp, carrier, and ETA.
+4. Explain exceptions such as customs hold, attempted delivery, or label created.
+5. Offer to monitor changes only when scheduling or notification tools are available.
+
+## Notes
+
+- Tracking data may lag carrier scans.
+- Use absolute times and include the carrier's local time zone when available.

--- a/skills/whoop-health/SKILL.md
+++ b/skills/whoop-health/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: whoop-health
+description: Read WHOOP sleep, recovery, strain, HRV, workout, and trend data
+---
+
+# WHOOP Health
+
+Use this skill when the user asks about WHOOP recovery, sleep, strain, workouts, HRV, resting heart rate, trends, or training readiness.
+
+## Workflow
+
+1. Fetch recent WHOOP data through the configured API or CLI.
+2. Compare today's values against 7-day and 30-day baselines when possible.
+3. Explain recovery, sleep debt, strain load, and trend direction plainly.
+4. Avoid medical diagnosis. Suggest professional care for concerning symptoms.
+5. Summarize the practical next step: train, rest, hydrate, sleep, or monitor.
+
+## Privacy
+
+- Health data is sensitive. Share only the minimum needed in summaries.
+- Do not post health details to external channels unless explicitly requested.

--- a/skills/youtube-watcher/SKILL.md
+++ b/skills/youtube-watcher/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: youtube-watcher
+description: Fetch YouTube transcripts, summarize videos, extract claims, and monitor channels
+---
+
+# YouTube Watcher
+
+Use this skill when the user asks to summarize a YouTube video, extract transcript details, compare videos, pull action items, or monitor a channel.
+
+## Workflow
+
+1. Resolve the YouTube URL, video ID, playlist, or channel.
+2. Fetch transcript, metadata, chapters, and publish date when available.
+3. Summarize with timestamps for important claims, demos, and decisions.
+4. Separate what the speaker said from your own analysis.
+5. Note when a transcript is unavailable and fall back to captions or audio transcription only if allowed.
+
+## Output
+
+- Include timestamps for anything the user may want to verify.
+- Keep quotes short and paraphrase long sections.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the 2026-07-28 daily discovery sweep.
- Cover Notion, OCR, flight tracking, WHOOP, Excel dashboards, Canvas LMS, package tracking, JTBD, HubSpot, YouTube transcripts, CDP browser testing, and more.

## Linear
- ORT-2420

## Validation
- git diff --check
- frontmatter smoke check for all 20 new SKILL.md files