### PR TITLE
Add August 9 discovery skill stubs

### DIFF
--- a/skills/better-accessibility/SKILL.md
+++ b/skills/better-accessibility/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: better-accessibility
+description: Improve accessibility for web and app interfaces, including semantics, keyboard flow, contrast, and motion.
+---
+
+# Better Accessibility
+
+Use this skill when auditing or improving accessibility in a user interface.
+
+## Workflow
+
+- Check semantic structure, labels, focus order, keyboard support, contrast, touch targets, and reduced-motion behavior.
+- Prefer native elements and established accessibility patterns before custom interactions.
+- Verify critical flows with automated checks and manual keyboard navigation when possible.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/better-auth-security-best-practices/SKILL.md
+++ b/skills/better-auth-security-best-practices/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: better-auth-security-best-practices
+description: Review Better Auth integrations for secure session, OAuth, credential, and deployment configuration.
+---
+
+# Better Auth Security Best Practices
+
+Use this skill when implementing or auditing Better Auth in an application.
+
+## Workflow
+
+- Check secret management, trusted origins, cookies, session expiration, adapter configuration, and provider callbacks.
+- Review account linking, email verification, password reset, MFA, and OAuth edge cases.
+- Verify production settings differ from local development settings where required.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/better-interface/SKILL.md
+++ b/skills/better-interface/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: better-interface
+description: Improve product interfaces for clarity, hierarchy, scanning, ergonomics, and visual restraint.
+---
+
+# Better Interface
+
+Use this skill when asked to make an interface easier to understand or more professional.
+
+## Workflow
+
+- Identify the primary workflow, decision points, density needs, and visual hierarchy.
+- Improve layout, spacing, labels, controls, states, and affordances while respecting the existing design system.
+- Check that the final UI works on small and large viewports without overlapping or oversized text.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/better-layout/SKILL.md
+++ b/skills/better-layout/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: better-layout
+description: Improve UI layout systems, spacing, responsive constraints, density, alignment, and visual hierarchy.
+---
+
+# Better Layout
+
+Use this skill when a screen feels cramped, sparse, misaligned, or fragile across viewport sizes.
+
+## Workflow
+
+- Identify the content model, primary task, scan path, and responsive breakpoints.
+- Use stable layout primitives, clear spacing scales, and predictable alignment.
+- Check small, medium, and wide viewports for overlap, awkward wrapping, and inefficient use of space.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/better-writing/SKILL.md
+++ b/skills/better-writing/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: better-writing
+description: Rewrite product, technical, or explanatory text so it is clearer, shorter, and more useful.
+---
+
+# Better Writing
+
+Use this skill when improving copy, documentation, emails, product text, or explanations.
+
+## Workflow
+
+- Preserve the intended meaning and audience while removing filler, ambiguity, and inflated phrasing.
+- Prefer concrete nouns, active verbs, and examples where they reduce confusion.
+- Keep the result natural for the surface, whether it is UI copy, docs, outreach, or internal notes.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/convex-auth/SKILL.md
+++ b/skills/convex-auth/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: convex-auth
+description: Implement and troubleshoot authentication flows in Convex-backed applications.
+---
+
+# Convex Auth
+
+Use this skill when adding or reviewing auth in a Convex application.
+
+## Workflow
+
+- Identify the auth provider, session model, user document mapping, and client/server trust boundaries.
+- Check route protection, mutation authorization, onboarding, account linking, and sign-out behavior.
+- Keep user identity and permissions validated on the server side.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/convex-authz/SKILL.md
+++ b/skills/convex-authz/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: convex-authz
+description: Design and audit authorization rules for Convex data, functions, teams, roles, and ownership checks.
+---
+
+# Convex Authz
+
+Use this skill when implementing permissions or access control in a Convex application.
+
+## Workflow
+
+- Map actors, resources, roles, ownership, teams, and public versus private data.
+- Enforce authorization inside queries, mutations, and actions rather than only in the UI.
+- Add tests or fixtures covering allowed, denied, cross-tenant, and unauthenticated cases.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/convex-optimize/SKILL.md
+++ b/skills/convex-optimize/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: convex-optimize
+description: Optimize Convex apps for query performance, indexes, pagination, caching, and mutation patterns.
+---
+
+# Convex Optimize
+
+Use this skill when a Convex app has slow queries, high read volume, or unclear data access patterns.
+
+## Workflow
+
+- Review schema, indexes, query filters, pagination, subscriptions, mutations, and derived data.
+- Prefer indexed access paths and smaller reactive query surfaces.
+- Verify performance-sensitive changes with representative data and realistic user flows.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/email-and-password-best-practices/SKILL.md
+++ b/skills/email-and-password-best-practices/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: email-and-password-best-practices
+description: Implement email and password authentication flows with secure defaults and usable account recovery.
+---
+
+# Email And Password Best Practices
+
+Use this skill when designing, reviewing, or implementing email and password auth.
+
+## Workflow
+
+- Check signup, login, password reset, email verification, rate limiting, session handling, and error messages.
+- Avoid user enumeration, weak password storage, unsafe reset tokens, and confusing recovery flows.
+- Recommend secure defaults that fit the app's auth provider and threat model.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/firebase-ai-logic-basics/SKILL.md
+++ b/skills/firebase-ai-logic-basics/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: firebase-ai-logic-basics
+description: Use Firebase AI Logic for app-facing generative AI features with provider, safety, and telemetry awareness.
+---
+
+# Firebase AI Logic Basics
+
+Use this skill when adding Firebase AI Logic to mobile or web apps.
+
+## Workflow
+
+- Identify the client platform, model provider, prompt shape, safety requirements, and latency constraints.
+- Keep secrets and privileged operations out of client code.
+- Add logging, error handling, rate limits, and fallback behavior for production use.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/firebase-basics/SKILL.md
+++ b/skills/firebase-basics/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: firebase-basics
+description: Set up and troubleshoot Firebase projects, SDKs, hosting, auth, database, storage, and local emulators.
+---
+
+# Firebase Basics
+
+Use this skill when starting or debugging a Firebase-backed application.
+
+## Workflow
+
+- Identify the Firebase products in use and the target platforms.
+- Check SDK initialization, environment separation, emulator setup, deployment commands, and access rules.
+- Keep configuration, billing, and production safety visible before recommending changes.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/firebase-firestore/SKILL.md
+++ b/skills/firebase-firestore/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: firebase-firestore
+description: Design, query, secure, and troubleshoot Cloud Firestore data models and application access patterns.
+---
+
+# Firebase Firestore
+
+Use this skill when working with Cloud Firestore collections, documents, queries, indexes, or security rules.
+
+## Workflow
+
+- Model data around read patterns, document size limits, indexing needs, and offline behavior.
+- Check rule coverage, query constraints, pagination, batched writes, transactions, and listener costs.
+- Recommend emulator tests for rules and data access changes.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/firebase-security-rules-auditor/SKILL.md
+++ b/skills/firebase-security-rules-auditor/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: firebase-security-rules-auditor
+description: Audit Firebase security rules for Firestore, Realtime Database, and Storage access control mistakes.
+---
+
+# Firebase Security Rules Auditor
+
+Use this skill when reviewing Firebase security rules or diagnosing authorization behavior.
+
+## Workflow
+
+- Map authenticated and unauthenticated access by collection, path, method, role, and ownership checks.
+- Look for broad reads, broad writes, bypassable role fields, missing validation, and rule/query mismatches.
+- Recommend emulator tests that prove both allowed and denied cases.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/imagegen-frontend-web/SKILL.md
+++ b/skills/imagegen-frontend-web/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: imagegen-frontend-web
+description: Create frontend-ready image prompts and asset specs for landing pages, apps, icons, and visual systems.
+---
+
+# Imagegen Frontend Web
+
+Use this skill when a frontend needs generated bitmap assets, art direction, or promptable visual references.
+
+## Workflow
+
+- Translate product context into image prompts with composition, aspect ratio, lighting, subject, and usage constraints.
+- Produce variants for hero media, empty states, thumbnails, app imagery, or social previews.
+- Keep assets inspectable, on-brand, and responsive to the actual UI surface they will occupy.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/interface-review/SKILL.md
+++ b/skills/interface-review/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: interface-review
+description: Review UI screens for usability, consistency, accessibility, responsive behavior, and implementation risk.
+---
+
+# Interface Review
+
+Use this skill when reviewing an existing interface or proposed screen.
+
+## Workflow
+
+- Evaluate workflow fit, information hierarchy, control choice, empty states, loading states, and errors.
+- Call out concrete issues with screenshots, file references, or component names when available.
+- Prioritize fixes by user impact and implementation effort.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/next-cache-components-optimizer/SKILL.md
+++ b/skills/next-cache-components-optimizer/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: next-cache-components-optimizer
+description: Optimize Next.js cache components, revalidation, fetch caching, and rendering boundaries.
+---
+
+# Next Cache Components Optimizer
+
+Use this skill when a Next.js app has slow pages, stale data, over-rendering, or confusing cache behavior.
+
+## Workflow
+
+- Map route rendering modes, server components, client boundaries, fetch calls, tags, and revalidation needs.
+- Prefer narrow cache scopes and explicit invalidation over broad dynamic rendering.
+- Verify behavior with builds, route inspection, and user-facing freshness requirements.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/pick-ui-library/SKILL.md
+++ b/skills/pick-ui-library/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: pick-ui-library
+description: Choose frontend UI libraries by stack, design goals, accessibility, maintenance, and implementation constraints.
+---
+
+# Pick UI Library
+
+Use this skill when choosing a UI component library or design system for a frontend project.
+
+## Workflow
+
+- Identify the app framework, styling system, accessibility needs, theming requirements, and team preferences.
+- Compare realistic library options by fit, bundle impact, component coverage, customization model, and maintenance signals.
+- Recommend one default choice plus one fallback, with migration notes when replacing an existing library.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/recon-a-domain-passively/SKILL.md
+++ b/skills/recon-a-domain-passively/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: recon-a-domain-passively
+description: Perform passive domain reconnaissance using public sources without touching target infrastructure.
+---
+
+# Recon A Domain Passively
+
+Use this skill when collecting public intelligence about a domain without active scanning.
+
+## Workflow
+
+- Gather DNS, certificate transparency, WHOIS, technology, archive, search, and public repository signals.
+- Avoid intrusive requests, vulnerability probing, login attempts, or traffic that would look like active scanning.
+- Summarize exposed assets, likely vendors, public risks, and follow-up questions for authorized testing.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/review-animations/SKILL.md
+++ b/skills/review-animations/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: review-animations
+description: Review UI animations for clarity, performance, accessibility, timing, and interaction polish.
+---
+
+# Review Animations
+
+Use this skill when reviewing or improving animations in a web or app UI.
+
+## Workflow
+
+- Inspect whether motion clarifies state changes, hierarchy, and user intent.
+- Check reduced-motion handling, layout stability, frame budget, and interaction latency.
+- Suggest concrete timing, easing, and implementation changes without adding decorative motion for its own sake.
+
+## Source
+
+Discovered from the current skills.sh hot list.

--- a/skills/vercel-react-view-transitions/SKILL.md
+++ b/skills/vercel-react-view-transitions/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: vercel-react-view-transitions
+description: Add and review React view transitions for Vercel apps with routing, accessibility, and performance in mind.
+---
+
+# Vercel React View Transitions
+
+Use this skill when adding or tuning page and component transitions in React applications deployed on Vercel.
+
+## Workflow
+
+- Identify route boundaries, layout persistence, suspense boundaries, and shared elements.
+- Keep transitions fast, interruptible, and respectful of reduced-motion preferences.
+- Verify that motion does not mask loading problems or break navigation semantics.
+
+## Source
+
+Discovered from the current skills.sh hot list.


### PR DESCRIPTION
## Summary
- Add 20 fresh SKILL.md stubs from the daily skills discovery run
- Focus on frontend review, auth, Firebase, Convex, Vercel, image generation, and passive domain recon workflows
- Checked against memory/discovery-posts.md and current skills directories to avoid repeats

Linear: ORT-2521

## Test plan
- Validated all 20 new SKILL.md files include frontmatter and source sections

Sources: skills.sh hot list, sundial-org/awesome-openclaw-skills, orthogonal-sh/skills current main