### PR TITLE
Add daily discovery skill stubs for 2026-08-20

### DIFF
--- a/skills/ai-research-reproduction/SKILL.md
+++ b/skills/ai-research-reproduction/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: ai-research-reproduction
+description: Reproduce AI research papers, experiments, and benchmarks
+---
+
+# AI Research Reproduction
+
+Use this skill when a user wants to reproduce a paper, compare implementation claims, run a benchmark, or turn research into working code.
+
+## Workflow
+
+1. Find the paper, official repo, model cards, datasets, and benchmark definitions.
+2. Record hardware, software versions, seeds, checkpoints, and licenses.
+3. Build the smallest runnable reproduction first.
+4. Compare metrics against the paper and note any deviations.
+5. Package scripts, commands, logs, and caveats so the run can be repeated.
+
+## Guardrails
+
+- Prefer official code and datasets.
+- Do not silently substitute datasets, checkpoints, or evaluation metrics.
+- Separate confirmed results from inferred explanations.
+
+## Source
+
+Discovered from skills.sh trending: `lllllllama/rigorpilot-skills`.

--- a/skills/analyze-project/SKILL.md
+++ b/skills/analyze-project/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: analyze-project
+description: Inspect a repository and produce a structured project analysis
+---
+
+# Analyze Project
+
+Use this skill when a user asks for a codebase overview, technical due diligence, onboarding notes, or a map of how a project works.
+
+## Workflow
+
+1. Read the README, package manifests, config files, and directory structure.
+2. Identify the main runtime, frameworks, entry points, and data stores.
+3. Trace the most important user flows or background jobs.
+4. Summarize architecture, risks, test coverage, and high-leverage next steps.
+
+## Output
+
+Return a concise project brief with:
+
+- What the project does
+- How it is structured
+- How to run and test it
+- Notable dependencies and integration points
+- Risks, unknowns, and recommended follow-ups
+
+## Source
+
+Discovered from skills.sh trending: `lllllllama/rigorpilot-skills`.

--- a/skills/azure-diagnostics/SKILL.md
+++ b/skills/azure-diagnostics/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: azure-diagnostics
+description: Diagnose Azure resources, deployments, logs, and configuration
+---
+
+# Azure Diagnostics
+
+Use this skill when a user asks why an Azure service, deployment, identity, network path, or application is failing.
+
+## Workflow
+
+1. Identify subscription, resource group, resource type, region, and recent changes.
+2. Prefer read-only Azure CLI commands and portal-equivalent diagnostics.
+3. Check deployment status, activity logs, app logs, metrics, identities, and network rules.
+4. Separate platform issues from application issues.
+5. Return a prioritized diagnosis with exact commands used and next fixes.
+
+## Guardrails
+
+- Do not mutate cloud resources without explicit approval.
+- Do not print secrets or connection strings.
+
+## Source
+
+Discovered from skills.sh trending: `microsoft/azure-skills`.

--- a/skills/clawdbot-self-security-audit/SKILL.md
+++ b/skills/clawdbot-self-security-audit/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: clawdbot-self-security-audit
+description: Audit OpenClaw configuration and workspace security posture
+---
+
+# Clawdbot Self Security Audit
+
+Use this skill when a user asks to harden an OpenClaw, Clawdbot, or agent workspace setup.
+
+## Workflow
+
+1. Inventory config files, channel integrations, secrets references, skills, cron jobs, and exposed services.
+2. Check for overbroad permissions, direct secrets, public endpoints, stale tokens, and risky automations.
+3. Treat the audit as read-only unless the user asks for fixes.
+4. Rank findings by impact and exploitability.
+5. Provide exact remediation steps with file paths or commands.
+
+## Guardrails
+
+- Do not print secret values.
+- Do not disable integrations without explicit approval.
+
+## Source
+
+Discovered from `sundial-org/awesome-openclaw-skills`.

--- a/skills/env-and-assets-bootstrap/SKILL.md
+++ b/skills/env-and-assets-bootstrap/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: env-and-assets-bootstrap
+description: Bootstrap local environment files, fixtures, and assets for a repo
+---
+
+# Environment And Assets Bootstrap
+
+Use this skill when a repo needs a local setup pass before development, testing, demos, or agent work.
+
+## Workflow
+
+1. Inspect setup docs, examples, `.env.example`, package scripts, and asset folders.
+2. Create missing local-only placeholders from documented examples.
+3. Install dependencies using the repo's package manager.
+4. Generate or download non-secret fixtures only when the docs allow it.
+5. Run the smallest health check and document remaining manual setup.
+
+## Guardrails
+
+- Never ask for API keys.
+- Never invent secrets.
+- Keep generated assets small, local, and easy to replace.
+
+## Source
+
+Discovered from skills.sh trending: `lllllllama/rigorpilot-skills`.

