### PR TITLE
Add August 11 discovery skill stubs

### DIFF
--- a/skills/auto-updater/SKILL.md
+++ b/skills/auto-updater/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: auto-updater
+description: Check installed agents, tools, and skills for updates and produce a safe update plan.
+---
+
+# Auto-Updater
+
+Check installed agents, tools, and skills for updates and produce a safe update plan.
+
+## When to Use
+
+Use when asked to update skills, audit installed versions, prepare a daily update summary, or schedule routine update checks.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills and skills.sh: auto-updater.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/component-gen/SKILL.md
+++ b/skills/component-gen/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: component-gen
+description: Generate frontend components from natural-language requirements while matching the target framework.
+---
+
+# Component Generator
+
+Generate frontend components from natural-language requirements while matching the target framework.
+
+## When to Use
+
+Use when asked to create React, Vue, Svelte, or similar UI components from a concise spec.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: component-gen.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/cron-gen/SKILL.md
+++ b/skills/cron-gen/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: cron-gen
+description: Turn natural-language schedules into cron expressions with timezone and edge-case notes.
+---
+
+# Cron Generator
+
+Turn natural-language schedules into cron expressions with timezone and edge-case notes.
+
+## When to Use
+
+Use when asked to create, explain, validate, or compare cron schedules.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: cron-gen.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/excalidraw-flowchart/SKILL.md
+++ b/skills/excalidraw-flowchart/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: excalidraw-flowchart
+description: Create Excalidraw diagrams and flowcharts from written descriptions.
+---
+
+# Excalidraw Flowchart
+
+Create Excalidraw diagrams and flowcharts from written descriptions.
+
+## When to Use
+
+Use when asked to draw a flowchart, architecture sketch, process diagram, or editable Excalidraw scene.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: excalidraw-flowchart.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/feishu-bridge/SKILL.md
+++ b/skills/feishu-bridge/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: feishu-bridge
+description: Set up and troubleshoot Feishu/Lark bot bridges for OpenClaw-style agent messaging.
+---
+
+# Feishu Bridge
+
+Set up and troubleshoot Feishu/Lark bot bridges for OpenClaw-style agent messaging.
+
+## When to Use
+
+Use when asked to connect Feishu or Lark, debug bot delivery, verify webhook settings, or explain bridge setup.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: feishu-bridge.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/glab/SKILL.md
+++ b/skills/glab/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: glab
+description: Manage GitLab issues, merge requests, pipelines, and repositories through the glab CLI.
+---
+
+# GitLab CLI
+
+Manage GitLab issues, merge requests, pipelines, and repositories through the glab CLI.
+
+## When to Use
+
+Use when asked to work with GitLab MRs, CI/CD pipelines, issues, releases, or repository metadata.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: glab.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/google-chat/SKILL.md
+++ b/skills/google-chat/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: google-chat
+description: Send Google Chat notifications and work with spaces through webhooks or OAuth.
+---
+
+# Google Chat
+
+Send Google Chat notifications and work with spaces through webhooks or OAuth.
+
+## When to Use
+
+Use when asked to notify a Google Chat space, draft a Chat message, or automate Chat-based status updates.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: google-chat.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/instruments-profiling/SKILL.md
+++ b/skills/instruments-profiling/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: instruments-profiling
+description: Profile macOS and iOS apps with xctrace and Instruments exports.
+---
+
+# Instruments Profiling
+
+Profile macOS and iOS apps with xctrace and Instruments exports.
+
+## When to Use
+
+Use when asked to diagnose native app performance, collect traces, inspect allocations, or explain Instruments output.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: instruments-profiling.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/ios-simulator/SKILL.md
+++ b/skills/ios-simulator/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: ios-simulator
+description: Build, boot, inspect, and automate iOS Simulator workflows from the command line.
+---
+
+# iOS Simulator
+
+Build, boot, inspect, and automate iOS Simulator workflows from the command line.
+
+## When to Use
+
+Use when asked to test iOS apps, capture simulator logs, drive UI flows, install builds, or diagnose simulator failures.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: ios-simulator.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/kubectl-skill/SKILL.md
+++ b/skills/kubectl-skill/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: kubectl-skill
+description: Operate and debug Kubernetes clusters with kubectl using scoped, reviewable commands.
+---
+
+# kubectl Skill
+
+Operate and debug Kubernetes clusters with kubectl using scoped, reviewable commands.
+
+## When to Use
+
+Use when asked to inspect Kubernetes resources, debug pods, review deployments, collect logs, or prepare kubectl commands for a cluster.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: kubectl-skill.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/opencode-controller/SKILL.md
+++ b/skills/opencode-controller/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: opencode-controller
+description: Control OpenCode sessions, agents, models, and slash-command workflows.
+---
+
+# OpenCode Controller
+
+Control OpenCode sessions, agents, models, and slash-command workflows.
+
+## When to Use
+
+Use when asked to start, inspect, switch, or coordinate OpenCode coding-agent sessions.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: opencode-controller.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/private-connect/SKILL.md
+++ b/skills/private-connect/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: private-connect
+description: Access private services by stable names using tunnels, proxies, or secure local routes.
+---
+
+# Private Connect
+
+Access private services by stable names using tunnels, proxies, or secure local routes.
+
+## When to Use
+
+Use when asked to reach private dashboards, set up private service access, or document secure connection steps.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: private-connect.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/proxmox-full/SKILL.md
+++ b/skills/proxmox-full/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: proxmox-full
+description: Manage Proxmox VE virtual machines, containers, storage, backups, and snapshots.
+---
+
+# Proxmox Full
+
+Manage Proxmox VE virtual machines, containers, storage, backups, and snapshots.
+
+## When to Use
+
+Use when asked to inspect, start, stop, clone, snapshot, or troubleshoot Proxmox VMs or LXC containers.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: proxmox-full.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/react-expert/SKILL.md
+++ b/skills/react-expert/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: react-expert
+description: Review and build React apps with attention to components, hooks, state, performance, and tests.
+---
+
+# React Expert
+
+Review and build React apps with attention to components, hooks, state, performance, and tests.
+
+## When to Use
+
+Use when asked to implement, refactor, review, or debug React 18+ application code.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills and skills.sh: react-expert.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/refactor-assist/SKILL.md
+++ b/skills/refactor-assist/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: refactor-assist
+description: Plan and apply focused refactors with readable diffs and behavior-preserving checks.
+---
+
+# Refactor Assist
+
+Plan and apply focused refactors with readable diffs and behavior-preserving checks.
+
+## When to Use
+
+Use when asked to improve code structure, reduce duplication, split functions, or modernize code without changing behavior.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: refactor-assist.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/schema-gen/SKILL.md
+++ b/skills/schema-gen/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: schema-gen
+description: Design practical database schemas from product requirements and query patterns.
+---
+
+# Schema Generator
+
+Design practical database schemas from product requirements and query patterns.
+
+## When to Use
+
+Use when asked to draft SQL tables, indexes, relationships, constraints, migrations, or data-model notes.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: schema-gen.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/sports-ticker/SKILL.md
+++ b/skills/sports-ticker/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: sports-ticker
+description: Track live sports scores, schedules, and alerts across major leagues.
+---
+
+# Sports Ticker
+
+Track live sports scores, schedules, and alerts across major leagues.
+
+## When to Use
+
+Use when asked for live sports scores, upcoming games, team alerts, or a lightweight scoreboard workflow.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: sports-ticker.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/systemmonitor/SKILL.md
+++ b/skills/systemmonitor/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: systemmonitor
+description: Summarize local CPU, memory, disk, GPU, process, and service health.
+---
+
+# System Monitor
+
+Summarize local CPU, memory, disk, GPU, process, and service health.
+
+## When to Use
+
+Use when asked to check machine health, investigate resource pressure, or capture a quick server status snapshot.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: systemmonitor.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/test-gen/SKILL.md
+++ b/skills/test-gen/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: test-gen
+description: Generate unit tests from source files and behavior descriptions.
+---
+
+# Test Generator
+
+Generate unit tests from source files and behavior descriptions.
+
+## When to Use
+
+Use when asked to add test coverage, sketch unit cases, or create tests around a bug fix.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: test-gen.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.

