### PR TITLE
Add daily Azure skill stubs

### DIFF
--- a/skills/appinsights-instrumentation/SKILL.md
+++ b/skills/appinsights-instrumentation/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: appinsights-instrumentation
+description: "Instrument applications with Azure Application Insights traces, metrics, logs, dependencies, and alerts."
+---
+
+# App Insights Instrumentation
+
+Use this skill when adding or debugging Application Insights telemetry.
+
+## Stub
+
+- Confirm the app runtime, hosting platform, instrumentation key or connection string, and environment.
+- Capture requests, dependencies, exceptions, logs, custom metrics, and correlation IDs.
+- Avoid logging secrets, personal data, or high-cardinality values without a reason.
+- Verify telemetry in the Azure portal or query layer after deployment.

--- a/skills/azure-ai/SKILL.md
+++ b/skills/azure-ai/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-ai
+description: "Build, configure, and troubleshoot Azure AI services, model deployments, embeddings, and agent workflows."
+---
+
+# Azure AI
+
+Use this skill for Azure AI service setup, integration, or debugging.
+
+## Stub
+
+- Verify the Azure AI service, model, deployment name, region, and API version.
+- Check identity, endpoint configuration, content filters, quota, and rate limits.
+- Use small reproducible requests before changing larger application flows.
+- Include cost, privacy, and monitoring notes for production-facing changes.

--- a/skills/azure-aigateway/SKILL.md
+++ b/skills/azure-aigateway/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-aigateway
+description: "Configure Azure AI gateway patterns for routing, safety, observability, quotas, caching, and failover."
+---
+
+# Azure AI Gateway
+
+Use this skill when designing or debugging an Azure-hosted AI gateway.
+
+## Stub
+
+- Identify upstream model providers, downstream apps, auth model, and routing rules.
+- Review quota handling, retries, fallbacks, content safety, caching, and request logging.
+- Keep secrets out of logs and client-visible configuration.
+- Verify behavior with representative prompts, failures, and rate-limit cases.

--- a/skills/azure-compliance/SKILL.md
+++ b/skills/azure-compliance/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-compliance
+description: "Review Azure compliance posture, policies, regulatory controls, evidence, remediation, and audit readiness."
+---
+
+# Azure Compliance
+
+Use this skill for Azure policy, compliance, and audit readiness work.
+
+## Stub
+
+- Confirm the required framework, scope, subscriptions, and control owner.
+- Check policy assignments, exemptions, Defender recommendations, logging, and encryption.
+- Separate evidence gathering from remediation work.
+- Document residual risk, false positives, and any controls needing human approval.

--- a/skills/azure-compute/SKILL.md
+++ b/skills/azure-compute/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-compute
+description: "Manage Azure compute resources including VMs, App Service, Functions, Container Apps, scale, and health."
+---
+
+# Azure Compute
+
+Use this skill for Azure compute provisioning, deployment, or incident checks.
+
+## Stub
+
+- Confirm compute service, SKU, region, runtime, scaling rules, and environment.
+- Review identity, networking, secrets, startup commands, health checks, and logs.
+- Check CPU, memory, restarts, cold starts, quotas, and recent deployments.
+- Verify changes with service-specific smoke tests.

--- a/skills/azure-cost/SKILL.md
+++ b/skills/azure-cost/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-cost
+description: "Analyze Azure spend, budgets, reservations, rightsizing, idle resources, tags, and cost anomalies."
+---
+
+# Azure Cost
+
+Use this skill for Azure cost review or optimization.
+
+## Stub
+
+- Scope by subscription, resource group, tag, service, region, and time window.
+- Separate recurring baseline spend from one-off spikes and recent deployments.
+- Look for idle resources, oversized SKUs, retention settings, egress, and reservation opportunities.
+- Present savings ideas with risk, effort, and verification steps.

--- a/skills/azure-deploy/SKILL.md
+++ b/skills/azure-deploy/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-deploy
+description: "Deploy applications and infrastructure to Azure with environment checks, rollout validation, and rollback notes."
+---
+
+# Azure Deploy
+
+Use this skill when deploying an app or infrastructure change to Azure.
+
+## Stub
+
+- Confirm the target service, subscription, resource group, region, and deployment slot.
+- Review build artifacts, configuration, secrets, migrations, and dependency versions.
+- Prefer staged rollout, health checks, logs, and rollback instructions.
+- Verify the deployed endpoint or workload with a smoke test.

