### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/app-store-changelog/SKILL.md
+++ b/skills/app-store-changelog/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: app-store-changelog
+description: Create App Store release notes from git history, tags, merged PRs, and user-facing changes.
+---
+
+# App Store Changelog
+
+Use this skill when preparing App Store, TestFlight, or mobile release notes.
+
+## Workflow
+
+1. Identify the previous release tag, build number, or supplied comparison ref.
+2. Review commits, merged PRs, issue links, and existing changelog entries.
+3. Keep only user-visible changes, bug fixes, performance work, and compatibility updates.
+4. Group items into concise release-note bullets.
+5. Remove internal implementation detail, ticket IDs, and sensitive context.
+
+## Output
+
+Provide a short release note suitable for App Store Connect, plus an optional longer internal summary.

--- a/skills/arxiv-watcher/SKILL.md
+++ b/skills/arxiv-watcher/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: arxiv-watcher
+description: Search, filter, and summarize recent arXiv papers for a topic or daily research digest.
+---
+
+# ArXiv Watcher
+
+Use this skill when the user asks for recent papers, research monitoring, or a digest from arXiv.
+
+## Workflow
+
+1. Convert the topic into arXiv categories, keywords, authors, or date ranges.
+2. Search arXiv and rank papers by relevance, recency, venue signals, and citations when available.
+3. Read abstracts and, when needed, paper PDFs.
+4. Summarize contributions, methods, limitations, and practical relevance.
+5. Include links, publication dates, and caveats about preliminary results.
+
+## Output
+
+Prefer a short ranked digest with why each paper matters.

--- a/skills/coolify/SKILL.md
+++ b/skills/coolify/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: coolify
+description: Manage Coolify apps, services, deployments, databases, domains, and logs.
+---
+
+# Coolify
+
+Use this skill for deployment and operations tasks on Coolify.
+
+## Workflow
+
+1. Identify the Coolify project, resource, environment, branch, domain, and deployment target.
+2. Check current deployment status, logs, build output, health checks, and linked services.
+3. Verify required secrets and environment variables without exposing values.
+4. Trigger deployment, restart, or configuration changes only when appropriate.
+5. Summarize result, endpoint status, and rollback path.
+
+## Guardrails
+
+Do not reveal secrets from Coolify configuration.

--- a/skills/deepwiki/SKILL.md
+++ b/skills/deepwiki/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: deepwiki
+description: Query DeepWiki-style repository docs for architecture, API, and codebase questions.
+---
+
+# DeepWiki
+
+Use this skill when answering questions about an open-source repository that has generated wiki documentation.
+
+## Workflow
+
+1. Identify the target repository and the question being asked.
+2. Search the generated wiki pages for relevant architecture, setup, API, and module notes.
+3. Cross-check important claims against repository source files when possible.
+4. Explain findings with file, symbol, or documentation references.
+5. Call out stale or missing wiki coverage instead of guessing.
+
+## Output
+
+Return a direct answer first, then supporting references.

--- a/skills/docker-essentials/SKILL.md
+++ b/skills/docker-essentials/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: docker-essentials
+description: Docker build, run, compose, image, volume, network, and container debugging workflows.
+---
+
+# Docker Essentials
+
+Use this skill for practical Docker tasks and troubleshooting.
+
+## Workflow
+
+1. Inspect `Dockerfile`, compose files, env requirements, volumes, and exposed ports.
+2. Build or run the smallest target needed to reproduce the task.
+3. Use `docker ps`, logs, inspect, exec, network, and volume commands to diagnose issues.
+4. Keep changes limited to Docker-related config unless the app itself is broken.
+5. Document exact commands and verification results.
+
+## Guardrails
+
+Avoid removing images, volumes, or containers unless the user asked for cleanup.