--- a/skills/explore-code/SKILL.md
+++ b/skills/explore-code/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: explore-code
+description: Explore unfamiliar codebases with focused questions and findings
+---
+
+# Explore Code
+
+Use this skill when a user asks where behavior lives, how a feature works, or what code needs to change.
+
+## Workflow
+
+1. Start from the user's target behavior or error.
+2. Search with `rg` for routes, commands, symbols, strings, and tests.
+3. Read the smallest connected set of files that explain the behavior.
+4. Build a short evidence-backed map of the relevant modules.
+5. Only propose edits after the ownership and data flow are clear.
+
+## Output
+
+Return file references, key functions, and a direct answer to the user's question.
+
+## Source
+
+Discovered from skills.sh trending: `lllllllama/rigorpilot-skills`.

--- a/skills/explore-run/SKILL.md
+++ b/skills/explore-run/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: explore-run
+description: Run a project just enough to verify behavior while exploring
+---
+
+# Explore Run
+
+Use this skill when code exploration needs a live run, smoke test, local server, CLI command, or reproduction script.
+
+## Workflow
+
+1. Inspect package scripts and setup docs before running commands.
+2. Choose the lightest command that exercises the behavior.
+3. Capture command, environment assumptions, and output summary.
+4. If the run fails, diagnose missing dependencies, config, ports, or fixtures.
+5. Stop background processes that are no longer needed.
+
+## Guardrails
+
+- Avoid destructive commands.
+- Prefer smoke tests before full suites.
+- Keep user-visible summaries concise.
+
+## Source
+
+Discovered from skills.sh trending: `lllllllama/rigorpilot-skills`.

--- a/skills/google-agents-cli-workflow/SKILL.md
+++ b/skills/google-agents-cli-workflow/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: google-agents-cli-workflow
+description: Build and run Google Agents CLI workflows
+---
+
+# Google Agents CLI Workflow
+
+Use this skill when working with Google Agents CLI workflows, agent orchestration, deployment pipelines, or local workflow tests.
+
+## Workflow
+
+1. Inspect the workflow definition, agent config, tools, and environment requirements.
+2. Validate the local CLI version and auth state.
+3. Run a minimal local workflow before deployment.
+4. Check tool permissions, inputs, outputs, logs, and failure branches.
+5. Document exact commands and any cloud-side resources touched.
+
+## Guardrails
+
+- Do not deploy or publish workflows without explicit user intent.
+- Do not request or expose API keys.
+
+## Source
+
+Discovered from skills.sh trending: `google/agents-cli`.

--- a/skills/homeassistant/SKILL.md
+++ b/skills/homeassistant/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: homeassistant
+description: Control and inspect Home Assistant entities and automations
+---
+
+# Home Assistant
+
+Use this skill when a user asks to check smart home state, control devices, run scenes, inspect automations, or troubleshoot Home Assistant entities.
+
+## Workflow
+
+1. Identify entity IDs, domains, area names, and the requested action.
+2. Read current state before changing anything.
+3. Use Home Assistant REST, WebSocket, or configured CLI tools.
+4. Confirm irreversible or disruptive actions such as unlocks, alarms, or garage controls.
+5. Report the final entity state and any errors.
+
+## Source
+
+Discovered from `sundial-org/awesome-openclaw-skills`.

--- a/skills/hyperframes-cli/SKILL.md
+++ b/skills/hyperframes-cli/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: hyperframes-cli
+description: Operate Hyperframes video workflows from the command line
+---
+
+# Hyperframes CLI
+
+Use this skill when a user wants to scaffold, render, inspect, or automate Hyperframes video projects from the terminal.
+
+## Workflow
+
+1. Check whether the Hyperframes CLI is installed and authenticated.
+2. Inspect project config, assets, scene definitions, and render targets.
+3. Run the smallest validation command before full renders.
+4. Capture render IDs, output paths, errors, and retry guidance.
+5. Keep generated files organized under the project asset or output directory.
+
+## Guardrails
+
+- Do not start expensive renders unless the user clearly asked for production output.
+- Preserve existing generated media unless cleanup is requested.
+
+## Source
+
+Discovered from skills.sh trending: `heygen-com/hyperframes`.

