### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/ai-research-explore/SKILL.md
+++ b/skills/ai-research-explore/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ai-research-explore
+description: Explore AI research topics, papers, methods, baselines, and reproduction paths.
+---
+
+# AI Research Explore
+
+Use this skill when a user asks to understand an AI research area or compare papers and methods.
+
+## Stub Scope
+
+- Identify core papers, datasets, baselines, and evaluation metrics.
+- Distinguish established results from new or uncertain claims.
+- Track citations, code availability, and reproduction notes.
+- Summarize implications for implementation or product use.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: anti-ui-slop
+description: Review and improve UI quality by catching vague layouts, weak hierarchy, and generic visuals.
+---
+
+# Anti UI Slop
+
+Use this skill when reviewing or improving frontend UI quality.
+
+## Stub Scope
+
+- Check hierarchy, spacing, density, interaction states, and responsive behavior.
+- Remove generic filler copy and decorative noise.
+- Match design choices to the product domain and user workflow.
+- Require visual verification for meaningful UI changes.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/design-taste-frontend/SKILL.md
+++ b/skills/design-taste-frontend/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: design-taste-frontend
+description: Apply stronger frontend design judgment to layout, typography, color, and interaction details.
+---
+
+# Design Taste Frontend
+
+Use this skill when building or polishing frontend interfaces.
+
+## Stub Scope
+
+- Start from the existing design system and product audience.
+- Tune information hierarchy, typography scale, controls, and visual rhythm.
+- Avoid one-note palettes and oversized decorative layouts for work tools.
+- Verify desktop and mobile states before finishing.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/git-guardrails-claude-code/SKILL.md
+++ b/skills/git-guardrails-claude-code/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: git-guardrails-claude-code
+description: Protect user work in agent coding sessions with careful git status, diffs, and branch hygiene.
+---
+
+# Git Guardrails Claude Code
+
+Use this skill when an agent is editing a git repository with possible user changes.
+
+## Stub Scope
+
+- Check branch and worktree status before edits.
+- Treat unknown changes as user-owned.
+- Avoid destructive resets, checkouts, and force pushes.
+- Summarize only relevant diffs and commit hashes.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-base
+description: Query and update Lark Base tables, records, fields, views, and automation data.
+---
+
+# Lark Base
+
+Use this skill when working with Lark Base records, views, tables, or structured workspace data.
+
+## Stub Scope
+
+- Discover apps, tables, fields, and views before changing data.
+- Support filtered reads, record creation, updates, and exports.
+- Handle pagination and field type conversions.
+- Confirm before bulk edits or deletes.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-calendar
+description: Manage Lark calendars, events, availability, attendees, reminders, and schedule conflicts.
+---
+
+# Lark Calendar
+
+Use this skill when scheduling, inspecting, or updating events in Lark Calendar.
+
+## Stub Scope
+
+- Check timezone, attendee availability, and calendar ownership.
+- Support event search, create, update, cancel, and reminder workflows.
+- Surface conflicts before changing a meeting.
+- Confirm before sending invitations or cancellations.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-doc
+description: Work with Lark documents, including read, create, update, export, and collaboration workflows.
+---
+
+# Lark Doc
+
+Use this skill when a task involves Lark documents or Feishu docs.
+
+## Stub Scope
+
+- Document authentication and workspace selection.
+- Support document lookup, read, create, update, export, and sharing flows.
+- Preserve formatting and links when moving content between systems.
+- Confirm before making broad permission or sharing changes.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-drive
+description: Manage Lark Drive files, folders, permissions, search, uploads, and downloads.
+---
+
+# Lark Drive
+
+Use this skill when a task involves finding, uploading, downloading, organizing, or sharing files in Lark Drive.
+
+## Stub Scope
+
+- Search by file name, owner, folder, type, and modified date.
+- Support folder creation, upload, download, move, copy, and permission checks.
+- Preserve file metadata when possible.
+- Confirm before deleting or changing external access.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-im
+description: Send, read, search, and manage Lark instant messages, chats, threads, and bot events.
+---
+
+# Lark IM
+
+Use this skill when a task needs Lark or Feishu chat messaging.
+
+## Stub Scope
+
+- Resolve chat, user, and thread identifiers before sending.
+- Support message reads, searches, replies, edits, and bot card delivery.
+- Keep outbound messages concise and channel-appropriate.
+- Ask before sending sensitive or external-facing messages.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-minutes/SKILL.md
+++ b/skills/lark-minutes/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-minutes
+description: Retrieve, summarize, search, and organize Lark Minutes meeting transcripts and notes.
+---
+
+# Lark Minutes
+
+Use this skill when a task involves Lark Minutes transcripts, recordings, summaries, or action items.
+
+## Stub Scope
+
+- Locate meetings by date, title, participants, or linked calendar event.
+- Extract decisions, action items, owners, and unresolved questions.
+- Preserve timestamps and speaker attribution where available.
+- Respect privacy for recordings and meeting content.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-sheets
+description: Read, write, append, format, and summarize data in Lark Sheets.
+---
+
+# Lark Sheets
+
+Use this skill when working with spreadsheet data in Lark Sheets.
+
+## Stub Scope
+
+- Resolve spreadsheet, sheet, and range identifiers.
+- Support reads, appends, updates, formatting, and exports.
+- Preserve formulas and avoid overwriting hidden data.
+- Confirm before bulk writes or destructive changes.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lark-wiki
+description: Search, create, update, organize, and audit Lark Wiki spaces and pages.
+---
+
+# Lark Wiki
+
+Use this skill when a task involves Lark Wiki knowledge bases, spaces, pages, or permissions.
+
+## Stub Scope
+
+- Search spaces and pages before creating duplicates.
+- Support page creation, updates, moves, exports, and link collection.
+- Preserve hierarchy and backlinks.
+- Confirm before changing page visibility or ownership.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/minimal-run-and-audit/SKILL.md
+++ b/skills/minimal-run-and-audit/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: minimal-run-and-audit
+description: Run the smallest useful project checks and audit failures before making larger changes.
+---
+
+# Minimal Run And Audit
+
+Use this skill when entering a repo or diagnosing a task and the right verification path is unclear.
+
+## Stub Scope
+
+- Run lightweight install, lint, typecheck, or test commands first.
+- Capture failures, likely causes, and whether they are pre-existing.
+- Pick the next verification step based on observed risk.
+- Keep command output summarized unless exact logs are requested.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/paper-context-resolver/SKILL.md
+++ b/skills/paper-context-resolver/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: paper-context-resolver
+description: Resolve paper context, related work, datasets, code, claims, and citation chains.
+---
+
+# Paper Context Resolver
+
+Use this skill when a research paper needs context beyond the abstract.
+
+## Stub Scope
+
+- Find paper metadata, authors, venue, code, datasets, and related work.
+- Trace important claims to cited sources where possible.
+- Note missing artifacts, benchmark caveats, and follow-up papers.
+- Produce a concise context brief with confidence levels.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/repo-intake-and-plan/SKILL.md
+++ b/skills/repo-intake-and-plan/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: repo-intake-and-plan
+description: Inspect an unfamiliar repository and produce a practical implementation or cleanup plan.
+---
+
+# Repo Intake And Plan
+
+Use this skill at the start of coding work in a new or unfamiliar repository.
+
+## Stub Scope
+
+- Inspect structure, package metadata, tests, docs, and recent changes.
+- Identify local conventions before proposing changes.
+- Produce a scoped plan with risks and verification steps.
+- Avoid unrelated refactors during intake.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/safe-debug/SKILL.md
+++ b/skills/safe-debug/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: safe-debug
+description: Debug failures with reversible steps, evidence collection, and minimal blast radius.
+---
+
+# Safe Debug
+
+Use this skill when diagnosing bugs, crashes, flaky tests, or production-like failures.
+
+## Stub Scope
+
+- Reproduce before changing behavior.
+- Collect logs, inputs, environment details, and recent diffs.
+- Isolate hypotheses with small reversible experiments.
+- Stop before destructive or externally visible actions unless approved.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/setup-pre-commit/SKILL.md
+++ b/skills/setup-pre-commit/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: setup-pre-commit
+description: Add or repair pre-commit hooks for formatting, linting, security, and repo hygiene checks.
+---
+
+# Setup Pre Commit
+
+Use this skill when adding or maintaining pre-commit checks in a repository.
+
+## Stub Scope
+
+- Detect the repo language, package manager, and existing formatting tools.
+- Add minimal hooks that match existing conventions.
+- Document install and run commands.
+- Verify hooks locally and avoid broad formatting churn.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/to-spec/SKILL.md
+++ b/skills/to-spec/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: to-spec
+description: Turn product ideas, issues, or rough notes into concrete implementation specifications.
+---
+
+# To Spec
+
+Use this skill when a user wants a loose idea turned into a buildable specification.
+
+## Stub Scope
+
+- Capture goals, non-goals, constraints, user flows, and acceptance criteria.
+- Identify unknowns and propose conservative defaults.
+- Keep specs implementation-ready without over-prescribing internals.
+- Include verification and rollout notes for engineering work.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/to-tickets/SKILL.md
+++ b/skills/to-tickets/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: to-tickets
+description: Break specs or project plans into small, sequenced engineering tickets with acceptance criteria.
+---
+
+# To Tickets
+
+Use this skill when a user wants a project, plan, or spec decomposed into actionable tickets.
+
+## Stub Scope
+
+- Group work by dependency and ownership boundary.
+- Write each ticket with context, scope, acceptance criteria, and test notes.
+- Keep ticket slices small enough for independent delivery.
+- Mark risks, blockers, and follow-up decisions explicitly.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.

--- a/skills/writing-great-skills/SKILL.md
+++ b/skills/writing-great-skills/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: writing-great-skills
+description: Improve agent skill instructions for triggers, boundaries, examples, and operational clarity.
+---
+
+# Writing Great Skills
+
+Use this skill when creating or revising `SKILL.md` files.
+
+## Stub Scope
+
+- Make triggers concrete and easy for agents to recognize.
+- Separate setup, workflow, safety, and examples.
+- Keep instructions reusable and concise.
+- Include tests or validation guidance when skills include scripts or tools.
+
+Source candidates: skills.sh and sundial-org/awesome-openclaw-skills.


### PR DESCRIPTION
## Summary
- Adds 20 SKILL.md stubs from the 2026-08-12 daily skills discovery pass.
- Sources: skills.sh and sundial-org/awesome-openclaw-skills, filtered against existing repo skills and prior discovery posts.

## Linear
ORT-2539

## Test plan
- Verified all 20 candidates are absent from memory/discovery-posts.md before committing.
- Verified each new skill has frontmatter name and description.

Reviewers: @christianpickettcode @berasogut