--- a/skills/azure-kubernetes/SKILL.md
+++ b/skills/azure-kubernetes/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-kubernetes
+description: "Operate AKS clusters, workloads, node pools, identities, ingress, scaling, upgrades, and diagnostics."
+---
+
+# Azure Kubernetes
+
+Use this skill for Azure Kubernetes Service setup, operations, or troubleshooting.
+
+## Stub
+
+- Confirm cluster, namespace, workload, node pool, Kubernetes version, and ingress path.
+- Check pods, events, logs, identities, secrets, network policy, autoscaling, and quotas.
+- Treat upgrades and node pool changes as staged operations with rollback notes.
+- Verify externally visible services and internal workload health after changes.

--- a/skills/azure-kusto/SKILL.md
+++ b/skills/azure-kusto/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-kusto
+description: "Query and troubleshoot Azure Data Explorer or Kusto logs, tables, ingestion, retention, and dashboards."
+---
+
+# Azure Kusto
+
+Use this skill for Azure Data Explorer, KQL, and Kusto-backed log analysis.
+
+## Stub
+
+- Confirm cluster, database, table, time window, schema, and permissions.
+- Write narrow KQL queries first, then expand only as needed.
+- Check ingestion health, retention, materialized views, and query performance.
+- Return reproducible queries with clear time bounds and assumptions.

--- a/skills/azure-messaging/SKILL.md
+++ b/skills/azure-messaging/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-messaging
+description: "Work with Azure Service Bus, Event Hubs, Event Grid, queues, topics, consumers, retries, and dead letters."
+---
+
+# Azure Messaging
+
+Use this skill for Azure messaging design, integration, or debugging.
+
+## Stub
+
+- Identify service type, namespace, queue or topic, consumer group, and message contract.
+- Check auth, network access, throughput units, retries, ordering, sessions, and dead letters.
+- Inspect metrics and sample messages without exposing sensitive payloads.
+- Validate producers and consumers with a small end-to-end test.

--- a/skills/azure-prepare/SKILL.md
+++ b/skills/azure-prepare/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-prepare
+description: "Prepare Azure environments, subscriptions, identity, networking, quotas, and deployment prerequisites."
+---
+
+# Azure Prepare
+
+Use this skill before Azure implementation or migration work.
+
+## Stub
+
+- Identify subscription, tenant, resource group, region, and environment tier.
+- Check permissions, service quotas, naming conventions, tags, and policy constraints.
+- Confirm networking, DNS, secrets, and observability requirements before provisioning.
+- Produce a short readiness checklist and call out blockers before deployment.

--- a/skills/azure-quotas/SKILL.md
+++ b/skills/azure-quotas/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-quotas
+description: "Check and request Azure quotas for compute, AI models, networking, storage, and regional capacity."
+---
+
+# Azure Quotas
+
+Use this skill when Azure capacity, quota, throttling, or allocation limits block work.
+
+## Stub
+
+- Identify service, region, SKU, deployment, subscription, and observed error.
+- Compare current usage, limit, pending requests, and projected need.
+- Suggest right-sized quota requests with business justification and fallback regions.
+- Verify after approval with a minimal allocation or deployment test.

--- a/skills/azure-rbac/SKILL.md
+++ b/skills/azure-rbac/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-rbac
+description: "Audit and manage Azure RBAC assignments, scopes, roles, managed identities, and least-privilege access."
+---
+
+# Azure RBAC
+
+Use this skill for Azure access review or permission troubleshooting.
+
+## Stub
+
+- Identify principal, role, scope, tenant, subscription, and resource group.
+- Prefer least-privilege built-in roles before custom role changes.
+- Check inherited assignments, deny assignments, PIM, groups, and managed identities.
+- Document why each permission is required and how to revoke it.

--- a/skills/azure-resource-lookup/SKILL.md
+++ b/skills/azure-resource-lookup/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-resource-lookup
+description: "Find Azure resources across subscriptions, groups, tags, regions, identities, and dependency relationships."
+---
+
+# Azure Resource Lookup
+
+Use this skill when a user needs to find, inventory, or explain Azure resources.
+
+## Stub
+
+- Start from subscription, resource group, tag, region, workload, or resource ID.
+- Use structured Azure CLI or Resource Graph queries where available.
+- Include resource type, name, location, owner hints, tags, and last changed signals.
+- Highlight ambiguous matches instead of guessing.