--- a/skills/hyperframes-core/SKILL.md
+++ b/skills/hyperframes-core/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: hyperframes-core
+description: Create structured AI video scenes with Hyperframes concepts
+---
+
+# Hyperframes Core
+
+Use this skill when a user wants to design AI-generated video scenes, storyboards, templates, or programmatic video assets with Hyperframes-style structure.
+
+## Workflow
+
+1. Clarify audience, aspect ratio, duration, visual style, and delivery channel.
+2. Break the video into scenes, beats, narration, and visual assets.
+3. Define reusable components for titles, lower thirds, transitions, and captions.
+4. Keep prompts specific about subject, motion, framing, and continuity.
+5. Export a concise production plan or implementation checklist.
+
+## Source
+
+Discovered from skills.sh trending: `heygen-com/hyperframes`.

--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: imsg
+description: Search, inspect, and send iMessage or SMS through a local CLI
+---
+
+# iMessage CLI
+
+Use this skill when a user asks to search iMessage history, inspect chats, watch incoming messages, or send iMessage/SMS through a configured local CLI.
+
+## Workflow
+
+1. Identify the contact, group, chat ID, date range, and requested operation.
+2. Use read-only search or list commands before sending.
+3. Draft outbound messages clearly and ask for approval when the user has not explicitly authorized sending.
+4. Record message IDs and timestamps after sends.
+5. Keep private message contents out of unrelated summaries.
+
+## Source
+
+Discovered from `sundial-org/awesome-openclaw-skills`.

--- a/skills/mcporter/SKILL.md
+++ b/skills/mcporter/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: mcporter
+description: Manage and call MCP servers and tools with mcporter
+---
+
+# Mcporter
+
+Use this skill when a user asks to list MCP servers, inspect tool schemas, configure auth, call MCP tools, or debug MCP connectivity.
+
+## Workflow
+
+1. Inspect configured MCP servers and transport type.
+2. Validate server health and available tools.
+3. Read tool schemas before calling tools.
+4. Prefer non-mutating calls while diagnosing.
+5. Document server name, tool name, arguments, and result summary.
+
+## Guardrails
+
+- Do not expose tokens or secrets from MCP configs.
+- Confirm before invoking tools that mutate external systems.
+
+## Source
+
+Discovered from `sundial-org/awesome-openclaw-skills`.

--- a/skills/ms365/SKILL.md
+++ b/skills/ms365/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: ms365
+description: Work with Microsoft 365 services through CLI or Graph APIs
+---
+
+# Microsoft 365
+
+Use this skill when a user asks to inspect or automate Microsoft 365 mail, calendar, files, users, groups, Teams, SharePoint, or tenant configuration.
+
+## Workflow
+
+1. Identify the service, tenant context, user, and required permission scope.
+2. Prefer the Microsoft 365 CLI, Microsoft Graph CLI, or documented Graph endpoints.
+3. Use read-only checks before creating or changing objects.
+4. Capture IDs, URLs, timestamps, and permission assumptions.
+5. Summarize actions and any admin approval needed.
+
+## Guardrails
+
+- Do not request secrets.
+- Do not send messages, change permissions, or delete resources without explicit approval.
+
+## Source
+
+Discovered from `sundial-org/awesome-openclaw-skills`.

--- a/skills/prisma-cli/SKILL.md
+++ b/skills/prisma-cli/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: prisma-cli
+description: Use the Prisma CLI for schema, migration, and database tasks
+---
+
+# Prisma CLI
+
+Use this skill when a task involves Prisma schema validation, migrations, generation, seeding, or local database inspection.
+
+## Workflow
+
+1. Inspect `schema.prisma`, package scripts, and the configured Prisma version.
+2. Prefer existing npm scripts before raw `prisma` commands.
+3. Use `prisma validate`, `prisma format`, and `prisma generate` for safe checks.
+4. Treat migrations as user-visible data changes and explain their impact.
+5. Verify generated client usage with tests or a small smoke command.
+
+## Guardrails
+
+- Do not run destructive reset commands without explicit approval.
+- Do not read production database credentials.
+
+## Source
+
+Discovered from skills.sh trending: `prisma/skills`.

