### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/agentlens/SKILL.md
+++ b/skills/agentlens/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: agentlens
+description: Navigate large codebases through generated maps, symbols, and module notes
+---
+
+# Agentlens
+
+Use this skill when a large or unfamiliar codebase needs quick orientation, module discovery, symbol lookup, or architectural navigation.
+
+## Workflow
+
+1. Build or refresh the codebase index.
+2. Search for the target feature, module, route, or symbol.
+3. Read the smallest set of files needed to validate the map.
+4. Summarize ownership, call paths, and likely edit points.
+5. Note stale or missing index areas.
+
+## Output
+
+- Include file paths and concrete next steps.
+- Treat generated maps as hints until verified against source files.

--- a/skills/api-designer/SKILL.md
+++ b/skills/api-designer/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: api-designer
+description: Design REST and GraphQL APIs with schemas, resources, errors, and versioning
+---
+
+# API Designer
+
+Use this skill when designing or reviewing an API, OpenAPI specification, GraphQL schema, resource model, pagination, auth, errors, or versioning strategy.
+
+## Workflow
+
+1. Capture the product use cases and consumers.
+2. Model resources, operations, schemas, and identifiers.
+3. Define authentication, authorization, pagination, filtering, and error formats.
+4. Draft OpenAPI, GraphQL SDL, or endpoint tables.
+5. Review backwards compatibility, observability, and SDK ergonomics.
+
+## Output
+
+- Prefer concrete request and response examples.
+- Call out tradeoffs and migration risks.

--- a/skills/bambu-cli/SKILL.md
+++ b/skills/bambu-cli/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: bambu-cli
+description: Operate and troubleshoot Bambu Lab printers through the bambu-cli tool
+---
+
+# Bambu CLI
+
+Use this skill when the user asks about Bambu Lab printer status, files, print jobs, camera, AMS, fans, lights, calibration, or troubleshooting.
+
+## Workflow
+
+1. Confirm the target printer and connection profile.
+2. Check printer status before issuing actions.
+3. Use bambu-cli for read operations, file inspection, or print controls.
+4. Verify the printer state after any change.
+5. Report warnings, temperatures, job progress, and next actions.
+
+## Safety
+
+- Ask before starting, stopping, or cancelling prints.
+- Treat printer motion and heat controls as physical-world actions.

--- a/skills/causal-inference/SKILL.md
+++ b/skills/causal-inference/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: causal-inference
+description: Reason about interventions, outcomes, confounders, and observable evidence
+---
+
+# Causal Inference
+
+Use this skill when the user is evaluating whether an action caused an outcome or planning an intervention where confounders matter.
+
+## Workflow
+
+1. State the treatment, outcome, population, and time window.
+2. List plausible confounders, mediators, and selection effects.
+3. Identify available observational or experimental evidence.
+4. Choose an appropriate design, such as A/B test, diff-in-diff, matching, or regression discontinuity.
+5. Explain the strongest claim the evidence can support.
+
+## Output
+
+- Distinguish correlation, mechanism, and causal claim.
+- Include what evidence would change the conclusion.

--- a/skills/claude-team/SKILL.md
+++ b/skills/claude-team/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: claude-team
+description: Coordinate multiple Claude Code workers in isolated worktrees
+---
+
+# Claude Team
+
+Use this skill when a coding task can be split across multiple Claude Code workers with separate worktrees and clear ownership.
+
+## Workflow
+
+1. Break the task into independent work scopes.
+2. Create or assign clean worktrees for each worker.
+3. Give each worker explicit files, goals, and verification commands.
+4. Monitor progress and resolve conflicts.
+5. Integrate reviewed changes into the main branch.
+
+## Safety
+
+- Do not let workers edit overlapping files without coordination.
+- Review worker output before committing or pushing.

--- a/skills/clickup-mcp/SKILL.md
+++ b/skills/clickup-mcp/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: clickup-mcp
+description: Manage ClickUp tasks, docs, comments, search, and time tracking through MCP
+---
+
+# ClickUp MCP
+
+Use this skill when working with ClickUp workspaces, tasks, lists, docs, comments, assignees, statuses, or time tracking.
+
+## Workflow
+
+1. Identify the workspace, space, folder, list, or task target.
+2. Search before creating new tasks to avoid duplicates.
+3. Apply the requested task, doc, comment, or status change.
+4. Verify the changed object and return its link or ID.
+5. Capture follow-up tasks if the workflow creates dependencies.
+
+## Safety
+
+- Ask before destructive changes or broad bulk updates.
+- Keep workspace permissions and private docs in mind.

