### PR TITLE
Add August 7 discovery skill stubs

### DIFF
--- a/skills/create-cli/SKILL.md
+++ b/skills/create-cli/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: create-cli
+description: Design command-line interfaces with arguments, flags, help, and output formats.
+---
+
+# Create CLI
+
+Use this skill when designing or reviewing a command-line interface.
+
+## Capabilities
+
+- Define subcommands, arguments, and flags
+- Design help text and examples
+- Specify exit codes and error messages
+- Choose output formats for humans and automation
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add local CLI design conventions and examples before enabling as a reusable workflow.

--- a/skills/discord-chat/SKILL.md
+++ b/skills/discord-chat/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: discord-chat
+description: Read, send, reply to, and search Discord channel messages.
+---
+
+# Discord Chat
+
+Use this skill when the user asks to interact with Discord channels, messages, or threads.
+
+## Capabilities
+
+- Read recent channel history
+- Search messages by text or author
+- Draft replies for approval
+- Send messages when explicitly authorized
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add the configured Discord tool or CLI details before enabling external sends.

--- a/skills/fabric-api/SKILL.md
+++ b/skills/fabric-api/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: fabric-api
+description: Create and search Fabric resources through the Fabric API.
+---
+
+# Fabric API
+
+Use this skill when the user wants to work with Fabric notepads, folders, bookmarks, files, or related resources.
+
+## Capabilities
+
+- Create Fabric resources
+- Search existing notes and bookmarks
+- Organize resources into folders
+- Retrieve saved context for later work
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add Fabric API authentication, endpoint mapping, and examples before enabling actions.

--- a/skills/faster-whisper/SKILL.md
+++ b/skills/faster-whisper/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: faster-whisper
+description: Run local speech-to-text with faster-whisper.
+---
+
+# Faster Whisper
+
+Use this skill when the user wants local speech-to-text transcription without sending audio to a hosted API.
+
+## Capabilities
+
+- Transcribe local audio and video files
+- Use CPU or GPU acceleration when available
+- Produce readable transcripts
+- Support batch transcription workflows
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add installation, model cache, and command examples before enabling actions.

--- a/skills/imap-smtp-email/SKILL.md
+++ b/skills/imap-smtp-email/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: imap-smtp-email
+description: Read, search, and send email through IMAP and SMTP.
+---
+
+# IMAP SMTP Email
+
+Use this skill when the user wants mailbox access through standard IMAP and SMTP rather than a provider-specific integration.
+
+## Capabilities
+
+- Check unread and recent messages
+- Search mailboxes by sender, subject, date, and body text
+- Fetch message bodies and attachments
+- Send email through SMTP after approval
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add authentication setup, host configuration, and safety rules before enabling sends.

--- a/skills/mineru-pdf/SKILL.md
+++ b/skills/mineru-pdf/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: mineru-pdf
+description: Parse PDFs locally into Markdown, JSON, tables, and extracted assets.
+---
+
+# MinerU PDF
+
+Use this skill when the user needs local PDF parsing with structured output.
+
+## Capabilities
+
+- Convert PDFs to Markdown
+- Extract tables and images
+- Produce JSON output for downstream processing
+- Review parse quality before relying on results
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add MinerU installation and output folder conventions before enabling actions.

--- a/skills/moltbot-security/SKILL.md
+++ b/skills/moltbot-security/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: moltbot-security
+description: Harden Moltbot and OpenClaw gateways, configs, auth, and firewalls.
+---
+
+# Moltbot Security
+
+Use this skill when auditing or hardening Moltbot, Clawdbot, or OpenClaw deployments.
+
+## Capabilities
+
+- Review gateway exposure and auth settings
+- Check file permissions and secret hygiene
+- Recommend firewall and network controls
+- Produce safe, operator-readable remediation steps
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Keep actions read-only until local security policies are added.