--- a/skills/github-pr/SKILL.md
+++ b/skills/github-pr/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: github-pr
+description: Fetch, inspect, test, and apply GitHub pull requests locally before merge.
+---
+
+# GitHub PR Tool
+
+Use this skill when evaluating a pull request from GitHub.
+
+## Workflow
+
+1. Fetch PR metadata, diff, comments, checks, and changed files with `gh`.
+2. Create or reuse a local branch or worktree for the PR.
+3. Install only the dependencies required by the repo.
+4. Run focused tests, linters, type checks, or manual verification steps.
+5. Summarize risks, failures, and suggested fixes before approval or merge.
+
+## Guardrails
+
+Do not merge PRs unless explicitly asked. Preserve unrelated local changes.

--- a/skills/hn-digest/SKILL.md
+++ b/skills/hn-digest/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: hn-digest
+description: Fetch, filter, and summarize Hacker News stories, comments, trends, and topic threads.
+---
+
+# HN Digest
+
+Use this skill when the user asks for Hacker News stories, comments, trends, or a topic digest.
+
+## Workflow
+
+1. Fetch front page, newest, best, ask, show, jobs, or search results as requested.
+2. Filter by topic, score, age, author, comment count, or relevance.
+3. Read top comments when the discussion quality matters.
+4. Summarize key links, discussion themes, and practical takeaways.
+5. Include direct story and comment links.
+
+## Output
+
+Prefer a ranked list with title, score, comment count, and one-sentence why it matters.

--- a/skills/mactop/SKILL.md
+++ b/skills/mactop/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: mactop
+description: Inspect Apple Silicon CPU, GPU, memory, thermal, power, network, and disk metrics with mactop.
+---
+
+# mactop
+
+Use this skill when diagnosing local Apple Silicon performance or hardware pressure.
+
+## Workflow
+
+1. Confirm the symptom, process, workload, and time window.
+2. Run or parse `mactop` metrics in a machine-readable format when available.
+3. Review CPU, GPU, ANE, memory pressure, swap, thermal state, power, and IO.
+4. Correlate spikes with processes or workload phases.
+5. Recommend focused mitigations or deeper profiling.
+
+## Output
+
+Return a concise hardware health summary with any notable limits or bottlenecks.

--- a/skills/meeting-prep/SKILL.md
+++ b/skills/meeting-prep/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: meeting-prep
+description: Prepare meeting briefs from calendar events, attendees, recent docs, and repo activity.
+---
+
+# Meeting Prep
+
+Use this skill before meetings, calls, standups, and customer conversations.
+
+## Workflow
+
+1. Identify the meeting time, title, attendees, agenda, and linked docs.
+2. Gather relevant recent work from notes, email, GitHub, Linear, Slack, or project files.
+3. Summarize context, decisions needed, likely questions, and open follow-ups.
+4. Prepare a concise talking-points list and any useful links.
+5. Respect privacy boundaries for attendees and channels.
+
+## Output
+
+Return a brief with context, agenda, questions, and suggested next actions.

--- a/skills/n8n-automation/SKILL.md
+++ b/skills/n8n-automation/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: n8n-automation
+description: Inspect, trigger, debug, and document n8n workflows, credentials, executions, and webhooks.
+---
+
+# n8n Automation
+
+Use this skill when working with n8n workflows or automation runs.
+
+## Workflow
+
+1. Identify the n8n instance, workflow, trigger, execution ID, and intended outcome.
+2. Inspect workflow nodes, credentials references, recent executions, and error output.
+3. Reproduce with a manual trigger or test payload when safe.
+4. Propose node-level fixes, retries, or observability improvements.
+5. Document workflow purpose, inputs, outputs, and failure modes.
+
+## Guardrails
+
+Never expose credential values. Ask before activating workflows that affect external systems.

