### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/accli/SKILL.md
+++ b/skills/accli/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: accli
+description: Use AC CLI workflows for account, command, config, and automation tasks.
+---
+
+# AC CLI
+
+Use when a task involves the `accli` tool or an AC CLI-compatible workflow.
+
+## Workflow
+
+1. Confirm the installed CLI version and authenticated account.
+2. Inspect available commands before executing state-changing actions.
+3. Prefer JSON or machine-readable output when available.
+4. Dry-run commands first when the CLI supports it.
+5. Capture command, result, and follow-up state for repeatability.
+

--- a/skills/affiliatematic/SKILL.md
+++ b/skills/affiliatematic/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: affiliatematic
+description: Research affiliate opportunities, offers, tracking links, payouts, and content fit.
+---
+
+# Affiliatematic
+
+Use when evaluating affiliate programs, matching offers to content, or preparing affiliate campaign assets.
+
+## Workflow
+
+1. Define audience, niche, geography, and acceptable promotion rules.
+2. Compare offers by payout, cookie window, approval rules, brand fit, and restrictions.
+3. Check whether claims need disclaimers or regulated-language review.
+4. Draft assets with clear disclosure language.
+5. Track links, campaign IDs, and performance metrics.
+

--- a/skills/ai-pdf-builder/SKILL.md
+++ b/skills/ai-pdf-builder/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ai-pdf-builder
+description: Create polished PDFs from structured content, templates, charts, and review notes.
+---
+
+# AI PDF Builder
+
+Use when creating PDF reports, briefs, handouts, or formatted exports.
+
+## Workflow
+
+1. Identify the audience, page size, orientation, and brand constraints.
+2. Convert source notes into a clear document outline.
+3. Generate or reuse templates for typography, spacing, tables, and chart placement.
+4. Export a PDF and inspect pagination, links, images, and text overflow.
+5. Keep source files alongside the exported PDF for later edits.
+

--- a/skills/amap/SKILL.md
+++ b/skills/amap/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: amap
+description: Use AMap location services for geocoding, routing, places, maps, and traffic data.
+---
+
+# AMap
+
+Use when a task needs Gaode/AMap geocoding, POI search, routing, or traffic context.
+
+## Workflow
+
+1. Clarify city, language, coordinates, travel mode, and result format.
+2. Use precise geocoding before route or nearby-place lookup.
+3. Preserve coordinate system details to avoid map offsets.
+4. Summarize route time, distance, major constraints, and alternatives.
+5. Redact personal locations unless the user explicitly asks to share them.
+

--- a/skills/anachb/SKILL.md
+++ b/skills/anachb/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: anachb
+description: Query Austrian transit departures, disruptions, station search, and route planning.
+---
+
+# ANACHB
+
+Use when planning or checking Austrian public transit through ANACHB-style data.
+
+## Workflow
+
+1. Identify origin, destination, date, time, and accessibility constraints.
+2. Search stops before requesting departures or journeys.
+3. Compare route options by transfers, walking time, disruptions, and delay risk.
+4. Use local timezone and clearly state departure and arrival times.
+5. Re-check live departures close to travel time.
+

--- a/skills/animation-gen/SKILL.md
+++ b/skills/animation-gen/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: animation-gen
+description: Generate short animations, motion concepts, timing plans, and export-ready assets.
+---
+
+# Animation Generation
+
+Use when creating or planning an animation for product demos, explainers, UI motion, or social clips.
+
+## Workflow
+
+1. Define format, duration, frame size, visual style, and target platform.
+2. Break motion into scenes, keyframes, transitions, and timing.
+3. Generate assets or code in the format best suited to the deliverable.
+4. Preview motion for legibility, pacing, and artifacts.
+5. Export with filenames and settings that make revision easy.
+

--- a/skills/antigravity-balance/SKILL.md
+++ b/skills/antigravity-balance/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: antigravity-balance
+description: Inspect Antigravity usage, quotas, balances, and cost-related account signals.
+---
+
+# Antigravity Balance
+
+Use when checking Antigravity account balance, usage windows, or quota pressure.
+
+## Workflow
+
+1. Identify the configured Antigravity account and workspace.
+2. Fetch balance, plan, usage, reset window, and active limits.
+3. Highlight anything likely to block current work.
+4. Avoid exposing tokens, billing identifiers, or private account details.
+5. Suggest practical usage adjustments when quota is tight.
+