--- a/skills/codex-quota/SKILL.md
+++ b/skills/codex-quota/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: codex-quota
+description: Inspect Codex CLI session logs to estimate remaining quota and usage
+---
+
+# Codex Quota
+
+Use this skill when the user asks about Codex CLI quota, rate limits, model usage, session duration, or token burn.
+
+## Workflow
+
+1. Locate local Codex session and usage logs.
+2. Parse recent model, token, and timing entries.
+3. Group usage by day, model, and session.
+4. Estimate remaining quota from known limits when available.
+5. Flag uncertainty where logs do not expose provider-side counters.
+
+## Output
+
+- Report estimates plainly.
+- Include the log time window used for the calculation.

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: context7
+description: Fetch current library documentation through Context7 for coding tasks
+---
+
+# Context7
+
+Use this skill when the user is working with a third-party library or framework and needs current documentation, API examples, or version-specific usage notes.
+
+## Workflow
+
+1. Identify the library, framework, package, or API surface in question.
+2. Resolve the correct Context7 library identifier.
+3. Fetch the smallest relevant documentation slice for the task.
+4. Ground implementation advice in the fetched docs.
+5. Note any version assumptions or gaps.
+
+## Safety
+
+- Prefer official package documentation surfaced through Context7.
+- Do not guess at changed APIs when docs are available.

--- a/skills/git-notes-memory/SKILL.md
+++ b/skills/git-notes-memory/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: git-notes-memory
+description: Store branch-aware agent knowledge in git notes for repo-local continuity
+---
+
+# Git Notes Memory
+
+Use this skill when repository-specific learnings should travel with Git history without changing source files.
+
+## Workflow
+
+1. Identify the commit, branch, file, or decision the memory belongs to.
+2. Read existing git notes before adding new ones.
+3. Write concise notes with date, scope, and source context.
+4. Push or fetch notes refs when collaboration requires it.
+5. Retrieve notes during future codebase work.
+
+## Safety
+
+- Do not store secrets in git notes.
+- Keep notes scoped to repo knowledge, not broad personal memory.

--- a/skills/gno/SKILL.md
+++ b/skills/gno/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: gno
+description: Index and search local documents with BM25, vector, and cited answer modes
+---
+
+# Gno
+
+Use this skill when the user wants to search local files, notes, markdown, PDFs, or project knowledge bases with ranked results and citations.
+
+## Workflow
+
+1. Identify the target directories and file types.
+2. Build or refresh the Gno index.
+3. Run keyword, vector, or hybrid search based on the query.
+4. Open top matches to verify context.
+5. Answer with citations to local files.
+
+## Safety
+
+- Avoid indexing secrets or private memory into shared stores.
+- Prefer local search before web search for workspace-specific questions.

--- a/skills/linearis/SKILL.md
+++ b/skills/linearis/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: linearis
+description: Use the Linearis CLI to search, create, and update Linear issues and projects
+---
+
+# Linearis
+
+Use this skill when managing Linear issues, comments, cycles, projects, documents, or workflow states through the Linearis CLI.
+
+## Workflow
+
+1. Identify the team, project, issue, or cycle target.
+2. Search existing issues before creating new work.
+3. Apply updates with JSON output enabled where possible.
+4. Verify final issue ID, title, state, and project assignment.
+5. Include reviewer, PR, or dependency links when relevant.
+
+## Safety
+
+- Avoid noisy comments or status changes unless requested.
+- Keep private issue context out of public summaries.

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: llm-council
+description: Gather independent implementation plans from multiple LLM workers and judge tradeoffs
+---
+
+# LLM Council
+
+Use this skill when a decision benefits from several independent plans, critiques, or technical approaches before implementation.
+
+## Workflow
+
+1. Define the decision, constraints, and judging criteria.
+2. Ask each council member for an independent answer.
+3. Remove identifying bias where practical.
+4. Compare plans by correctness, risk, cost, maintainability, and fit.
+5. Return a recommended path with rejected alternatives.
+
+## Safety
+
+- Do not outsource secrets or private data to external models.
+- Use the council for hard choices, not routine edits.

--- a/skills/memory-hygiene/SKILL.md
+++ b/skills/memory-hygiene/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: memory-hygiene
+description: Audit and clean noisy agent memory while preserving durable context
+---
+
+# Memory Hygiene
+
+Use this skill when memory recall is noisy, stale, duplicated, overbroad, or causing irrelevant context to appear in future sessions.
+
+## Workflow
+
+1. Review recent memory entries and recall results.
+2. Identify duplicates, obsolete facts, secrets that should not be retained, and low-value chatter.
+3. Propose removals, consolidations, and long-term memory updates.
+4. Preserve source dates or paths for important retained context.
+5. Record the cleanup in the daily memory log.
+
+## Safety
+
+- Do not delete memory without clear intent.
+- Keep private context scoped to the right audience and session type.

--- a/skills/ontology/SKILL.md
+++ b/skills/ontology/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ontology
+description: Model people, projects, tasks, events, and documents as typed knowledge graphs
+---
+
+# Ontology
+
+Use this skill when information should be represented as entities and relationships rather than a flat note, list, or summary.
+
+## Workflow
+
+1. Identify entity types, required properties, and relationship types.
+2. Extract candidate entities from the source material.
+3. Normalize names, dates, IDs, and aliases.
+4. Link entities with explicit relationship labels.
+5. Return a compact graph, schema proposal, or update plan.
+
+## Output
+
+- Separate observed facts from inferred relationships.
+- Include enough IDs or labels for later updates.

