### PR TITLE
Add August 14 discovery skill stubs

### DIFF
--- a/skills/browsh/SKILL.md
+++ b/skills/browsh/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: browsh
+description: Use Browsh for terminal-based web browsing when a graphical browser is unavailable or too expensive.
+---
+
+# Browsh
+
+Use this skill when a task needs visual-ish web browsing from a terminal session.
+
+## Scope
+
+- Launch and navigate Browsh sessions.
+- Capture readable terminal output for pages that need JavaScript rendering.
+- Fall back to simpler fetch tools when full browser rendering is unnecessary.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add installation checks, command examples, and accessibility limitations.

--- a/skills/clinkding/SKILL.md
+++ b/skills/clinkding/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: clinkding
+description: Manage Linkding bookmarks, tags, search, and retrieval for personal knowledge workflows.
+---
+
+# Clinkding
+
+Use this skill when the user wants to save, search, tag, or organize bookmarks in Linkding.
+
+## Scope
+
+- Add and update bookmarks with tags and notes.
+- Search bookmark titles, URLs, descriptions, and tag sets.
+- Retrieve saved links for research and memory workflows.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add Linkding API and CLI examples with authentication placeholders.

--- a/skills/content-advisory/SKILL.md
+++ b/skills/content-advisory/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: content-advisory
+description: Look up detailed movie and TV content advisories and summarize them for viewing decisions.
+---
+
+# Content Advisory
+
+Use this skill when the user asks whether a movie or TV show is appropriate for a viewer or setting.
+
+## Scope
+
+- Search content rating sources and advisory databases.
+- Summarize sensitive content by category without unnecessary detail.
+- Include uncertainty when sources disagree or are unavailable.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add preferred advisory sources, citation requirements, and family-safe wording guidance.

--- a/skills/elevenlabs-music/SKILL.md
+++ b/skills/elevenlabs-music/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: elevenlabs-music
+description: Generate music, soundtracks, jingles, and short audio beds with ElevenLabs Music workflows.
+---
+
+# ElevenLabs Music
+
+Use this skill when the user wants generated music or a short soundtrack.
+
+## Scope
+
+- Turn creative direction into a concise music prompt.
+- Generate or request audio with length, genre, mood, and instrumentation constraints.
+- Save outputs with descriptive filenames and usage notes.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add current API commands, licensing cautions, and retry guidance.

--- a/skills/fathom/SKILL.md
+++ b/skills/fathom/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: fathom
+description: Fetch Fathom AI meeting recordings, transcripts, summaries, and action items.
+---
+
+# Fathom
+
+Use this skill when the user asks about meeting recordings or summaries stored in Fathom.
+
+## Scope
+
+- Search meetings by title, participants, date, and keywords.
+- Retrieve transcripts, summaries, and action items.
+- Convert meeting notes into follow-ups, tickets, or briefs.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add API setup, data privacy cautions, and transcript handling examples.

--- a/skills/ffmpeg-cli/SKILL.md
+++ b/skills/ffmpeg-cli/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ffmpeg-cli
+description: Build and run FFmpeg commands for media inspection, conversion, trimming, compression, and extraction.
+---
+
+# FFmpeg CLI
+
+Use this skill when manipulating audio or video files with FFmpeg.
+
+## Scope
+
+- Inspect media streams and metadata.
+- Convert formats, trim clips, extract audio, compress files, and generate thumbnails.
+- Prefer non-destructive outputs and preserve originals.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add common command recipes and verification steps with `ffprobe`.

--- a/skills/ffmpeg-video-editor/SKILL.md
+++ b/skills/ffmpeg-video-editor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ffmpeg-video-editor
+description: Translate natural-language video edit requests into FFmpeg filter graphs and safe command plans.
+---
+
+# FFmpeg Video Editor
+
+Use this skill when the user describes an edit such as trimming, cropping, resizing, captions, speed changes, or overlays.
+
+## Scope
+
+- Map requested edits to FFmpeg commands.
+- Explain expected output format, duration, resolution, and quality tradeoffs.
+- Run quick probes before and after editing.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add reusable filter graph recipes and preview-generation workflow.

