### PR TITLE
Add daily discovered skill stubs

### DIFF
--- a/skills/clerk-nextjs-patterns/SKILL.md
+++ b/skills/clerk-nextjs-patterns/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: clerk-nextjs-patterns
+description: Implement Clerk auth patterns in Next.js with middleware, sessions, orgs, webhooks, and tests
+---
+
+# Clerk Next.js Patterns
+
+Use this skill when adding or reviewing Clerk authentication in a Next.js app.
+
+## Workflow
+
+1. Identify the router mode, Clerk package versions, middleware file, and protected routes.
+2. Model public, signed-in, signed-out, organization, and role-gated states.
+3. Keep server-side auth checks close to data access.
+4. Add webhook verification before processing user or organization events.
+5. Test redirects, session loading states, and unauthorized paths.
+
+## Checks
+
+- Never expose secret keys to client bundles.
+- Validate middleware matchers for static assets and APIs.
+- Handle expired sessions and missing organizations.
+- Keep local and production redirect URLs aligned.

--- a/skills/cloudflare-one-migrations/SKILL.md
+++ b/skills/cloudflare-one-migrations/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: cloudflare-one-migrations
+description: Migrate apps, tunnels, access policies, and DNS routing into Cloudflare One with rollout checks
+---
+
+# Cloudflare One Migrations
+
+Use this skill when moving services, access rules, tunnels, or DNS flows into Cloudflare One or between Cloudflare accounts.
+
+## Workflow
+
+1. Inventory the current ingress, auth, DNS, firewall, and device posture setup.
+2. Map each legacy rule to a Cloudflare One equivalent.
+3. Create a migration plan with test users, canary routes, rollback steps, and owner signoff.
+4. Apply changes in small batches and verify logs after each batch.
+5. Remove legacy rules only after traffic and access checks pass.
+
+## Checks
+
+- Keep DNS TTLs low during switchover.
+- Validate tunnel health and route precedence.
+- Confirm break-glass access still works.
+- Capture before and after policy diffs.

--- a/skills/cloudflare-one/SKILL.md
+++ b/skills/cloudflare-one/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: cloudflare-one
+description: Plan and validate Cloudflare One access, Zero Trust, tunnels, DNS, and network security changes
+---
+
+# Cloudflare One
+
+Use this skill when working with Cloudflare One, Zero Trust, Access, Gateway, tunnels, WARP, DNS policy, or network security changes.
+
+## Workflow
+
+1. Identify the Cloudflare account, zone, application, tunnel, identity provider, and policy surface involved.
+2. Read the current configuration before proposing edits.
+3. Separate identity policy, network routing, DNS, and device posture concerns.
+4. Prefer staged rollout with a test group, logging, and a rollback path.
+5. Verify access from an allowed and denied user or device path.
+
+## Checks
+
+- Confirm policy order and default deny behavior.
+- Check DNS, route, and tunnel overlap before changes.
+- Preserve emergency access paths.
+- Document affected users, apps, and networks.

--- a/skills/firebase-firestore-enterprise-native-mode/SKILL.md
+++ b/skills/firebase-firestore-enterprise-native-mode/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: firebase-firestore-enterprise-native-mode
+description: Model, query, secure, and migrate Firestore Enterprise native mode databases
+---
+
+# Firestore Enterprise Native Mode
+
+Use this skill when working with Firestore Enterprise native mode schemas, indexes, queries, rules, migrations, or performance issues.
+
+## Workflow
+
+1. Identify collections, document shapes, access patterns, and consistency needs.
+2. Design composite indexes around real query filters and sort orders.
+3. Keep transactions and batch writes bounded and retry-aware.
+4. Validate security rules with emulator tests when possible.
+5. Measure read, write, and storage costs for the proposed shape.
+
+## Checks
+
+- Avoid hot documents and unbounded fanout writes.
+- Prefer explicit denormalization over cross-collection joins.
+- Check migration backfill idempotency.
+- Verify production indexes before rollout.

--- a/skills/golang-context/SKILL.md
+++ b/skills/golang-context/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-context
+description: Use Go context correctly for cancellation, deadlines, request scope, and goroutine cleanup
+---
+
+# Go Context
+
+Use this skill when adding or reviewing `context.Context` usage in Go code.
+
+## Workflow
+
+1. Pass context as the first parameter for request-scoped work.
+2. Derive deadlines and cancellation at ownership boundaries.
+3. Avoid storing context in structs unless a framework requires it.
+4. Thread cancellation through I/O, database, and worker calls.
+5. Test cancellation, timeout, and cleanup paths.
+
+## Checks
+
+- Do not use context for optional function parameters.
+- Always call cancel functions when creating derived contexts.
+- Keep context values limited to request-scoped metadata.
+- Ensure goroutines exit when context is canceled.

