### PR TITLE
Add daily discovery skill stubs for 2026-08-31

### DIFF
--- a/skills/api-designer/SKILL.md
+++ b/skills/api-designer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: api-designer
+description: Design REST or GraphQL APIs and OpenAPI specifications
+---
+
+# API Designer
+
+Use API Designer for API architecture, resource modeling, endpoint design, and OpenAPI or GraphQL schema planning.
+
+## Capabilities
+
+- Model resources, operations, pagination, filtering, and errors
+- Draft OpenAPI specs, GraphQL schemas, and endpoint examples
+- Review API consistency, versioning, authentication, and backward compatibility
+
+## Workflow
+
+1. Capture the product use case, clients, auth model, and data lifecycle.
+2. Model resources and common workflows before individual endpoints.
+3. Specify request/response shapes, errors, and pagination.
+4. Validate the design against maintainability and client ergonomics.
+
+## Notes
+
+- Prefer boring, predictable API conventions.
+- Call out migration and compatibility risks early.

--- a/skills/apple-calendar/SKILL.md
+++ b/skills/apple-calendar/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: apple-calendar
+description: Manage Apple Calendar events on macOS
+---
+
+# Apple Calendar
+
+Use Apple Calendar for local macOS calendar search, event creation, updates, deletion, and scheduling support.
+
+## Capabilities
+
+- List calendars and search events
+- Create, update, and delete calendar events
+- Inspect event times, attendees, notes, and locations
+
+## Workflow
+
+1. Clarify calendar, date range, timezone, and event details.
+2. Search existing events to avoid duplicates.
+3. Apply requested calendar changes with local automation.
+4. Summarize exact dates, times, calendar names, and conflicts.
+
+## Notes
+
+- Confirm before deleting or rescheduling existing events.
+- Use explicit dates and timezones in user-facing summaries.

--- a/skills/apple-mail/SKILL.md
+++ b/skills/apple-mail/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: apple-mail
+description: Search, read, draft, and manage Apple Mail locally
+---
+
+# Apple Mail
+
+Use Apple Mail when the user asks to inspect or manage email in macOS Mail.app.
+
+## Capabilities
+
+- Search and read messages from local Apple Mail data
+- Draft replies, forwards, and new messages
+- Manage read state, mailboxes, and attachments when supported
+
+## Workflow
+
+1. Determine account, mailbox, sender, subject, or date range.
+2. Search metadata first, then read only relevant messages.
+3. Draft replies or summarize threads as requested.
+4. Ask for approval before sending or bulk-changing messages.
+
+## Notes
+
+- Email content is sensitive; minimize quotations.
+- Report message dates and senders clearly.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: apple-notes
+description: Create, search, edit, and export Apple Notes from macOS
+---
+
+# Apple Notes
+
+Use Apple Notes when the user asks to create, search, update, move, delete, or export notes from macOS Notes.app.
+
+## Capabilities
+
+- Search folders and notes
+- Create and update notes through local automation or CLI tools
+- Export note content when requested
+
+## Workflow
+
+1. Identify the target folder, note title, or search query.
+2. Read matching note metadata before editing.
+3. Apply the requested note change or create a new note.
+4. Confirm the note title, folder, and key content changes.
+
+## Notes
+
+- Ask before deleting notes.
+- Treat note contents as private by default.

--- a/skills/architecture-designer/SKILL.md
+++ b/skills/architecture-designer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: architecture-designer
+description: Design and review software architecture decisions
+---
+
+# Architecture Designer
+
+Use Architecture Designer when planning a system, reviewing architecture, or making tradeoffs around scalability, reliability, and maintainability.
+
+## Capabilities
+
+- Produce architecture options and decision records
+- Analyze components, boundaries, data flows, and failure modes
+- Review designs for scaling, security, operability, and cost
+
+## Workflow
+
+1. Define goals, constraints, workloads, and non-goals.
+2. Map the current or proposed system boundaries.
+3. Compare a small number of viable options.
+4. Recommend a path with tradeoffs, risks, and validation steps.
+
+## Notes
+
+- Keep architecture grounded in expected usage, not abstract preference.
+- Prefer incremental designs when they satisfy the requirement.

