### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/angular-developer/SKILL.md
+++ b/skills/angular-developer/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: angular-developer
+description: Build and maintain Angular applications with components, services, routing, forms, and tests.
+---
+
+# Angular Developer
+
+Use this skill when implementing or reviewing Angular code.
+
+## Stub Workflow
+
+1. Inspect module or standalone component structure and existing style conventions.
+2. Keep state, services, templates, and route boundaries explicit.
+3. Add tests for component behavior, services, and route flows.
+4. Verify accessibility, change detection behavior, and production build output.
+
+## Source
+
+Discovered from skills.sh trending, `angular/skills`.

--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: browser-testing-with-devtools
+description: Debug browser behavior with DevTools traces, network inspection, console logs, and screenshots.
+---
+
+# Browser Testing With DevTools
+
+Use this skill when a web issue needs direct browser diagnosis.
+
+## Stub Workflow
+
+1. Reproduce the issue in a controlled browser session.
+2. Inspect console output, network requests, storage, layout, and performance traces.
+3. Capture screenshots or traces for evidence when useful.
+4. Fix the root cause and add regression coverage.
+
+## Source
+
+Discovered from skills.sh trending, `addyosmani/agent-skills`.

--- a/skills/clerk-backend-api/SKILL.md
+++ b/skills/clerk-backend-api/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: clerk-backend-api
+description: Use Clerk backend APIs for users, organizations, sessions, invitations, and webhooks.
+---
+
+# Clerk Backend API
+
+Use this skill when server code needs to query or mutate Clerk resources.
+
+## Stub Workflow
+
+1. Confirm which Clerk resource is needed: user, organization, membership, session, or invitation.
+2. Use server-side SDKs or REST APIs with scoped credentials.
+3. Handle pagination, idempotency, validation, and permission checks.
+4. Add tests around auth failure, missing resources, and role boundaries.
+
+## Source
+
+Discovered from skills.sh trending, `clerk/skills`.

--- a/skills/clerk-setup/SKILL.md
+++ b/skills/clerk-setup/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: clerk-setup
+description: Set up Clerk authentication, providers, middleware, environment variables, and local testing.
+---
+
+# Clerk Setup
+
+Use this skill when integrating Clerk into a web application.
+
+## Stub Workflow
+
+1. Identify framework, router, auth boundaries, and required sign-in methods.
+2. Add Clerk provider, middleware, route protection, and environment variable guidance.
+3. Configure local development and preview deployment settings.
+4. Verify login, logout, protected routes, and session refresh behavior.
+
+## Source
+
+Discovered from skills.sh trending, `clerk/skills`.

--- a/skills/clerk-webhooks/SKILL.md
+++ b/skills/clerk-webhooks/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: clerk-webhooks
+description: Implement and verify Clerk webhook handlers for user, organization, and membership events.
+---
+
+# Clerk Webhooks
+
+Use this skill when building Clerk webhook consumers.
+
+## Stub Workflow
+
+1. List required events and downstream side effects.
+2. Verify signatures before parsing trusted payloads.
+3. Make handlers idempotent and resilient to retries.
+4. Test event fixtures for create, update, delete, and out-of-order delivery.
+
+## Source
+
+Discovered from skills.sh trending, `clerk/skills`.

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: code-review-and-quality
+description: Review code for correctness, maintainability, tests, security, and production readiness.
+---
+
+# Code Review And Quality
+
+Use this skill when reviewing a code change or preparing one for review.
+
+## Stub Workflow
+
+1. Read the diff and the surrounding code before judging the change.
+2. Prioritize correctness, regressions, data loss, security, and missing tests.
+3. Separate blocking findings from style or cleanup suggestions.
+4. Verify fixes with the smallest meaningful test command.
+
+## Source
+
+Discovered from skills.sh trending, `addyosmani/agent-skills`.

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: deprecation-and-migration
+description: Plan and execute deprecations, migrations, compatibility windows, and cleanup work.
+---
+
+# Deprecation And Migration
+
+Use this skill when replacing APIs, libraries, flags, schemas, or workflows.
+
+## Stub Workflow
+
+1. Inventory consumers, compatibility requirements, and rollback paths.
+2. Design a phased migration with warnings, telemetry, and documentation.
+3. Implement adapters or dual-write paths only where risk justifies them.
+4. Remove deprecated code after adoption is verified.
+
+## Source
+
+Discovered from skills.sh trending, `addyosmani/agent-skills`.