--- a/skills/golang-database/SKILL.md
+++ b/skills/golang-database/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-database
+description: Build Go database code with transactions, pooling, migrations, query shape, and test coverage
+---
+
+# Go Database
+
+Use this skill when implementing or reviewing database access in Go services.
+
+## Workflow
+
+1. Identify the database driver, query library, migration system, and transaction boundaries.
+2. Keep SQL, parameters, scanning, and error handling explicit.
+3. Use contexts with deadlines for database calls.
+4. Add tests for successful queries, missing rows, constraint failures, and transaction rollback.
+5. Review connection pooling, indexes, and query plans for hot paths.
+
+## Checks
+
+- Avoid string-built SQL with user input.
+- Distinguish not-found errors from real failures.
+- Keep migrations reversible or clearly forward-only.
+- Close rows and release resources promptly.

--- a/skills/golang-dependency-management/SKILL.md
+++ b/skills/golang-dependency-management/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-dependency-management
+description: Manage Go modules, versions, replacements, vulnerability checks, and dependency update workflows
+---
+
+# Go Dependency Management
+
+Use this skill when updating, auditing, or troubleshooting Go module dependencies.
+
+## Workflow
+
+1. Inspect `go.mod`, `go.sum`, toolchain version, and replace directives.
+2. Check why a dependency is present before changing it.
+3. Update the narrowest useful dependency set.
+4. Run tests, vetting, and vulnerability checks where available.
+5. Commit dependency files with a clear explanation of the change.
+
+## Checks
+
+- Avoid broad upgrades for unrelated work.
+- Review transitive dependency changes.
+- Keep generated files in sync.
+- Remove stale replace directives after local testing.

--- a/skills/golang-design-patterns/SKILL.md
+++ b/skills/golang-design-patterns/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-design-patterns
+description: Apply idiomatic Go design patterns for interfaces, packages, composition, and maintainable services
+---
+
+# Go Design Patterns
+
+Use this skill when designing or refactoring Go packages, services, interfaces, and shared abstractions.
+
+## Workflow
+
+1. Start from concrete call sites and package boundaries.
+2. Prefer small interfaces owned by consumers.
+3. Use composition and plain functions before larger frameworks.
+4. Keep constructors explicit about dependencies and defaults.
+5. Add tests around behavior, not implementation shape.
+
+## Checks
+
+- Avoid premature generic abstractions.
+- Keep package names short and meaningful.
+- Prevent import cycles with clear ownership.
+- Document exported types and functions.

--- a/skills/golang-modernize/SKILL.md
+++ b/skills/golang-modernize/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-modernize
+description: Modernize Go code with current language features, tooling, modules, tests, and cleanup patterns
+---
+
+# Go Modernize
+
+Use this skill when updating older Go code to current idioms and tooling.
+
+## Workflow
+
+1. Inspect the Go version, module settings, CI, linters, and dependency age.
+2. Identify changes that improve clarity, safety, or maintainability.
+3. Apply small modernizations such as `errors.Is`, `errors.As`, `context`, `testing` helpers, generics where justified, and cleaner module usage.
+4. Preserve public APIs unless the task explicitly allows breaking changes.
+5. Run tests and tooling after each meaningful set of changes.
+
+## Checks
+
+- Avoid novelty for its own sake.
+- Keep generated code and vendored code out of manual rewrites.
+- Confirm minimum supported Go version.
+- Document behavioral changes separately from style cleanup.

--- a/skills/golang-observability/SKILL.md
+++ b/skills/golang-observability/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-observability
+description: Add Go logging, metrics, traces, health checks, and operational diagnostics
+---
+
+# Go Observability
+
+Use this skill when instrumenting Go services, workers, or CLIs.
+
+## Workflow
+
+1. Identify critical requests, background jobs, dependencies, and failure modes.
+2. Add structured logs with stable fields and request correlation.
+3. Emit metrics for rate, errors, duration, saturation, and queue depth.
+4. Trace cross-service calls and slow paths where useful.
+5. Add health and readiness checks that match runtime dependencies.
+
+## Checks
+
+- Avoid logging secrets or large payloads.
+- Keep metric labels bounded.
+- Propagate trace context through outbound calls.
+- Test observability behavior on error paths.