--- a/skills/asana/SKILL.md
+++ b/skills/asana/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: asana
+description: Manage Asana tasks, projects, workspaces, and comments
+---
+
+# Asana
+
+Use Asana when the user needs to inspect or update Asana workspaces, projects, tasks, subtasks, or comments.
+
+## Capabilities
+
+- Search and list workspaces, projects, tasks, and users
+- Create and update tasks, subtasks, assignees, due dates, and comments
+- Handle pagination and common Asana REST API patterns
+
+## Workflow
+
+1. Resolve the workspace/project/task from names or IDs.
+2. Read current task state before updating it.
+3. Make only the requested change.
+4. Return links, changed fields, and any ambiguous matches.
+
+## Notes
+
+- Confirm before closing, deleting, or bulk-moving tasks.
+- Keep comments short and externally appropriate.

--- a/skills/attio/SKILL.md
+++ b/skills/attio/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: attio
+description: Manage Attio CRM companies, people, deals, notes, and tasks
+---
+
+# Attio
+
+Use Attio when working with CRM records, sales pipelines, custom objects, notes, tasks, or relationship data in Attio.
+
+## Capabilities
+
+- Search and update people, companies, deals, and custom objects
+- Add notes, tasks, and relationship context
+- Support sales and account workflows with structured CRM data
+
+## Workflow
+
+1. Resolve the relevant workspace object and record.
+2. Read existing fields and relationships to avoid duplicate entries.
+3. Make the smallest requested CRM update.
+4. Return changed records, links, and next sales actions.
+
+## Notes
+
+- Treat CRM data as sensitive business context.
+- Ask before sending external messages or changing ownership/stage in bulk.

--- a/skills/basecamp-cli/SKILL.md
+++ b/skills/basecamp-cli/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: basecamp-cli
+description: Manage Basecamp projects, to-dos, messages, and campfires
+---
+
+# Basecamp CLI
+
+Use Basecamp CLI when the user needs to interact with Basecamp projects, to-do lists, messages, schedules, or campfires from the terminal.
+
+## Capabilities
+
+- List and inspect Basecamp projects and to-dos
+- Create, update, and complete to-do items
+- Post or retrieve messages and project updates
+
+## Workflow
+
+1. Identify the Basecamp account, project, and tool area.
+2. Fetch current project/task state before edits.
+3. Apply the requested update or draft a proposed message.
+4. Summarize with URLs and changed item names.
+
+## Notes
+
+- Confirm before posting externally visible project messages.
+- Keep Basecamp updates polished and human-readable.

--- a/skills/clickup/SKILL.md
+++ b/skills/clickup/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: clickup
+description: Manage ClickUp spaces, lists, tasks, assignees, and comments
+---
+
+# ClickUp
+
+Use ClickUp when the user needs to read or change ClickUp tasks, spaces, folders, lists, statuses, assignees, or comments.
+
+## Capabilities
+
+- Search, list, create, and update ClickUp tasks
+- Manage assignees, statuses, due dates, custom fields, and comments
+- Navigate spaces, folders, lists, and subtasks
+
+## Workflow
+
+1. Resolve the target workspace hierarchy and task identifiers.
+2. Read matching records before creating or updating.
+3. Apply the requested mutation through the ClickUp API.
+4. Summarize changes with task URLs and any unresolved ambiguity.
+
+## Notes
+
+- Confirm destructive or bulk operations.
+- Preserve existing task context unless explicitly asked to rewrite it.

--- a/skills/flowmind/SKILL.md
+++ b/skills/flowmind/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: flowmind
+description: Manage goals, tasks, notes, people, and tags in FlowMind
+---
+
+# FlowMind
+
+Use FlowMind when the user wants to manage productivity data through the FlowMind REST API.
+
+## Capabilities
+
+- Create, list, update, and delete goals and tasks
+- Manage notes, people, and tags
+- Connect tasks to larger goals or contacts
+
+## Workflow
+
+1. Identify whether the request concerns goals, tasks, notes, people, or tags.
+2. Read existing matching records before creating duplicates.
+3. Apply the requested change through the FlowMind API.
+4. Summarize changed records and any due dates or follow-ups.
+
+## Notes
+
+- Treat productivity data as personal context.
+- Ask before deleting or broadly rewriting existing records.