--- a/skills/gong/SKILL.md
+++ b/skills/gong/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: gong
+description: Search Gong calls, transcripts, snippets, and conversation intelligence for sales and customer workflows.
+---
+
+# Gong
+
+Use this skill when working with Gong call recordings and conversation intelligence.
+
+## Scope
+
+- Search calls by account, participant, owner, date, and topic.
+- Retrieve transcripts, summaries, and notable moments.
+- Extract objections, commitments, risks, and next steps.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add Gong API authentication, pagination, and safe summarization workflow.

--- a/skills/kokoro-tts/SKILL.md
+++ b/skills/kokoro-tts/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: kokoro-tts
+description: Generate local text-to-speech audio with Kokoro TTS for private or offline voice workflows.
+---
+
+# Kokoro TTS
+
+Use this skill when the user wants local, private, or offline speech synthesis.
+
+## Scope
+
+- Convert text to spoken audio using a local Kokoro setup.
+- Pick appropriate voices and output formats.
+- Keep source text and generated audio on-device by default.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add installation, model selection, and command examples.

--- a/skills/lastfm/SKILL.md
+++ b/skills/lastfm/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: lastfm
+description: Access Last.fm scrobbles, top artists, albums, tracks, and music discovery data.
+---
+
+# Last.fm
+
+Use this skill when the user asks about Last.fm listening history or music recommendations.
+
+## Scope
+
+- Query recent scrobbles and top charts by period.
+- Compare artists, albums, tracks, and tags.
+- Produce concise taste summaries and discovery suggestions.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add Last.fm API setup, user lookup, and response examples.

--- a/skills/markdown-converter/SKILL.md
+++ b/skills/markdown-converter/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: markdown-converter
+description: Convert PDFs, Office documents, slides, and other files into clean Markdown for agent workflows.
+---
+
+# Markdown Converter
+
+Use this skill when source files need to become Markdown before analysis, summarization, or editing.
+
+## Scope
+
+- Convert supported files with layout-preserving tools where available.
+- Preserve headings, lists, links, tables, and code blocks.
+- Note conversion losses, OCR gaps, and embedded media omissions.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add preferred converters, OCR fallback steps, and validation examples.

--- a/skills/media-backup/SKILL.md
+++ b/skills/media-backup/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: media-backup
+description: Archive conversation media such as photos, videos, and audio into an organized local backup folder.
+---
+
+# Media Backup
+
+Use this skill when the user wants media from conversations or sessions backed up locally.
+
+## Scope
+
+- Collect media files from known local sources.
+- Preserve filenames, timestamps, and conversation context when available.
+- Avoid uploading or sharing private media without explicit approval.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add platform-specific source paths and deduplication strategy.

--- a/skills/nudocs/SKILL.md
+++ b/skills/nudocs/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: nudocs
+description: Upload, edit, export, and share documents through Nudocs.ai workflows.
+---
+
+# Nudocs
+
+Use this skill when the user wants to create or manage shareable documents in Nudocs.ai.
+
+## Scope
+
+- Upload source documents.
+- Edit structured document content.
+- Export or share final documents with explicit approval for external sharing.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add API or browser workflow details and external-share confirmation rules.

--- a/skills/paperless/SKILL.md
+++ b/skills/paperless/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: paperless
+description: Search, retrieve, upload, tag, and organize documents in Paperless-NGX through its CLI or API.
+---
+
+# Paperless
+
+Use this skill when working with a Paperless-NGX document archive.
+
+## Scope
+
+- Search documents by text, tag, correspondent, type, and date.
+- Retrieve metadata and download source files.
+- Upload and organize documents with explicit user confirmation for destructive changes.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add CLI/API setup, authentication notes, and safe mutation workflows.

--- a/skills/sag/SKILL.md
+++ b/skills/sag/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: sag
+description: Generate text-to-speech audio with ElevenLabs-style voice workflows from the terminal.
+---
+
+# Sag
+
+Use this skill when the user asks for spoken audio, narration, storytime, or voice output files.
+
+## Scope
+
+- Select an appropriate voice and style for the requested context.
+- Generate local audio files from text.
+- Keep private content local unless the user approves external delivery.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add exact CLI commands, voice defaults, and output file conventions.