--- a/skills/golang-performance/SKILL.md
+++ b/skills/golang-performance/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-performance
+description: Profile and improve Go CPU, memory, allocations, latency, concurrency, and benchmark behavior
+---
+
+# Go Performance
+
+Use this skill when diagnosing or improving Go performance.
+
+## Workflow
+
+1. Define the target metric: latency, throughput, CPU, memory, allocations, or startup time.
+2. Reproduce with a benchmark, profile, trace, or production sample.
+3. Inspect hot paths before changing code.
+4. Make one measurable optimization at a time.
+5. Re-run benchmarks and compare before and after results.
+
+## Checks
+
+- Use `pprof`, `trace`, benchmarks, and race checks as appropriate.
+- Watch allocation churn in loops and serialization paths.
+- Avoid making code less clear for unmeasured wins.
+- Include representative input sizes.

--- a/skills/golang-project-layout/SKILL.md
+++ b/skills/golang-project-layout/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-project-layout
+description: Structure Go modules, packages, commands, internal code, tests, and configuration idiomatically
+---
+
+# Go Project Layout
+
+Use this skill when creating or reorganizing Go repositories.
+
+## Workflow
+
+1. Identify binaries, libraries, internal packages, generated code, and deployment assets.
+2. Keep package boundaries aligned with ownership and import direction.
+3. Put commands under `cmd/` only when there are multiple binaries or meaningful entrypoints.
+4. Use `internal/` for implementation that should not become public API.
+5. Keep tests close to the code unless integration fixtures need separate structure.
+
+## Checks
+
+- Avoid generic package names like `utils`.
+- Keep module paths and import names stable.
+- Document local development commands.
+- Make configuration explicit and environment-aware.

--- a/skills/golang-security/SKILL.md
+++ b/skills/golang-security/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: golang-security
+description: Review Go services for auth, input validation, crypto, secrets, dependencies, and secure defaults
+---
+
+# Go Security
+
+Use this skill when reviewing or hardening Go code.
+
+## Workflow
+
+1. Identify trust boundaries, external inputs, credentials, and privileged operations.
+2. Validate request parsing, auth checks, authorization, and error paths.
+3. Review cryptography, TLS, random generation, and token handling.
+4. Scan dependencies and generated files for known issues.
+5. Add tests for rejected input and unauthorized access.
+
+## Checks
+
+- Never log secrets or bearer tokens.
+- Keep timeouts on network calls.
+- Use constant-time comparison for secrets when needed.
+- Prefer standard library crypto over custom implementations.

--- a/skills/gsap-frameworks/SKILL.md
+++ b/skills/gsap-frameworks/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: gsap-frameworks
+description: Integrate GSAP across React, Next.js, Vue, Svelte, and SSR frameworks without lifecycle bugs
+---
+
+# GSAP Frameworks
+
+Use this skill when integrating GSAP in a frontend framework or SSR app.
+
+## Workflow
+
+1. Identify the framework, rendering mode, hydration boundary, and animation target.
+2. Run GSAP only where DOM APIs are available.
+3. Scope selectors, refs, and timelines to the component or page section.
+4. Clean up animations during route transitions and component unmount.
+5. Verify SSR, hydration, and mobile behavior.
+
+## Checks
+
+- Guard browser-only code from server execution.
+- Respect reduced-motion settings.
+- Keep animation initialization idempotent.
+- Validate no text or controls overlap during animation.

--- a/skills/gsap-react/SKILL.md
+++ b/skills/gsap-react/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: gsap-react
+description: Build React animations with GSAP contexts, cleanup, refs, timelines, and lifecycle-safe hooks
+---
+
+# GSAP React
+
+Use this skill when adding or reviewing GSAP animations in React.
+
+## Workflow
+
+1. Identify component ownership, refs, timeline lifecycle, and trigger conditions.
+2. Use scoped GSAP contexts or the project-standard React integration.
+3. Clean up animations on unmount and dependency changes.
+4. Keep animation state separate from application state unless interaction requires it.
+5. Test mount, rerender, route change, and reduced-motion cases.
+
+## Checks
+
+- Avoid querying outside the component scope.
+- Do not animate layout-critical content before it is measured.
+- Prevent duplicate timelines in strict mode.
+- Keep interactive controls keyboard accessible.