--- a/skills/frontend-design-extractor/SKILL.md
+++ b/skills/frontend-design-extractor/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: frontend-design-extractor
+description: Extract reusable UI systems from frontend codebases
+---
+
+# Frontend Design Extractor
+
+Use this skill when analyzing a frontend repo to identify its design tokens, layout patterns, components, and reusable UI conventions.
+
+## Capabilities
+
+- Inspect styles, tokens, theme files, and shared components
+- Summarize typography, spacing, color, motion, and interaction patterns
+- Produce implementation guidance for matching an existing product UI
+
+## Workflow
+
+1. Locate the app framework, global styles, theme config, and component library.
+2. Sample representative pages and shared components.
+3. Extract concrete conventions with file references.
+4. Recommend how new UI should fit the existing system.
+
+## Notes
+
+- Prefer code evidence over subjective style guesses.
+- Keep recommendations specific enough for another agent to implement.

--- a/skills/ggshield-scanner/SKILL.md
+++ b/skills/ggshield-scanner/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: ggshield-scanner
+description: Scan code and commits for leaked secrets with ggshield
+---
+
+# ggshield Secret Scanner
+
+Use ggshield-scanner when checking repositories, commits, or files for hardcoded secrets before they reach GitHub.
+
+## Capabilities
+
+- Scan working trees, staged changes, commits, and CI contexts
+- Detect common API keys, tokens, credentials, and private material
+- Report remediation guidance without exposing full secret values
+
+## Workflow
+
+1. Identify the scan scope: files, repo, staged changes, or commit range.
+2. Run ggshield with output suitable for automation.
+3. Triage findings and redact sensitive values in summaries.
+4. Recommend rotation, removal, and history cleanup when needed.
+
+## Notes
+
+- Never paste full secrets into chat or logs.
+- Treat positive findings as urgent until proven false.

--- a/skills/goplaces/SKILL.md
+++ b/skills/goplaces/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: goplaces
+description: Query Google Places with an agent-friendly CLI
+---
+
+# Goplaces
+
+Use Goplaces when the user needs place search, details, reviews, or location grounding through Google Places API.
+
+## Capabilities
+
+- Text search for businesses, restaurants, venues, and landmarks
+- Fetch place details, ratings, hours, reviews, and coordinates
+- Return structured JSON for scripts or concise recommendations for humans
+
+## Workflow
+
+1. Clarify location, category, constraints, and time sensitivity.
+2. Search with Goplaces and inspect top candidates.
+3. Compare relevant details such as hours, rating, distance, and reviews.
+4. Present the best matches with links and practical caveats.
+
+## Notes
+
+- Check current hours when the user might visit soon.
+- Do not assume place data is stable.

--- a/skills/homebrew/SKILL.md
+++ b/skills/homebrew/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: homebrew
+description: Search, install, upgrade, and troubleshoot Homebrew packages
+---
+
+# Homebrew
+
+Use Homebrew when managing packages, casks, taps, services, and troubleshooting on macOS or Linuxbrew systems.
+
+## Capabilities
+
+- Search formulas and casks
+- Install, upgrade, pin, unlink, and uninstall packages
+- Inspect package info, dependencies, services, and doctor output
+
+## Workflow
+
+1. Check existing Homebrew state before changing packages.
+2. Search or inspect package metadata.
+3. Apply the requested install, upgrade, or service action.
+4. Verify package availability and summarize any caveats.
+
+## Notes
+
+- Avoid broad upgrades unless explicitly requested.
+- Preserve user-managed services and taps.

--- a/skills/imap-email/SKILL.md
+++ b/skills/imap-email/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: imap-email
+description: Read and manage email through IMAP
+---
+
+# IMAP Email
+
+Use IMAP Email when working with mailboxes through standard IMAP, including Gmail, ProtonMail Bridge, and other providers.
+
+## Capabilities
+
+- List mailboxes and unread or recent messages
+- Search by sender, subject, date, and body terms
+- Mark messages read/unread and fetch message content
+
+## Workflow
+
+1. Identify the account, mailbox, and search criteria.
+2. Fetch message metadata before opening full content.
+3. Summarize relevant messages with dates and senders.
+4. Ask before changing mailbox state unless the user requested it.
+
+## Notes
+
+- Email is private; quote only what is necessary.
+- Prefer drafts over sending replies directly.

--- a/skills/linearis/SKILL.md
+++ b/skills/linearis/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: linearis
+description: Linear issue tracking from the terminal with JSON-friendly workflows
+---
+
+# Linearis
+
+Use Linearis when you need to manage Linear issues, projects, comments, and search from a terminal-first agent workflow.
+
+## Capabilities
+
+- List, search, create, and update Linear issues
+- Add comments and inspect issue/project metadata
+- Produce JSON output suitable for agent parsing
+
+## Workflow
+
+1. Confirm the target Linear workspace, team, project, or issue key.
+2. Use the Linearis CLI/API to fetch current state before making changes.
+3. Apply the smallest requested issue, comment, or project update.
+4. Return the issue key, URL, and a concise change summary.
+
+## Notes
+
+- Prefer read-only inspection unless the user asks to change Linear.
+- Keep outbound issue/comment text clear and ready for teammates to read.