--- a/skills/sfsymbol-generator/SKILL.md
+++ b/skills/sfsymbol-generator/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: sfsymbol-generator
+description: Generate Xcode SF Symbol asset catalogs from SVG artwork for Apple platform projects.
+---
+
+# SF Symbol Generator
+
+Use this skill when creating or adapting custom SF Symbols for iOS, macOS, watchOS, or tvOS apps.
+
+## Scope
+
+- Validate source SVG shape, viewBox, stroke, and fill requirements.
+- Generate `.symbolset` asset catalog files.
+- Check symbol variants and alignment for Xcode import.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add tool commands, Xcode validation steps, and template assets.

--- a/skills/skill-scanner/SKILL.md
+++ b/skills/skill-scanner/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: skill-scanner
+description: Scan agent skills for suspicious code, secrets, supply-chain risks, and unsafe install behavior before adding them.
+---
+
+# Skill Scanner
+
+Use this skill when reviewing third-party agent skills before installation, publication, or recommendation.
+
+## Scope
+
+- Inspect `SKILL.md`, scripts, package manifests, install commands, and referenced URLs.
+- Flag secrets, exfiltration paths, destructive commands, unexpected network calls, and risky postinstall hooks.
+- Produce a short risk summary with recommended next steps.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add concrete scanner commands and a rubric for low, medium, and high-risk findings.

--- a/skills/spotify-history/SKILL.md
+++ b/skills/spotify-history/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: spotify-history
+description: Query Spotify listening history, top artists, top tracks, and personalized music stats.
+---
+
+# Spotify History
+
+Use this skill when the user asks about listening history, music taste, or Spotify stats.
+
+## Scope
+
+- Fetch recently played tracks and top artists or tracks.
+- Summarize patterns by time period, genre, artist, or playlist.
+- Avoid changing library state unless explicitly requested.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add Spotify OAuth setup and rate-limit handling.

--- a/skills/voice-ai-tts/SKILL.md
+++ b/skills/voice-ai-tts/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: voice-ai-tts
+description: Generate multilingual text-to-speech with Voice.ai voices, streaming, and optional voice cloning.
+---
+
+# Voice.ai TTS
+
+Use this skill when the user asks for high-quality synthesized speech through Voice.ai.
+
+## Scope
+
+- Choose voice, language, speed, and style.
+- Generate speech from text and save local audio outputs.
+- Treat cloning and impersonation requests with explicit consent requirements.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add API setup, supported voices, and consent checks.

--- a/skills/ytmusic-librarian/SKILL.md
+++ b/skills/ytmusic-librarian/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ytmusic-librarian
+description: Manage YouTube Music library, playlists, listening history, and discovery through ytmusicapi.
+---
+
+# YouTube Music Librarian
+
+Use this skill when working with a user's YouTube Music library or playlists.
+
+## Scope
+
+- Search tracks, albums, artists, playlists, and library entries.
+- Create and update playlists after user approval.
+- Summarize listening history and recommend organization changes.
+
+## Source
+
+Discovered from skills.sh and awesome-openclaw-skills.
+
+## TODO
+
+- Add authentication setup and safe playlist mutation commands.


### PR DESCRIPTION
## Summary

Adds 20 daily discovery skill stubs from skills.sh and sundial-org/awesome-openclaw-skills.

Batch 83 skills:
- skill-scanner
- browsh
- paperless
- clinkding
- fathom
- gong
- content-advisory
- sfsymbol-generator
- nudocs
- markdown-converter
- ffmpeg-cli
- media-backup
- ytmusic-librarian
- ffmpeg-video-editor
- sag
- spotify-history
- lastfm
- elevenlabs-music
- voice-ai-tts
- kokoro-tts

Linear: ORT-2556

## Test Plan

- Verified every new `SKILL.md` starts with frontmatter.
- Reviewed `git diff --stat` for the expected 20 added files.