--- a/skills/gsap-utils/SKILL.md
+++ b/skills/gsap-utils/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: gsap-utils
+description: Use GSAP utility helpers for interpolation, snapping, wrapping, randomization, and reusable animation math
+---
+
+# GSAP Utils
+
+Use this skill when implementing animation math with GSAP utility helpers.
+
+## Workflow
+
+1. Identify where interpolation, snapping, wrapping, clamping, mapping, or randomization is needed.
+2. Prefer GSAP utility helpers over custom one-off math when they fit.
+3. Keep reusable helpers pure and easy to test.
+4. Validate animation output across initial, midpoint, and final states.
+5. Check reduced-motion behavior for nonessential motion.
+
+## Checks
+
+- Avoid recreating helper functions on every render.
+- Keep units explicit when mapping values to CSS.
+- Test boundary values for clamp and wrap behavior.
+- Ensure random values are acceptable for visual regression tests.

--- a/skills/gws-calendar-agenda/SKILL.md
+++ b/skills/gws-calendar-agenda/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: gws-calendar-agenda
+description: Build Google Calendar agendas, upcoming-event summaries, conflict checks, and preparation lists
+---
+
+# Google Workspace Calendar Agenda
+
+Use this skill when reading Google Calendar events or preparing an agenda.
+
+## Workflow
+
+1. Identify the calendar account, date range, timezone, and calendars to include.
+2. Fetch events with start, end, attendees, location, conferencing, and notes.
+3. Highlight conflicts, travel buffers, preparation needs, and soon-starting events.
+4. Convert relative times to explicit local times.
+5. Keep private event details minimal in shared contexts.
+
+## Checks
+
+- Confirm timezone before reporting times.
+- Treat all-day and tentative events separately.
+- Watch for hidden details on shared calendars.
+- Ask before creating, editing, or deleting events unless explicitly instructed.

--- a/skills/gws-gmail-read/SKILL.md
+++ b/skills/gws-gmail-read/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: gws-gmail-read
+description: Read Gmail messages with Google Workspace CLI, filters, labels, threads, and privacy-aware summaries
+---
+
+# Google Workspace Gmail Read
+
+Use this skill when reading Gmail through the Google Workspace CLI or equivalent Google APIs.
+
+## Workflow
+
+1. Identify the account, mailbox scope, labels, query, and time range.
+2. Fetch only the messages needed for the task.
+3. Summarize sender, subject, date, and actionable content.
+4. Preserve privacy by omitting irrelevant personal details.
+5. Link or reference message IDs when follow-up actions are needed.
+
+## Checks
+
+- Do not expose credentials or raw tokens.
+- Avoid broad mailbox searches when a focused query works.
+- Separate unread, starred, sent, and archived states.
+- Ask before sending or modifying mail unless explicitly instructed.

--- a/skills/gws-sheets-append/SKILL.md
+++ b/skills/gws-sheets-append/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: gws-sheets-append
+description: Append rows to Google Sheets with schema checks, dedupe, formatting awareness, and audit notes
+---
+
+# Google Workspace Sheets Append
+
+Use this skill when appending structured data to Google Sheets.
+
+## Workflow
+
+1. Identify spreadsheet ID, sheet name, columns, and expected row schema.
+2. Read headers before preparing appended rows.
+3. Normalize values for dates, currencies, links, booleans, and empty fields.
+4. Check for obvious duplicates when the sheet has a natural key.
+5. Append rows and report the affected range.
+
+## Checks
+
+- Do not overwrite existing rows during append.
+- Preserve column order and formulas.
+- Escape user-provided text safely.
+- Keep sensitive fields out unless the user explicitly requested them.

--- a/skills/remotion-maps/SKILL.md
+++ b/skills/remotion-maps/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: remotion-maps
+description: Build Remotion map scenes with tiles, routes, markers, camera motion, and render-safe assets
+---
+
+# Remotion Maps
+
+Use this skill when creating or debugging map-based videos in Remotion.
+
+## Workflow
+
+1. Define the map provider, tile source, attribution, route data, markers, and output dimensions.
+2. Preload or cache map assets so renders are deterministic.
+3. Animate camera moves with stable coordinates, zoom levels, and easing.
+4. Keep labels, markers, and route strokes legible at final export size.
+5. Render a short preview and inspect frames for missing tiles or layout drift.
+
+## Checks
+
+- Confirm provider licensing and attribution.
+- Avoid live network dependency during final render when possible.
+- Test high-DPI and social aspect ratios.
+- Keep route geometry simplified enough for smooth playback.


### PR DESCRIPTION
## Summary
- Add 20 SKILL.md stubs from the 2026-08-26 daily skills discovery batch
- Sources: skills.sh and sundial-org/awesome-openclaw-skills
- Checked against the current skills repo and memory/discovery-posts.md for duplicates

## Linear
- ORT-2633

## Test plan
- Verified all added stubs include YAML frontmatter
- Checked selected names against prior discovery posts

Reviewers: @christianpickettcode @berasogut