--- a/skills/gh-stack/SKILL.md
+++ b/skills/gh-stack/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gh-stack
+description: Manage stacked GitHub pull requests, branch dependencies, and incremental review flows.
+---
+
+# gh-stack
+
+Use this skill when a change should be split into stacked PRs.
+
+## Stub Workflow
+
+1. Identify independent review units and branch dependencies.
+2. Create or update stacked branches with clear base relationships.
+3. Keep each PR small, reviewable, and tested.
+4. Rebase or restack after upstream changes and document the review order.
+
+## Source
+
+Discovered from skills.sh trending, `github/gh-stack`.

--- a/skills/gsap-core/SKILL.md
+++ b/skills/gsap-core/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gsap-core
+description: Build polished GSAP animations with timelines, easing, cleanup, and accessibility checks.
+---
+
+# GSAP Core
+
+Use this skill when implementing GreenSock animations.
+
+## Stub Workflow
+
+1. Define animation purpose, trigger, duration, and reduced-motion fallback.
+2. Use timelines for sequencing and cleanup hooks for component lifecycles.
+3. Avoid layout thrash by animating transform and opacity where possible.
+4. Verify interactions on desktop and mobile.
+
+## Source
+
+Discovered from skills.sh trending, `greensock/gsap-skills`.

--- a/skills/gsap-scrolltrigger/SKILL.md
+++ b/skills/gsap-scrolltrigger/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gsap-scrolltrigger
+description: Implement GSAP ScrollTrigger scenes with responsive triggers, pinning, scrub, and cleanup.
+---
+
+# GSAP ScrollTrigger
+
+Use this skill when scroll position drives animations.
+
+## Stub Workflow
+
+1. Define trigger elements, start and end positions, scrub behavior, and pinning needs.
+2. Add responsive matchMedia rules when layouts change across breakpoints.
+3. Refresh triggers after content or media loads.
+4. Test reduced motion, touch scrolling, and cleanup on navigation.
+
+## Source
+
+Discovered from skills.sh trending, `greensock/gsap-skills`.

--- a/skills/linear-release-setup/SKILL.md
+++ b/skills/linear-release-setup/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: linear-release-setup
+description: Configure Linear release workflows, project milestones, release issues, and shipping checklists.
+---
+
+# Linear Release Setup
+
+Use this skill when setting up or improving a Linear-backed release workflow.
+
+## Stub Workflow
+
+1. Identify the product, project, release cadence, and target branch strategy.
+2. Map release stages to Linear projects, milestones, labels, cycles, and issue templates.
+3. Create a checklist for cutoff, QA, launch notes, rollback, and post-release follow-up.
+4. Document automation hooks for GitHub PRs, CI, changelog generation, and Slack updates.
+
+## Source
+
+Discovered from skills.sh trending, `linear/linear-release`.

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: observability-and-instrumentation
+description: Add practical logging, metrics, traces, events, dashboards, and alerting for production systems.
+---
+
+# Observability And Instrumentation
+
+Use this skill when improving production visibility.
+
+## Stub Workflow
+
+1. Identify user journeys, service boundaries, failure modes, and current blind spots.
+2. Add structured logs, metrics, traces, and domain events with bounded cardinality.
+3. Define dashboards and alerts tied to user impact.
+4. Verify instrumentation in local, staging, and production-like flows.
+
+## Source
+
+Discovered from skills.sh trending, `addyosmani/agent-skills`.

--- a/skills/open-knowledge-discovery/SKILL.md
+++ b/skills/open-knowledge-discovery/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: open-knowledge-discovery
+description: Discover, retrieve, and cite open knowledge sources for research and documentation tasks.
+---
+
+# Open Knowledge Discovery
+
+Use this skill when a task needs careful discovery across open documentation, public datasets, and community knowledge bases.
+
+## Stub Workflow
+
+1. Clarify the research question and the required confidence level.
+2. Search primary sources first, then trusted indexes and community references.
+3. Capture source URLs, dates, licensing notes, and key claims.
+4. Return a concise synthesis with unresolved gaps called out explicitly.
+
+## Source
+
+Discovered from skills.sh trending, `inkeep/open-knowledge-skills`.

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: planning-and-task-breakdown
+description: Break ambiguous work into scoped tasks, dependencies, risks, and executable next actions.
+---
+
+# Planning And Task Breakdown
+
+Use this skill when turning a fuzzy request into an implementation plan.
+
+## Stub Workflow
+
+1. Clarify the goal, constraints, required outputs, and definition of done.
+2. Break the work into small tasks with dependencies and risk notes.
+3. Identify what can run in parallel and what needs sequencing.
+4. Keep the plan updated as evidence changes.
+
+## Source
+
+Discovered from skills.sh trending, `addyosmani/agent-skills`.

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: security-and-hardening
+description: Harden applications, services, dependencies, credentials, permissions, and deployment surfaces.
+---
+
+# Security And Hardening
+
+Use this skill when auditing or improving security posture.
+
+## Stub Workflow
+
+1. Identify assets, trust boundaries, authentication, authorization, and secret handling.
+2. Check dependency, input validation, network, storage, and logging risks.
+3. Recommend concrete mitigations with owner and verification steps.
+4. Re-test the highest-risk paths after changes.
+
+## Source
+
+Discovered from skills.sh trending, `addyosmani/agent-skills`.