--- a/skills/azure-resource-visualizer/SKILL.md
+++ b/skills/azure-resource-visualizer/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-resource-visualizer
+description: "Map Azure resource topology, dependencies, identities, networks, and deployment relationships."
+---
+
+# Azure Resource Visualizer
+
+Use this skill to turn Azure inventory into diagrams or topology summaries.
+
+## Stub
+
+- Gather resource groups, networks, compute, storage, databases, identities, and endpoints.
+- Identify dependencies from resource IDs, private links, role assignments, and app settings.
+- Produce a concise diagram or adjacency list before suggesting architecture changes.
+- Call out missing telemetry, orphaned resources, and unclear ownership.

--- a/skills/azure-storage/SKILL.md
+++ b/skills/azure-storage/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-storage
+description: "Manage Azure Storage accounts, blobs, queues, tables, files, lifecycle rules, security, and diagnostics."
+---
+
+# Azure Storage
+
+Use this skill for Azure Storage setup, migration, troubleshooting, or access review.
+
+## Stub
+
+- Identify account type, containers or shares, region, redundancy, and access pattern.
+- Check RBAC, keys, SAS tokens, firewall rules, private endpoints, and encryption.
+- Review lifecycle policies, retention, backups, versioning, and cost controls.
+- Verify with read, write, list, or restore tests as appropriate.

--- a/skills/azure-upgrade/SKILL.md
+++ b/skills/azure-upgrade/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-upgrade
+description: "Plan Azure runtime, SDK, API version, platform, and infrastructure upgrades with compatibility checks."
+---
+
+# Azure Upgrade
+
+Use this skill for Azure platform, SDK, runtime, or API version upgrades.
+
+## Stub
+
+- Identify current and target versions, affected services, environments, and deadlines.
+- Read official migration notes and breaking-change guidance before editing code.
+- Stage upgrades with backups, canaries, observability, and rollback paths.
+- Verify compatibility in a non-production environment first when possible.

--- a/skills/azure-validate/SKILL.md
+++ b/skills/azure-validate/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: azure-validate
+description: "Validate Azure resources, deployments, permissions, policy compliance, health, and configuration drift."
+---
+
+# Azure Validate
+
+Use this skill to audit or verify Azure resources after setup or deployment.
+
+## Stub
+
+- Check resource existence, location, SKU, tags, identity, and policy state.
+- Review diagnostics, metrics, activity logs, health status, and recent failures.
+- Compare actual configuration to IaC, documentation, or the requested target state.
+- Summarize pass, fail, unknown, and recommended next checks.

--- a/skills/entra-app-registration/SKILL.md
+++ b/skills/entra-app-registration/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: entra-app-registration
+description: "Create and troubleshoot Microsoft Entra app registrations, permissions, secrets, certificates, and redirects."
+---
+
+# Entra App Registration
+
+Use this skill for Microsoft Entra ID application registration work.
+
+## Stub
+
+- Confirm tenant, app type, redirect URIs, owners, and supported account types.
+- Review API permissions, consent status, exposed scopes, app roles, and credentials.
+- Prefer certificates or managed identity over long-lived client secrets when possible.
+- Test auth flows with a minimal token request and document expiry or rotation needs.

--- a/skills/microsoft-foundry/SKILL.md
+++ b/skills/microsoft-foundry/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: microsoft-foundry
+description: "Work with Microsoft Foundry agents, models, deployments, evaluations, and production app setup."
+---
+
+# Microsoft Foundry
+
+Use this skill when a user needs help with Microsoft Foundry or Azure AI Foundry workflows.
+
+## Stub
+
+- Confirm the target project, subscription, region, and model deployment.
+- Prefer official Microsoft CLI, SDK, and portal documentation for exact commands.
+- Check identity, networking, quota, and deployment health before changing app code.
+- Validate changes with a minimal request, evaluation run, or deployment smoke test.


### PR DESCRIPTION
## Summary
- Add 20 Azure and Microsoft Foundry SKILL.md stubs from daily discovery.
- Keep each stub lean with frontmatter plus an initial usage checklist.

Linear: ORT-2643

## Validation
- Ruby YAML frontmatter parse across all skills
- git diff --cached --check

## Sources
- skills.sh
- sundial-org/awesome-openclaw-skills
