### PR TITLE
Add daily discovery skill stubs for 2026-08-19

### DIFF
--- a/skills/clawhub-2/SKILL.md
+++ b/skills/clawhub-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: clawhub-2
+description: Search, install, update, and publish agent skills from ClawHub.
+---
+
+# clawhub-2
+
+Use this skill when an agent needs to discover skills in ClawHub, install them into local agent directories, update installed skills, or prepare a skill for publication.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with install commands, cache behavior, verification steps, and publication safety checks before publishing as a fully supported Orthogonal skill.

--- a/skills/cloudflare-3/SKILL.md
+++ b/skills/cloudflare-3/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: cloudflare-3
+description: Manage Cloudflare Workers, KV, D1, R2, and secrets with Wrangler.
+---
+
+# cloudflare-3
+
+Use this skill when an agent needs to deploy or manage Cloudflare Workers, KV namespaces, D1 databases, R2 buckets, environment variables, routes, or secrets through Wrangler.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with Wrangler setup, dry-run commands, account-selection checks, and rollback guidance before publishing as a fully supported Orthogonal skill.

--- a/skills/create-content/SKILL.md
+++ b/skills/create-content/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: create-content
+description: Turn raw ideas into platform-optimized content drafts.
+---
+
+# create-content
+
+Use this skill when an agent needs to transform ideas, notes, or rough arguments into content drafts tailored for specific platforms and audiences.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with intake questions, platform constraints, editing passes, and approval requirements before publishing as a fully supported Orthogonal skill.

--- a/skills/gemini-yt-video-transcript/SKILL.md
+++ b/skills/gemini-yt-video-transcript/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: gemini-yt-video-transcript
+description: Create YouTube transcripts with Gemini and clean formatting.
+---
+
+# gemini-yt-video-transcript
+
+Use this skill when an agent needs to produce a readable transcript for a YouTube video using Gemini, with speaker labels and paragraph breaks when possible.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with input validation, transcript formatting rules, copyright boundaries, and fallback extraction steps before publishing as a fully supported Orthogonal skill.

--- a/skills/grounding-lite/SKILL.md
+++ b/skills/grounding-lite/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grounding-lite
+description: Use Google Maps Grounding Lite for places, weather, and routes.
+---
+
+# grounding-lite
+
+Use this skill when an agent needs lightweight location grounding, place lookup, route context, or weather context through a Google Maps Grounding Lite MCP/tooling setup.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with tool setup, supported actions, location privacy guidance, and fallback behavior before publishing as a fully supported Orthogonal skill.

--- a/skills/just-fucking-cancel/SKILL.md
+++ b/skills/just-fucking-cancel/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: just-fucking-cancel
+description: Detect recurring subscriptions and prepare cancellation workflows.
+---
+
+# just-fucking-cancel
+
+Use this skill when an agent needs to identify likely subscriptions from transaction exports, estimate recurring spend, and prepare cancellation steps for user approval.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with data-import formats, privacy handling, approval gates, and cancellation workflow limits before publishing as a fully supported Orthogonal skill.

--- a/skills/last30days-2/SKILL.md
+++ b/skills/last30days-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: last30days-2
+description: Research recent Reddit, X, and web discussion from the last 30 days.
+---
+
+# last30days-2
+
+Use this skill when an agent needs to understand what people have been saying about a topic across Reddit, X, and the broader web during the last 30 days.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with source selection, query templates, citation rules, and synthesis formats before publishing as a fully supported Orthogonal skill.

--- a/skills/news-aggregator-skill-3/SKILL.md
+++ b/skills/news-aggregator-skill-3/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: news-aggregator-skill-3
+description: Aggregate and analyze news from multiple real-time sources.
+---
+
+# news-aggregator-skill-3
+
+Use this skill when an agent needs to gather, filter, deduplicate, and summarize news across sources such as Hacker News, GitHub Trending, Product Hunt, and regional tech feeds.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with source adapters, citation requirements, recency rules, and output formats before publishing as a fully supported Orthogonal skill.

--- a/skills/omnifocus-2/SKILL.md
+++ b/skills/omnifocus-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: omnifocus-2
+description: Manage OmniFocus tasks through macOS automation.
+---
+
+# omnifocus-2
+
+Use this skill when an agent needs to add, list, update, complete, or organize OmniFocus tasks on macOS through JavaScript for Automation or a local CLI wrapper.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with install steps, permission prompts, supported fields, and approval gates before publishing as a fully supported Orthogonal skill.

--- a/skills/picnic/SKILL.md
+++ b/skills/picnic/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: picnic
+description: Search Picnic groceries, manage carts, and schedule delivery.
+---
+
+# picnic
+
+Use this skill when an agent needs to search Picnic supermarket products, manage a grocery cart, compare items, or prepare delivery scheduling.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with region support, login flow, cart approval gates, and purchase safeguards before publishing as a fully supported Orthogonal skill.