--- a/skills/linkedin-cli/SKILL.md
+++ b/skills/linkedin-cli/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: linkedin-cli
+description: Search LinkedIn profiles, messages, and feed context by CLI
+---
+
+# LinkedIn CLI
+
+Use LinkedIn CLI for terminal-based LinkedIn profile search, message checks, and feed summaries when credentials are available.
+
+## Capabilities
+
+- Search people and companies
+- Inspect profile or message context
+- Summarize feed activity and professional signals
+
+## Workflow
+
+1. Confirm the read-only or write scope of the request.
+2. Search or fetch the relevant LinkedIn records.
+3. Summarize verified profile, company, or message details.
+4. Ask for explicit approval before sending or reacting externally.
+
+## Notes
+
+- LinkedIn data is private and often rate-limited.
+- Never send connection requests, messages, or reactions without approval.

--- a/skills/manus/SKILL.md
+++ b/skills/manus/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: manus
+description: Create and manage autonomous work tasks through Manus API
+---
+
+# Manus
+
+Use Manus when a task should be handed to a Manus autonomous agent for browsing, tool use, or complete work-product delivery.
+
+## Capabilities
+
+- Create Manus tasks with clear objectives and constraints
+- Track task status and retrieve results
+- Summarize delivered artifacts and next actions
+
+## Workflow
+
+1. Clarify the desired deliverable and any privacy or execution limits.
+2. Create a scoped Manus task with acceptance criteria.
+3. Poll for completion or status changes.
+4. Review the returned work before presenting it to the user.
+
+## Notes
+
+- Do not delegate private or external-action work without explicit permission.
+- Include enough context for Manus to finish without back-and-forth.

--- a/skills/playwright-cli/SKILL.md
+++ b/skills/playwright-cli/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: playwright-cli
+description: Browser automation and screenshots through Playwright CLI
+---
+
+# Playwright CLI
+
+Use Playwright CLI when you need to automate browser navigation, interactions, screenshots, or lightweight end-to-end checks.
+
+## Capabilities
+
+- Open pages, click, type, and wait for selectors
+- Capture screenshots and inspect page state
+- Script repeatable browser verification flows
+
+## Workflow
+
+1. Start the target app or confirm the live URL.
+2. Choose desktop and mobile viewports relevant to the change.
+3. Run Playwright interactions and collect screenshots/logs.
+4. Summarize failures with reproducible steps.
+
+## Notes
+
+- Check console output for errors after page interactions.
+- Use stable selectors when available.

--- a/skills/verify-on-browser/SKILL.md
+++ b/skills/verify-on-browser/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: verify-on-browser
+description: Verify web behavior through Chrome DevTools Protocol
+---
+
+# Browser CDP MCP
+
+Use this skill when you need browser verification with Chrome DevTools Protocol access, including pages, DOM, console, network, and screenshots.
+
+## Capabilities
+
+- Navigate web pages and inspect DOM state
+- Capture console errors, network requests, and screenshots
+- Verify UI behavior after frontend changes
+
+## Workflow
+
+1. Start or identify the target browser session and URL.
+2. Reproduce the interaction or page state under test.
+3. Inspect visual output, console logs, and network behavior.
+4. Report verified behavior and any reproducible failures.
+
+## Notes
+
+- Prefer deterministic checks over manual impressions.
+- Include viewport and URL details in verification summaries.


### PR DESCRIPTION
## Summary

- Add 20 daily discovery SKILL.md stubs from skills.sh and sundial-org/awesome-openclaw-skills.
- Focus on workflow, CRM, browser verification, local macOS productivity, and developer operations skills not present on main.

## Added skills

- linearis
- manus
- frontend-design-extractor
- flowmind
- asana
- api-designer
- architecture-designer
- clickup
- attio
- basecamp-cli
- goplaces
- linkedin-cli
- imap-email
- verify-on-browser
- playwright-cli
- apple-notes
- apple-calendar
- apple-mail
- homebrew
- ggshield-scanner

## Verification

- Checked `git diff --cached --stat` before commit: 20 files, 520 insertions.