--- a/skills/para-second-brain/SKILL.md
+++ b/skills/para-second-brain/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: para-second-brain
+description: Organize notes and knowledge using PARA categories with searchable structure
+---
+
+# PARA Second Brain
+
+Use this skill when the user wants to organize knowledge into Projects, Areas, Resources, and Archives.
+
+## Workflow
+
+1. Classify each item as project, area, resource, or archive.
+2. Preserve active project context and next actions.
+3. Move reference material into stable resource locations.
+4. Archive completed or inactive material with dates.
+5. Make the resulting structure searchable.
+
+## Output
+
+- Explain moves briefly.
+- Keep naming consistent and easy to browse.

--- a/skills/process-watch/SKILL.md
+++ b/skills/process-watch/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: process-watch
+description: Monitor processes, ports, CPU, memory, disk IO, and resource hot spots
+---
+
+# Process Watch
+
+Use this skill when diagnosing slow machines, runaway processes, stuck dev servers, port conflicts, or resource-heavy commands.
+
+## Workflow
+
+1. Inspect active processes, ports, CPU, memory, disk, and network use.
+2. Identify the likely culprit with command, PID, owner, and start time.
+3. Check logs or child processes when needed.
+4. Recommend or perform a safe intervention.
+5. Verify resource usage after the intervention.
+
+## Safety
+
+- Ask before killing unrelated or user-owned long-running processes.
+- Prefer graceful termination before forceful signals.

--- a/skills/proxmox/SKILL.md
+++ b/skills/proxmox/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: proxmox
+description: Manage Proxmox VE nodes, VMs, containers, snapshots, and cluster tasks
+---
+
+# Proxmox
+
+Use this skill when the user asks to inspect or manage Proxmox nodes, virtual machines, containers, storage, snapshots, or cluster tasks.
+
+## Workflow
+
+1. Identify the target cluster, node, VM, container, or storage pool.
+2. Read current status before making changes.
+3. Perform requested API or CLI actions with explicit target IDs.
+4. Poll task status until completion when needed.
+5. Summarize state changes and any follow-up maintenance.
+
+## Safety
+
+- Ask before stop, delete, rollback, or migration operations.
+- Take or confirm backups before risky infrastructure changes.

--- a/skills/reflect/SKILL.md
+++ b/skills/reflect/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: reflect
+description: Extract durable lessons from corrections, failures, and successful patterns
+---
+
+# Reflect
+
+Use this skill after a correction, mistake, surprising success, recurring friction, or workflow improvement worth preserving.
+
+## Workflow
+
+1. Identify the event and what changed.
+2. Separate durable lesson from one-off circumstance.
+3. Decide whether it belongs in memory, workspace instructions, or a skill.
+4. Write the smallest useful update.
+5. Tell the user when persistent instructions changed.
+
+## Output
+
+- Keep lessons operational and specific.
+- Avoid saving secrets or transient noise.

--- a/skills/supermemory/SKILL.md
+++ b/skills/supermemory/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: supermemory
+description: Store, search, and chat with knowledge through the Supermemory API
+---
+
+# Supermemory
+
+Use this skill when the user wants to save knowledge, search a managed memory store, or chat over a personal or team knowledge base backed by Supermemory.
+
+## Workflow
+
+1. Determine whether the task is add, search, update, delete, or chat.
+2. Scope the memory collection and user context.
+3. Execute the Supermemory operation with metadata where useful.
+4. Verify returned IDs, excerpts, and timestamps.
+5. Summarize the action without leaking private memory.
+
+## Safety
+
+- Ask before storing sensitive personal or credential-like content.
+- Respect collection boundaries.

--- a/skills/ticktick/SKILL.md
+++ b/skills/ticktick/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ticktick
+description: Manage TickTick tasks, projects, due dates, and batch updates from the CLI
+---
+
+# TickTick
+
+Use this skill when the user wants to add, list, update, complete, or organize TickTick tasks and projects.
+
+## Workflow
+
+1. Confirm the intended task list, project, due date, and priority.
+2. Use the TickTick CLI or API wrapper for reads and writes.
+3. Batch related changes where supported.
+4. Verify created or updated task IDs.
+5. Summarize only the resulting task changes.
+
+## Safety
+
+- Ask before deleting tasks or bulk-moving existing projects.
+- Do not expose task contents outside the active user context.


### PR DESCRIPTION
Linear: ORT-2495

## Summary
- Add 20 SKILL.md stubs from the 2026-08-04 daily discovery pass
- Cover agent memory, codebase navigation, task systems, infrastructure, API design, and workflow orchestration candidates

## Sources
- skills.sh
- sundial-org/awesome-openclaw-skills
- orthogonal-sh/skills current main

## Verification
- git diff --cached --check before commit