--- a/skills/moltguard/SKILL.md
+++ b/skills/moltguard/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: moltguard
+description: Scan emails and webpages for prompt injection, phishing, and malware.
+---
+
+# Moltguard
+
+Use this skill when content from email, web pages, or files should be screened before an agent acts on it.
+
+## Capabilities
+
+- Check for prompt injection markers
+- Flag phishing and social-engineering cues
+- Identify risky links and attachments
+- Return a risk summary with recommended handling
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add scanner commands and thresholds before enabling enforcement.

--- a/skills/morning-email-rollup/SKILL.md
+++ b/skills/morning-email-rollup/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: morning-email-rollup
+description: Produce a morning summary of important email and calendar items.
+---
+
+# Morning Email Rollup
+
+Use this skill for scheduled or on-demand morning briefings that summarize important messages and calendar events.
+
+## Capabilities
+
+- Find urgent or relevant unread email
+- Summarize upcoming calendar items
+- Highlight follow-ups and deadlines
+- Keep output short enough for chat delivery
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add mailbox, calendar, and scheduling integrations before enabling automation.

--- a/skills/newsletter-digest/SKILL.md
+++ b/skills/newsletter-digest/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: newsletter-digest
+description: Summarize newsletters and articles into insights and reading lists.
+---
+
+# Newsletter Digest
+
+Use this skill when the user wants newsletters, long articles, or reading queues condensed into useful summaries.
+
+## Capabilities
+
+- Summarize long newsletter issues
+- Extract links, companies, and topics
+- Build prioritized reading lists
+- Track recurring themes over time
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add inbox or RSS source configuration before enabling scheduled digests.

--- a/skills/openai-whisper-api/SKILL.md
+++ b/skills/openai-whisper-api/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: openai-whisper-api
+description: Transcribe audio files through the OpenAI Whisper transcription API.
+---
+
+# OpenAI Whisper API
+
+Use this skill when the user wants audio transcribed through OpenAI's audio transcription endpoint.
+
+## Capabilities
+
+- Transcribe local audio files
+- Return plain text or timestamp-aware output
+- Handle common audio formats
+- Prepare transcript summaries after transcription
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add the current OpenAI audio API command and model selection guidance before enabling actions.

--- a/skills/openclaw-feeds/SKILL.md
+++ b/skills/openclaw-feeds/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: openclaw-feeds
+description: Fetch and summarize curated RSS feeds for news, games, and finance.
+---
+
+# OpenClaw Feeds
+
+Use this skill when the user asks for a quick feed digest, latest headlines, or category-specific RSS summary.
+
+## Capabilities
+
+- Fetch curated RSS feeds
+- Group headlines by category
+- Deduplicate repeated stories
+- Summarize notable items concisely
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add feed lists and fetch commands before enabling scheduled digests.

--- a/skills/otter/SKILL.md
+++ b/skills/otter/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: otter
+description: List, search, download, and sync Otter.ai meeting transcripts.
+---
+
+# Otter.ai Transcription
+
+Use this skill when the user wants to find or summarize meeting transcripts stored in Otter.ai.
+
+## Capabilities
+
+- List available transcripts
+- Search transcript text
+- Download transcript exports
+- Summarize action items and decisions
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add Otter authentication and export commands before enabling actions.

--- a/skills/prompt-defense/SKILL.md
+++ b/skills/prompt-defense/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: prompt-defense
+description: Detect prompt injection and phishing patterns in emails and pages.
+---
+
+# Prompt Defense
+
+Use this skill when processing untrusted email, webpages, documents, or copied instructions that may contain prompt injection attempts.
+
+## Capabilities
+
+- Flag instructions that pretend to override system rules
+- Detect suspicious credential or exfiltration requests
+- Separate user-visible content from agent instructions
+- Recommend safe handling steps
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add detection rules, test cases, and escalation policy before enabling automatic blocking.