--- a/skills/ui-test/SKILL.md
+++ b/skills/ui-test/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: ui-test
+description: Plain-English end-to-end UI testing that turns user flows into browser checks and Playwright specs.
+---
+
+# UI Test
+
+Plain-English end-to-end UI testing that turns user flows into browser checks and Playwright specs.
+
+## When to Use
+
+Use when asked to test a web UI, reproduce a browser bug, create an E2E test, verify a user flow, or export a Playwright test from natural-language steps.
+
+## Workflow
+
+1. Confirm the target project, account, cluster, device, or service boundary before taking action.
+2. Prefer read-only inspection first, then present the smallest useful command or change.
+3. Capture the command, expected result, and rollback or recovery path when an operation changes external state.
+4. Verify the result with logs, status output, tests, screenshots, or another source appropriate to the task.
+
+## Notes
+
+- Source inspiration: Sundial awesome-openclaw-skills: ui-test.
+- This is a discovery stub. Expand with concrete commands, setup requirements, and safety checks before relying on it for production work.


### PR DESCRIPTION
## Summary
- Adds 20 lightweight SKILL.md discovery stubs from skills.sh and sundial-org/awesome-openclaw-skills.
- Focuses on developer, testing, infrastructure, simulator, and workflow automation skills that are not currently in the repo.

## Linear
- ORT-2527

## Verification
- Checked all SKILL.md files have frontmatter.
- Ran `git diff --cached --check` before commit.