--- a/skills/native-app-performance/SKILL.md
+++ b/skills/native-app-performance/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: native-app-performance
+description: Profile macOS and iOS apps with xctrace, Instruments exports, symbols, and performance reports.
+---
+
+# Native App Performance
+
+Use this skill for macOS or iOS app performance profiling.
+
+## Workflow
+
+1. Identify the app, build configuration, device, scenario, and performance symptom.
+2. Capture traces with appropriate Instruments templates such as Time Profiler or Allocations.
+3. Export traces and inspect hot paths, main-thread stalls, memory growth, and IO.
+4. Map findings to source symbols and propose focused changes.
+5. Re-run the scenario to compare before and after results.
+
+## Output
+
+Report the bottleneck, evidence, recommended fix, and verification data.

--- a/skills/parcel-package-tracking/SKILL.md
+++ b/skills/parcel-package-tracking/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: parcel-package-tracking
+description: Track shipments, carriers, delivery events, and package status across parcel APIs.
+---
+
+# Parcel Package Tracking
+
+Use this skill when tracking package deliveries or building shipment notifications.
+
+## Workflow
+
+1. Collect tracking number, carrier if known, destination region, and desired notification rules.
+2. Query the configured tracking provider or carrier API.
+3. Normalize events into status, location, timestamp, carrier, and estimated delivery.
+4. Highlight exceptions, failed delivery attempts, customs holds, and stale scans.
+5. Suggest next action when a delivery needs attention.
+
+## Guardrails
+
+Do not expose full delivery addresses unless necessary.

--- a/skills/pinch-to-post/SKILL.md
+++ b/skills/pinch-to-post/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: pinch-to-post
+description: Automate WordPress and WooCommerce posts, pages, media, products, orders, and SEO fields.
+---
+
+# Pinch To Post
+
+Use this skill when managing WordPress or WooCommerce content programmatically.
+
+## Workflow
+
+1. Confirm the site, auth method, content type, and publication state.
+2. Draft or transform content using the site's voice and metadata requirements.
+3. Upload media, set alt text, categories, tags, slugs, excerpts, and SEO fields.
+4. Preview or create drafts before publishing when possible.
+5. Verify the final URL, status, and rendered content.
+
+## Guardrails
+
+Ask before publishing public content unless the user explicitly requested publication.

--- a/skills/portable-tools/SKILL.md
+++ b/skills/portable-tools/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: portable-tools
+description: Build scripts and tools that run across machines without hardcoded paths or accounts.
+---
+
+# Portable Tools
+
+Use this skill when creating automation intended to work across devices, repos, or user accounts.
+
+## Workflow
+
+1. Identify all machine-specific paths, usernames, ports, services, and credentials.
+2. Replace hardcoded assumptions with environment variables, config files, discovery, or flags.
+3. Use XDG, platform, and shell conventions where appropriate.
+4. Add helpful errors for missing dependencies.
+5. Test from a clean working directory or alternate account shape when practical.
+
+## Output
+
+Document required config, defaults, and portability limits.

--- a/skills/portainer/SKILL.md
+++ b/skills/portainer/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: portainer
+description: Manage Portainer environments, stacks, containers, logs, redeploys, and status checks.
+---
+
+# Portainer
+
+Use this skill when working with Docker or Kubernetes environments managed through Portainer.
+
+## Workflow
+
+1. Confirm the Portainer endpoint, environment, stack, and access method.
+2. Inspect containers, stacks, images, volumes, networks, and recent logs.
+3. For redeploys, verify source repo, compose file, environment variables, and image tags.
+4. Apply the smallest operation needed, such as restart, pull, redeploy, or log review.
+5. Report status, changed resources, and rollback considerations.
+
+## Guardrails
+
+Ask before destructive stack, container, or volume operations.