--- a/skills/antigravity-image-gen/SKILL.md
+++ b/skills/antigravity-image-gen/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: antigravity-image-gen
+description: Generate or edit images through Antigravity image workflows with prompt and asset tracking.
+---
+
+# Antigravity Image Generation
+
+Use when creating images with Antigravity-backed tooling.
+
+## Workflow
+
+1. Clarify subject, style, aspect ratio, background, and usage constraints.
+2. Capture reference images and prompt constraints before generation.
+3. Generate small batches and inspect for artifacts, text errors, and brand mismatch.
+4. Track prompt, model, seed, and output filename.
+5. Use transparent or layered formats when downstream editing is expected.
+

--- a/skills/antigravity-quota/SKILL.md
+++ b/skills/antigravity-quota/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: antigravity-quota
+description: Monitor Antigravity quota, reset windows, model limits, and usage planning.
+---
+
+# Antigravity Quota
+
+Use when the user needs to understand or preserve Antigravity capacity.
+
+## Workflow
+
+1. Fetch current quota, reset schedule, plan limits, and recent usage.
+2. Estimate whether the requested work fits available capacity.
+3. Prefer lower-cost workflows for exploration and reserve expensive calls for final runs.
+4. Warn when a task may exhaust the quota window.
+5. Record reset timing and any recommended follow-up.
+

--- a/skills/apple-docs-mcp/SKILL.md
+++ b/skills/apple-docs-mcp/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: apple-docs-mcp
+description: Use an Apple documentation MCP server for symbols, frameworks, samples, and platform notes.
+---
+
+# Apple Docs MCP
+
+Use when Apple platform development needs current documentation through an MCP server.
+
+## Workflow
+
+1. Identify framework, symbol, platform, OS version, and programming language.
+2. Query the Apple docs MCP server for exact docs and related samples.
+3. Check availability, deprecations, and platform-specific behavior.
+4. Summarize implementation details with links or symbol names.
+5. Validate recommendations against local project constraints when possible.
+

--- a/skills/apple-mail-search-2/SKILL.md
+++ b/skills/apple-mail-search-2/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: apple-mail-search-2
+description: Search local Apple Mail stores by sender, subject, body, date, mailbox, and thread context.
+---
+
+# Apple Mail Search 2
+
+Use when the user needs targeted search across local Apple Mail data.
+
+## Workflow
+
+1. Build a narrow query from sender, recipient, subject terms, date range, and mailbox.
+2. Search headers first, then message bodies only when needed.
+3. Summarize only relevant messages and preserve thread ordering.
+4. Avoid exposing unrelated private mail.
+5. Ask before marking, moving, deleting, or replying to messages.
+

--- a/skills/apple-media/SKILL.md
+++ b/skills/apple-media/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: apple-media
+description: Work with local Apple media libraries, playlists, playback metadata, and media search.
+---
+
+# Apple Media
+
+Use when searching or organizing local Apple media such as music, videos, playlists, and playback metadata.
+
+## Workflow
+
+1. Identify the target app, library, playlist, device, and media type.
+2. Search by title, artist, album, date, metadata, and file location.
+3. Confirm before deleting, moving, syncing, or changing library metadata.
+4. Preserve playlists and ratings unless explicitly changed.
+5. Report actions in terms of media items, not private listening history unless requested.
+

--- a/skills/apple-music-2/SKILL.md
+++ b/skills/apple-music-2/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: apple-music-2
+description: Search, play, queue, and organize Apple Music tracks, albums, artists, and playlists.
+---
+
+# Apple Music 2
+
+Use when helping with Apple Music playback, library search, playlist edits, or music queue management.
+
+## Workflow
+
+1. Clarify whether the user wants playback control, search, playlist editing, or library cleanup.
+2. Search exact metadata before acting on similarly named tracks or artists.
+3. Ask before modifying playlists, deleting downloads, or changing library state.
+4. Include track, artist, album, and playlist names in confirmations.
+5. Keep account and listening details private.
+

--- a/skills/audio-gen/SKILL.md
+++ b/skills/audio-gen/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: audio-gen
+description: Generate music, sound effects, voice clips, and audio variations with prompt tracking.
+---
+
+# Audio Generation
+
+Use when creating generated audio such as music beds, sound effects, voice lines, or sonic logos.
+
+## Workflow
+
+1. Define duration, format, voice or instrument style, mood, tempo, and usage rights.
+2. Write prompts with concrete sound, pacing, and production constraints.
+3. Generate short variants before committing to longer renders.
+4. Review for clipping, artifacts, timing, and unwanted speech or noise.
+5. Track prompt, model, settings, and output filenames.
+