--- a/skills/prisma-client-api/SKILL.md
+++ b/skills/prisma-client-api/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: prisma-client-api
+description: Use Prisma Client APIs safely in application code
+---
+
+# Prisma Client API
+
+Use this skill when implementing, reviewing, or debugging code that calls Prisma Client.
+
+## Workflow
+
+1. Inspect the Prisma schema, generated client version, and datasource.
+2. Choose typed client methods that match the data model and relation needs.
+3. Handle pagination, transactions, nested writes, and error cases explicitly.
+4. Avoid N+1 queries and accidental broad reads.
+5. Add focused tests around query shape and edge cases.
+
+## Guardrails
+
+- Do not change migrations unless the user asked for schema changes.
+- Check official Prisma docs when behavior may be version-sensitive.
+
+## Source
+
+Discovered from skills.sh trending: `prisma/skills`.

--- a/skills/run-train/SKILL.md
+++ b/skills/run-train/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: run-train
+description: Run and document ML training or fine-tuning jobs
+---
+
+# Run Train
+
+Use this skill when a user asks to launch, debug, or document a model training, fine-tuning, or evaluation run.
+
+## Workflow
+
+1. Identify the training entry point, config, dataset, checkpoint, and output directory.
+2. Verify hardware requirements, dependency versions, and auth-free data access.
+3. Start with a tiny dry run or overfit batch when possible.
+4. Record exact commands, seeds, metrics, logs, and generated artifacts.
+5. Summarize cost, runtime, result quality, and next experiment choices.
+
+## Guardrails
+
+- Do not use private datasets unless the user provided them for this task.
+- Avoid long or expensive jobs without clear user intent.
+
+## Source
+
+Discovered from skills.sh trending: `lllllllama/rigorpilot-skills`.

--- a/skills/sonoscli/SKILL.md
+++ b/skills/sonoscli/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: sonoscli
+description: Control Sonos speakers and groups from the command line
+---
+
+# Sonos CLI
+
+Use this skill when a user asks to play, pause, group, ungroup, adjust volume, inspect status, or troubleshoot Sonos speakers.
+
+## Workflow
+
+1. Discover available speakers and groups.
+2. Read current playback and volume state before changes.
+3. Apply the requested command to the correct room or group.
+4. Avoid abrupt high-volume changes.
+5. Report final playback state, room, and volume.
+
+## Source
+
+Discovered from `sundial-org/awesome-openclaw-skills`.

--- a/skills/to-questionnaire/SKILL.md
+++ b/skills/to-questionnaire/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: to-questionnaire
+description: Turn messy requirements into a concise questionnaire
+---
+
+# To Questionnaire
+
+Use this skill when a project, feature, or process is underspecified and the best next step is a small set of targeted questions.
+
+## Workflow
+
+1. Extract known requirements, constraints, stakeholders, and unknowns.
+2. Group unknowns by decision area.
+3. Ask only questions whose answers change the work.
+4. Prefer multiple choice where tradeoffs are clear.
+5. Keep the questionnaire short enough to answer in one sitting.
+
+## Output
+
+Return grouped questions with brief context for why each answer matters.
+
+## Source
+
+Discovered from skills.sh trending: `mattpocock/skills`.

--- a/skills/writing-for-agents/SKILL.md
+++ b/skills/writing-for-agents/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: writing-for-agents
+description: Write instructions that agents can execute reliably
+---
+
+# Writing For Agents
+
+Use this skill when drafting prompts, playbooks, skill instructions, agent specs, or operational procedures.
+
+## Workflow
+
+1. State the trigger clearly.
+2. Give the agent an ordered workflow with concrete decision points.
+3. Define inputs, outputs, safety rules, and failure handling.
+4. Include examples only when they remove ambiguity.
+5. Remove vague advice, motivational filler, and conflicting instructions.
+
+## Output
+
+Produce concise instructions an agent can follow without guessing.
+
+## Source
+
+Discovered from skills.sh trending: `mattpocock/skills`.


### PR DESCRIPTION
## Summary
- Add 20 daily discovery SKILL.md stubs from skills.sh trending and sundial-org/awesome-openclaw-skills.
- Cover project analysis, AI research reproduction, Prisma, Hyperframes, Azure diagnostics, Google Agents CLI, Microsoft 365, Home Assistant, Sonos, mcporter, OpenClaw security audit, and iMessage workflows.

Linear: ORT-2603

## Verification
- Ran `git diff --check`.
- Checked all new stubs for basic frontmatter shape.

Reviewers: @christianpickettcode @berasogut