--- a/skills/reflect-2/SKILL.md
+++ b/skills/reflect-2/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: reflect-2
+description: Capture notes, thoughts, todos, and daily entries in Reflect.
+---
+
+# Reflect Notes
+
+Use this skill when the user wants to capture, append, or organize information in Reflect notes, including daily notes, todos, meeting notes, and lightweight knowledge graph updates.
+
+## Capabilities
+
+- Append entries to daily notes
+- Create new notes from structured text
+- Capture todos, links, and references
+- Keep note updates concise and searchable
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add the local Reflect integration details before enabling actions.

--- a/skills/swagger-gen/SKILL.md
+++ b/skills/swagger-gen/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: swagger-gen
+description: Generate OpenAPI specifications from application routes.
+---
+
+# Swagger Generator
+
+Use this skill when the user wants an OpenAPI or Swagger spec generated from code, especially Express-style route definitions.
+
+## Capabilities
+
+- Inspect route files
+- Infer endpoints, methods, parameters, and response shapes
+- Generate an OpenAPI document
+- Flag missing schemas and ambiguous handlers
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add framework-specific parsers and validation commands before enabling generation.

--- a/skills/video-transcript-downloader/SKILL.md
+++ b/skills/video-transcript-downloader/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: video-transcript-downloader
+description: Download videos, audio, subtitles, and clean transcripts.
+---
+
+# Video Transcript Downloader
+
+Use this skill when the user asks to download a video transcript, extract subtitles, or create a readable transcript from online media.
+
+## Capabilities
+
+- Download subtitles when available
+- Extract audio for transcription
+- Produce paragraph-style transcripts
+- Preserve source URLs and metadata
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add yt-dlp and transcription workflow details before enabling actions.

--- a/skills/web-deploy-github/SKILL.md
+++ b/skills/web-deploy-github/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: web-deploy-github
+description: Build and deploy single-page static websites to GitHub Pages.
+---
+
+# Web Deploy GitHub Pages
+
+Use this skill when the user wants to create, update, and publish a small static website or landing page through GitHub Pages.
+
+## Capabilities
+
+- Create single-page static sites
+- Prepare GitHub Pages deployment branches
+- Update page assets and metadata
+- Verify published site URLs
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add repo conventions and deployment commands before enabling actions.

--- a/skills/web-qa-bot/SKILL.md
+++ b/skills/web-qa-bot/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: web-qa-bot
+description: Run accessibility-tree based QA checks for web applications.
+---
+
+# Web QA Bot
+
+Use this skill when the user wants smoke tests, flow checks, or QA reports for a web application.
+
+## Capabilities
+
+- Explore pages through accessibility snapshots
+- Run smoke tests against critical flows
+- Capture failures with reproducible steps
+- Produce concise QA reports
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add browser automation tooling and report format before enabling actions.

--- a/skills/xai-search/SKILL.md
+++ b/skills/xai-search/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: xai-search
+description: Search X and the web in real time through xAI Grok APIs.
+---
+
+# xAI Search
+
+Use this skill when the user needs current X/Twitter or web search results through xAI's search-capable Grok APIs.
+
+## Capabilities
+
+- Search recent X posts and web results
+- Summarize social discussion with links
+- Compare web and social evidence
+- Use freshness-focused queries for current events
+
+## Implementation Notes
+
+Stub discovered from the OpenClaw skills ecosystem. Add API authentication, endpoints, and citation formatting before enabling actions.


### PR DESCRIPTION
## Summary
- Add 20 August 7 discovery skill stubs from skills.sh and sundial-org/awesome-openclaw-skills
- Focus on agent security, transcription, feeds, Discord/email workflows, CLI design, PDF parsing, and web QA
- Avoid previously posted discovery picks from memory/discovery-posts.md and current skills on main

Linear: ORT-2507

## Verification
- Confirmed all 20 `SKILL.md` files exist
- Scanned new stubs for disallowed dash characters
- Compared selected skill names against `memory/discovery-posts.md` and existing repo skill directories

Reviewers: @christianpickettcode @berasogut