--- a/skills/audio-reply/SKILL.md
+++ b/skills/audio-reply/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: audio-reply
+description: Turn replies into concise spoken audio with voice, pacing, and delivery constraints.
+---
+
+# Audio Reply
+
+Use when the user wants a response delivered as audio or a voice note.
+
+## Workflow
+
+1. Decide whether the answer should be spoken, written, or both.
+2. Rewrite for speech with short sentences and clear pacing.
+3. Choose the requested voice, language, and audio format.
+4. Generate and inspect the audio for pronunciation, clipping, and awkward timing.
+5. Keep the written summary short when attaching the final audio.
+

--- a/skills/bearblog/SKILL.md
+++ b/skills/bearblog/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: bearblog
+description: Draft, publish, update, and audit Bear Blog posts with simple Markdown-first workflows.
+---
+
+# Bear Blog
+
+Use when managing Bear Blog content or preparing Markdown posts for a Bear Blog site.
+
+## Workflow
+
+1. Identify the blog, post slug, title, tags, and publication state.
+2. Keep formatting simple and compatible with Bear Blog Markdown.
+3. Check links, images, headings, and metadata before publishing.
+4. Ask before publishing or editing live posts.
+5. Keep a local copy of source text when substantial edits are made.
+

--- a/skills/blucli/SKILL.md
+++ b/skills/blucli/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: blucli
+description: Use Bluetooth CLI workflows for device discovery, pairing, diagnostics, and connection checks.
+---
+
+# Bluetooth CLI
+
+Use when diagnosing or automating Bluetooth device connections from the command line.
+
+## Workflow
+
+1. Identify the host OS, target device, adapter, and pairing state.
+2. Scan for devices and record MAC address, name, RSSI, and service UUIDs.
+3. Diagnose pairing, trust, connection, audio profile, and battery issues.
+4. Ask before forgetting, unpairing, or changing trusted device state.
+5. Summarize final device state and next steps.
+

--- a/skills/brave-images/SKILL.md
+++ b/skills/brave-images/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: brave-images
+description: Search Brave Images for visual references, thumbnails, source pages, and asset candidates.
+---
+
+# Brave Images
+
+Use when an image search should use Brave Image Search or a Brave-compatible image API.
+
+## Workflow
+
+1. Clarify subject, image type, recency, rights constraints, and visual requirements.
+2. Search with specific terms and filter noisy or low-trust results.
+3. Prefer original source pages over copied thumbnails.
+4. Capture title, source, dimensions, and license clues when available.
+5. Do not use copyrighted images as final assets unless usage is clearly allowed.
+

--- a/skills/bridle/SKILL.md
+++ b/skills/bridle/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: bridle
+description: Coordinate Bridle workflows for structured tasks, controls, state, and execution notes.
+---
+
+# Bridle
+
+Use when a task references Bridle or needs a lightweight control layer for repeatable workflows.
+
+## Workflow
+
+1. Identify the workflow name, inputs, expected outputs, and control points.
+2. Inspect existing Bridle configuration before creating new state.
+3. Prefer dry runs and explicit checkpoints for tasks that affect external systems.
+4. Record decisions, parameters, and resulting artifacts.
+5. Keep workflow notes concise enough to reuse on the next run.

--- a/skills/calctl/SKILL.md
+++ b/skills/calctl/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: calctl
+description: Use calendar control workflows for event search, schedule edits, conflicts, and reminders.
+---
+
+# Calctl
+
+Use when a command-line calendar workflow should search, create, update, or inspect events.
+
+## Workflow
+
+1. Confirm target calendar, timezone, and date range.
+2. Search existing events before creating new ones.
+3. Detect conflicts, duplicate holds, travel buffers, and missing attendees.
+4. Ask before changing shared calendars or inviting people.
+5. Summarize final event details with exact dates and times.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the August 5 daily skills discovery batch
- Cover practical integrations, agent operations, accessibility, outbound, Apple local tools, credentials hygiene, and AI media workflows

## Sources
- skills.sh
- sundial-org/awesome-openclaw-skills
- orthogonal-sh/skills current main

## Linear
ORT-2496: https://linear.app/orthogonalsh/issue/ORT-2496/daily-skills-discovery-batch-2026-08-05

## Reviewers
@christianpickettcode @berasogut

## Testing
- git diff --check