--- a/skills/qmd-3/SKILL.md
+++ b/skills/qmd-3/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: qmd-3
+description: Search local markdown notes and documentation with qmd hybrid search.
+---
+
+# qmd-3
+
+Use this skill when an agent needs to search local Markdown notes, documentation, or knowledge-base files with qmd instead of ad hoc file scanning.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with install steps, authentication requirements, common commands, and safety notes before publishing as a fully supported Orthogonal skill.

--- a/skills/reddit-2/SKILL.md
+++ b/skills/reddit-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: reddit-2
+description: Read and search Reddit posts through old.reddit.com scraping.
+---
+
+# reddit-2
+
+Use this skill when an agent needs to browse Reddit posts, search subreddits, inspect discussion threads, or monitor public Reddit topics without posting.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with scraping commands, rate-limit guidance, privacy constraints, and posting boundaries before publishing as a fully supported Orthogonal skill.

--- a/skills/search-reddit/SKILL.md
+++ b/skills/search-reddit/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: search-reddit
+description: Search Reddit threads and enrich results with engagement context.
+---
+
+# search-reddit
+
+Use this skill when an agent needs recent Reddit threads, subreddit-filtered results, high-signal comments, engagement context, and practical synthesis from public discussions.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with search commands, comment-selection heuristics, quote limits, and privacy boundaries before publishing as a fully supported Orthogonal skill.

--- a/skills/searxng-2/SKILL.md
+++ b/skills/searxng-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: searxng-2
+description: Search the web through a self-hosted SearXNG metasearch instance.
+---
+
+# searxng-2
+
+Use this skill when an agent needs privacy-respecting web search through a self-hosted SearXNG instance that aggregates multiple engines.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with instance configuration, query parameters, result parsing, and fallback behavior before publishing as a fully supported Orthogonal skill.

--- a/skills/security-audit-2/SKILL.md
+++ b/skills/security-audit-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: security-audit-2
+description: Audit OpenClaw or ClawHub skills and repos for security risks.
+---
+
+# security-audit-2
+
+Use this skill when an agent needs to inspect OpenClaw or ClawHub skills, local repositories, or downloaded packages for secrets, prompt-injection risks, unsafe persistence, and supply-chain issues.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with scan tools, severity rules, remediation workflow, and false-positive handling before publishing as a fully supported Orthogonal skill.

--- a/skills/solobuddy/SKILL.md
+++ b/skills/solobuddy/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: solobuddy
+description: Support indie-hacker build-in-public and project-content workflows.
+---
+
+# solobuddy
+
+Use this skill when an agent needs to help an indie hacker plan build-in-public updates, track project narrative, draft launch notes, or manage lightweight audience engagement.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with content boundaries, platform-specific formats, scheduling steps, and public-posting approvals before publishing as a fully supported Orthogonal skill.

--- a/skills/voice-wake-say/SKILL.md
+++ b/skills/voice-wake-say/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: voice-wake-say
+description: Speak responses on macOS with the built-in say command.
+---
+
+# voice-wake-say
+
+Use this skill when an agent should read short responses aloud on macOS after voice-wake input or explicit requests for spoken output.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with voice selection, length limits, interruption handling, and quiet-hours behavior before publishing as a fully supported Orthogonal skill.

--- a/skills/wacli-2/SKILL.md
+++ b/skills/wacli-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: wacli-2
+description: Send WhatsApp messages and search synced WhatsApp history via wacli.
+---
+
+# wacli-2
+
+Use this skill when an agent needs to search WhatsApp history or send WhatsApp messages through the wacli command-line tool.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with installation steps, account setup, explicit-send approvals, formatting rules, and audit logging before publishing as a fully supported Orthogonal skill.

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: x-api
+description: Post to X through the official API with OAuth credentials.
+---
+
+# x-api
+
+Use this skill when an agent needs to draft or publish posts to X using the official API and OAuth 1.0a credentials.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with credential setup, approval requirements for public posting, dry-run behavior, and error handling before publishing as a fully supported Orthogonal skill.

--- a/skills/yahoo-finance-2/SKILL.md
+++ b/skills/yahoo-finance-2/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: yahoo-finance-2
+description: Retrieve stock quotes, earnings data, and market summaries.
+---
+
+# yahoo-finance-2
+
+Use this skill when an agent needs to fetch stock prices, market summaries, earnings dates, ticker fundamentals, or trending securities from Yahoo Finance compatible tooling.
+
+This is a discovery stub from the August 19, 2026 skills sweep. Flesh it out with command examples, freshness warnings, and financial-disclaimer language before publishing as a fully supported Orthogonal skill.


### PR DESCRIPTION
## Summary

- Adds 20 daily discovery SKILL.md stubs from the August 19, 2026 skills sweep
- Sources: skills.sh and sundial-org/awesome-openclaw-skills
- Avoids previously posted exact picks from memory/discovery-posts.md and existing skills in the repo

## Linear

ORT-2574

## Test Plan

- git diff --check