--- a/skills/read-github/SKILL.md
+++ b/skills/read-github/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: read-github
+description: Read GitHub repositories through clone, sparse checkout, raw files, or semantic repo docs.
+---
+
+# Read GitHub
+
+Use this skill when the user asks to inspect a GitHub repository.
+
+## Workflow
+
+1. Identify the repo, branch, paths, and question.
+2. Prefer `gh`, `git clone --depth 1`, sparse checkout, or raw file fetches over search snippets.
+3. Read README, package manifests, docs, tests, and the relevant source files.
+4. Use `rg` for symbols and behavior paths.
+5. Answer with concrete file references and note any unverified assumptions.
+
+## Guardrails
+
+Do not run untrusted repo code until dependencies and scripts have been inspected.

--- a/skills/searxng/SKILL.md
+++ b/skills/searxng/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: searxng
+description: Search the web, news, images, and files through a SearXNG metasearch instance.
+---
+
+# SearXNG
+
+Use this skill when the user wants privacy-respecting metasearch or a self-hosted search backend.
+
+## Workflow
+
+1. Confirm the SearXNG base URL and available result categories.
+2. Query with precise terms, language, freshness, and safe-search settings when supported.
+3. Prefer source pages over snippets for important claims.
+4. Deduplicate mirrors, SEO spam, and low-quality aggregator pages.
+5. Return cited findings or a compact result list with URLs.
+
+## Notes
+
+Respect instance rate limits and avoid sending private data in search queries.

--- a/skills/servicenow-agent/SKILL.md
+++ b/skills/servicenow-agent/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: servicenow-agent
+description: Read ServiceNow tables, attachments, catalog items, schemas, incidents, and change records.
+---
+
+# ServiceNow Agent
+
+Use this skill for read-oriented ServiceNow research and ticket workflows.
+
+## Workflow
+
+1. Identify the ServiceNow instance, table, record, query, or catalog item.
+2. Use API filters, pagination, and selected fields to avoid oversized responses.
+3. Inspect schema and reference fields before building queries.
+4. Summarize records, history, attachments, ownership, and next steps.
+5. Link back to records when available.
+
+## Guardrails
+
+Ask before creating or modifying incidents, changes, requests, or catalog submissions.

--- a/skills/sql-gen/SKILL.md
+++ b/skills/sql-gen/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: sql-gen
+description: Generate, explain, and validate SQL queries from schema, requirements, and examples.
+---
+
+# SQL Query Generator
+
+Use this skill when the user needs SQL written or explained.
+
+## Workflow
+
+1. Gather dialect, schema, table relationships, sample rows, and desired output.
+2. Write the query with explicit columns, joins, filters, grouping, and ordering.
+3. Explain assumptions and edge cases.
+4. Provide indexes or performance notes when the query may be expensive.
+5. If execution is available and safe, validate against test data.
+
+## Guardrails
+
+Do not access production databases directly unless explicitly allowed in the environment instructions.

--- a/skills/track17/SKILL.md
+++ b/skills/track17/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: track17
+description: Track parcels through 17TRACK, persist shipment state, poll updates, and handle webhooks.
+---
+
+# 17TRACK Package Tracking
+
+Use this skill when tracking shipments through 17TRACK or normalizing logistics events.
+
+## Workflow
+
+1. Collect tracking number, carrier hint, title, and notification preference.
+2. Register or query the shipment through 17TRACK.
+3. Store normalized checkpoints with status, location, timestamp, and carrier.
+4. Poll or process webhook updates for delivery changes.
+5. Flag exceptions, stale shipments, and delivery-complete events.
+
+## Guardrails
+
+Keep tracking numbers and delivery metadata private unless the user asks to share them.


### PR DESCRIPTION
Linear: ORT-2512

## Summary
- Add 20 discovered skill stubs from the 2026-08-08 daily skills discovery run.
- Keep each addition scoped to a simple SKILL.md with metadata, workflow notes, and guardrails.

## Sources
- skills.sh
- sundial-org/awesome-openclaw-skills
- orthogonal-sh/skills current main

## Test Plan
- Verified all 20 new SKILL.md files exist under skills/<name>/.
- Confirmed no selected skill directory already existed on main.