--- a/skills/solana-dev/SKILL.md
+++ b/skills/solana-dev/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: solana-dev
+description: Build, test, and debug Solana programs, clients, wallets, and local validator workflows.
+---
+
+# Solana Dev
+
+Use this skill when working on Solana smart contracts or client integrations.
+
+## Stub Workflow
+
+1. Identify whether the task touches programs, clients, wallets, RPC, or local validators.
+2. Confirm cluster, keypair handling, and transaction signing requirements.
+3. Add focused tests for accounts, instructions, errors, and token flows.
+4. Document deployment, migration, and rollback steps.
+
+## Source
+
+Discovered from skills.sh trending, `solana-foundation/solana-dev-skill`.

--- a/skills/source-driven-development/SKILL.md
+++ b/skills/source-driven-development/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: source-driven-development
+description: Ground implementation decisions in primary sources, local code evidence, and explicit assumptions.
+---
+
+# Source Driven Development
+
+Use this skill when accuracy depends on documentation, code evidence, or external specs.
+
+## Stub Workflow
+
+1. Identify the authoritative sources before changing behavior.
+2. Read local code paths and tests that prove current behavior.
+3. Keep assumptions explicit when sources disagree or are incomplete.
+4. Cite files, docs, commits, or issues in the final implementation notes.
+
+## Source
+
+Discovered from skills.sh trending, `addyosmani/agent-skills`.

--- a/skills/stripe-docs/SKILL.md
+++ b/skills/stripe-docs/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: stripe-docs
+description: Use Stripe documentation to design payments, billing, Connect, and webhook implementations.
+---
+
+# Stripe Docs
+
+Use this skill when a task depends on Stripe API behavior or integration guidance.
+
+## Stub Workflow
+
+1. Identify the Stripe product area and API version in use.
+2. Prefer official docs, SDK examples, and webhook event references.
+3. Model happy paths, failed payments, retries, refunds, and disputes where relevant.
+4. Test with Stripe test mode, fixtures, and webhook signature verification.
+
+## Source
+
+Discovered from skills.sh trending, `docs.stripe.com`.

--- a/skills/stripe-projects/SKILL.md
+++ b/skills/stripe-projects/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: stripe-projects
+description: Plan and implement Stripe payment projects with milestones, rollout checks, and test mode validation.
+---
+
+# Stripe Projects
+
+Use this skill when coordinating a Stripe integration as a project.
+
+## Stub Workflow
+
+1. Define the business flow, products, prices, customers, and settlement needs.
+2. Break work into API, frontend, webhook, reporting, and operations tasks.
+3. Validate test mode flows before live-mode rollout.
+4. Document monitoring, reconciliation, and support procedures.
+
+## Source
+
+Discovered from skills.sh trending, `stripe/ai`.

--- a/skills/unlazy/SKILL.md
+++ b/skills/unlazy/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: unlazy
+description: Optimize image loading, lazy-loading behavior, responsive sources, and perceived page speed.
+---
+
+# Unlazy
+
+Use this skill when improving frontend image loading and visual performance.
+
+## Stub Workflow
+
+1. Inventory images, sizes, formats, priorities, and layout stability risks.
+2. Define eager, lazy, placeholder, and responsive source behavior per viewport.
+3. Check Core Web Vitals impact, especially LCP and CLS.
+4. Verify output with browser traces or screenshots.
+
+## Source
+
+Discovered from skills.sh trending, `leonxlnx/unlazy`.


### PR DESCRIPTION
## Summary
- Add 20 fresh SKILL.md stubs from the August 21 daily discovery sweep
- Sources: skills.sh trending and sundial-org/awesome-openclaw-skills
- Avoided entries already present in orthogonal-sh/skills and memory/discovery-posts.md

## Linear
- ORT-2610: https://linear.app/orthogonalsh/issue/ORT-2610/daily-skills-discovery-batch-90

## Test Plan
- ruby -EUTF-8 YAML frontmatter parse over the 20 new SKILL.md files
- git diff --cached --check
