### PR TITLE
Add daily discovery skill stubs for 2026-09-01

### DIFF
--- a/skills/ai-image-generation/SKILL.md
+++ b/skills/ai-image-generation/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ai-image-generation
+description: Generate raster images, illustrations, textures, mockups, and visual variants.
+---
+
+# AI Image Generation
+
+Use this skill when the user wants new bitmap images or visual variants from prompts or references.
+
+## Requirements
+
+- Image generation provider credentials
+- Prompt, style direction, or reference assets
+
+## Suggested Actions
+
+- Draft concise image prompts
+- Generate multiple candidates
+- Edit or upscale selected outputs
+- Save generated assets with clear filenames
+

--- a/skills/ai-video-generation/SKILL.md
+++ b/skills/ai-video-generation/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: ai-video-generation
+description: Generate short AI videos from prompts, reference images, or production briefs.
+---
+
+# AI Video Generation
+
+Use this skill when the user asks to create, iterate, or package AI-generated video assets.
+
+## Requirements
+
+- Video generation provider credentials
+- Prompt, storyboard, or reference assets
+
+## Suggested Actions
+
+- Turn a brief into a video prompt
+- Generate video variations
+- Track output files and provider settings
+- Prepare review notes for revisions
+

--- a/skills/azure-cost/SKILL.md
+++ b/skills/azure-cost/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: azure-cost
+description: Inspect Azure cost data, budgets, forecasts, anomalies, and spend drivers.
+---
+
+# Azure Cost
+
+Use this skill when the user wants to understand or reduce Azure cloud spend.
+
+## Requirements
+
+- Azure CLI
+- Azure account access
+- Billing reader permissions
+
+## Suggested Actions
+
+- Fetch cost summaries by subscription or resource group
+- Identify top spend drivers
+- Compare current spend with budgets
+- Suggest cost optimization follow-ups
+

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: brainstorming
+description: Explore options, generate alternatives, and converge on practical next steps.
+---
+
+# Brainstorming
+
+Use this skill when the user wants structured ideation before committing to a direction.
+
+## Requirements
+
+- Goal, constraints, and audience
+
+## Suggested Actions
+
+- Generate diverse options
+- Cluster ideas by theme
+- Evaluate tradeoffs
+- Recommend a short list of next steps
+

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: docx
+description: Read, create, edit, convert, and inspect Microsoft Word DOCX documents.
+---
+
+# DOCX
+
+Use this skill when the user wants to work with Word documents.
+
+## Requirements
+
+- DOCX files or target document requirements
+- Local document tooling such as pandoc, LibreOffice, or a DOCX library
+
+## Suggested Actions
+
+- Extract document text and metadata
+- Convert between DOCX, Markdown, PDF, and HTML
+- Apply edits while preserving structure
+- Review formatting and comments
+

--- a/skills/firebase-hosting-basics/SKILL.md
+++ b/skills/firebase-hosting-basics/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: firebase-hosting-basics
+description: Configure, preview, and deploy static or web app builds with Firebase Hosting.
+---
+
+# Firebase Hosting Basics
+
+Use this skill when the user wants to publish a web project through Firebase Hosting.
+
+## Requirements
+
+- Firebase CLI
+- Firebase project access
+- Web app build output
+
+## Suggested Actions
+
+- Initialize hosting config
+- Configure rewrites, headers, and deploy targets
+- Run local hosting previews
+- Deploy and verify the hosted URL
+

--- a/skills/high-end-visual-design/SKILL.md
+++ b/skills/high-end-visual-design/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: high-end-visual-design
+description: Create polished visual direction for premium product, brand, and landing experiences.
+---
+
+# High-End Visual Design
+
+Use this skill when the user wants a refined visual system or premium-feeling interface direction.
+
+## Requirements
+
+- Brand, product, audience, and asset context
+
+## Suggested Actions
+
+- Define typography, color, spacing, and imagery direction
+- Improve composition and visual rhythm
+- Specify interaction and motion polish
+- Review implementation against the intended art direction
+

--- a/skills/hyperframes-core/SKILL.md
+++ b/skills/hyperframes-core/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: hyperframes-core
+description: Build and edit Hyperframes video projects, timelines, scenes, and media assets.
+---
+
+# Hyperframes Core
+
+Use this skill when the user wants programmatic video assembly using Hyperframes.
+
+## Requirements
+
+- Hyperframes project or package access
+- Source media assets
+
+## Suggested Actions
+
+- Create scene plans
+- Compose timelines and media layers
+- Render preview outputs
+- Prepare revision-ready project files
+

--- a/skills/just-scrape/SKILL.md
+++ b/skills/just-scrape/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: just-scrape
+description: Extract structured web data using Just Scrape or ScrapeGraphAI workflows.
+---
+
+# Just Scrape
+
+Use this skill when the user wants to scrape a page or site into structured data.
+
+## Requirements
+
+- Just Scrape or ScrapeGraphAI access
+- Target URLs and extraction schema
+
+## Suggested Actions
+
+- Define extraction fields
+- Run scrape jobs
+- Validate returned data
+- Export JSON, CSV, or downstream-ready records
+

--- a/skills/lark-markdown/SKILL.md
+++ b/skills/lark-markdown/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: lark-markdown
+description: Convert Markdown into Lark-friendly document, message, or wiki formatting.
+---
+
+# Lark Markdown
+
+Use this skill when the user wants Markdown adapted for Lark docs, messages, or wiki pages.
+
+## Requirements
+
+- Lark destination or document context
+
+## Suggested Actions
+
+- Convert Markdown structure to Lark-compatible formatting
+- Preserve links, lists, code blocks, and callouts
+- Flag unsupported Markdown constructs
+- Prepare content for paste or API publishing
+

--- a/skills/lark-okr/SKILL.md
+++ b/skills/lark-okr/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: lark-okr
+description: Manage Lark OKRs, objectives, key results, progress updates, and review cycles.
+---
+
+# Lark OKR
+
+Use this skill when the user wants to create, inspect, update, or summarize objectives and key results in Lark.
+
+## Requirements
+
+- Lark account access
+- Lark CLI or API credentials
+
+## Suggested Actions
+
+- List objectives and key results
+- Create or update OKRs
+- Post progress updates
+- Summarize at-risk OKRs and owners
+

--- a/skills/obsidian-vault/SKILL.md
+++ b/skills/obsidian-vault/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: obsidian-vault
+description: Search, organize, link, and maintain notes inside an Obsidian vault.
+---
+
+# Obsidian Vault
+
+Use this skill when the user wants help managing an Obsidian knowledge base.
+
+## Requirements
+
+- Path to the Obsidian vault
+- Permission to read or edit notes
+
+## Suggested Actions
+
+- Search vault notes
+- Create or update Markdown notes
+- Add backlinks and tags
+- Summarize orphaned, stale, or duplicate notes
+

--- a/skills/prisma-database-setup/SKILL.md
+++ b/skills/prisma-database-setup/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: prisma-database-setup
+description: Set up Prisma schemas, migrations, clients, and database connection configuration.
+---
+
+# Prisma Database Setup
+
+Use this skill when the user wants Prisma added to an app or database workflow.
+
+## Requirements
+
+- Node.js project
+- Database URL or local database plan
+- Prisma CLI
+
+## Suggested Actions
+
+- Initialize Prisma
+- Model schema entities
+- Create and apply migrations
+- Generate Prisma Client and verify access
+

--- a/skills/reddit-automation/SKILL.md
+++ b/skills/reddit-automation/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: reddit-automation
+description: Search, monitor, summarize, and draft Reddit posts or comments with API-aware safeguards.
+---
+
+# Reddit Automation
+
+Use this skill when the user wants Reddit research, monitoring, or posting support.
+
+## Requirements
+
+- Reddit API credentials for authenticated actions
+- Subreddit, keyword, or thread targets
+
+## Suggested Actions
+
+- Search posts and comments
+- Summarize threads and sentiment
+- Monitor keywords or communities
+- Draft posts or replies for approval
+

--- a/skills/runcomfy-cli/SKILL.md
+++ b/skills/runcomfy-cli/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: runcomfy-cli
+description: Run and manage ComfyUI workflows through RunComfy from the command line.
+---
+
+# RunComfy CLI
+
+Use this skill when the user wants to execute hosted ComfyUI image or video workflows.
+
+## Requirements
+
+- RunComfy account and API key
+- RunComfy CLI or API client
+- Workflow definition or template
+
+## Suggested Actions
+
+- Validate workflow inputs
+- Submit workflow jobs
+- Poll job status
+- Download and organize generated outputs
+

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: supabase
+description: Manage Supabase projects, databases, auth, storage, edge functions, and local dev.
+---
+
+# Supabase
+
+Use this skill when the user wants to build or operate against Supabase.
+
+## Requirements
+
+- Supabase account or local project
+- Supabase CLI
+- Project reference and credentials as needed
+
+## Suggested Actions
+
+- Start local Supabase services
+- Manage migrations and seed data
+- Configure auth, storage, and policies
+- Deploy edge functions
+

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: systematic-debugging
+description: Debug failures with hypotheses, reproducible checks, instrumentation, and verification.
+---
+
+# Systematic Debugging
+
+Use this skill when the user wants help diagnosing a bug, failing test, or unclear system behavior.
+
+## Requirements
+
+- Reproduction steps, logs, failing tests, or observed behavior
+
+## Suggested Actions
+
+- Establish a minimal reproduction
+- Form and test hypotheses
+- Add targeted instrumentation
+- Verify the fix and record residual risk
+

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: to-issues
+description: Convert plans, TODOs, bugs, and review notes into well-scoped GitHub issues.
+---
+
+# To Issues
+
+Use this skill when the user wants messy task notes converted into actionable issue tracker items.
+
+## Requirements
+
+- Repository or project context
+- GitHub CLI or issue tracker credentials
+
+## Suggested Actions
+
+- Extract tasks from notes or code comments
+- Group related work into separate issues
+- Write issue titles, bodies, labels, and acceptance criteria
+- Create issues after approval when needed
+

--- a/skills/ui-ux-pro-max/SKILL.md
+++ b/skills/ui-ux-pro-max/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: ui-ux-pro-max
+description: Review and improve product UI with interaction, hierarchy, and usability guidance.
+---
+
+# UI UX Pro Max
+
+Use this skill when the user wants senior-level UI and UX critique or implementation guidance.
+
+## Requirements
+
+- Product context, screenshots, prototype, or code
+
+## Suggested Actions
+
+- Audit hierarchy, layout, and interaction states
+- Identify usability risks
+- Recommend focused UI changes
+- Verify responsive behavior when implementation changes are made
+

--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: xlsx
+description: Read, create, edit, validate, and summarize Excel XLSX workbooks.
+---
+
+# XLSX
+
+Use this skill when the user wants to work with Excel spreadsheets.
+
+## Requirements
+
+- XLSX files or workbook requirements
+- Local spreadsheet tooling or a workbook library
+
+## Suggested Actions
+
+- Inspect sheets, headers, formulas, and metadata
+- Convert workbooks to CSV or JSON
+- Create or update worksheets
+- Validate formulas and tabular structure
+


### PR DESCRIPTION
## Summary
- Adds 20 SKILL.md stubs from the September 1 daily discovery pass.
- Sources include skills.sh and awesome-openclaw-skills.

## Notes
- Stubs are intentionally lightweight for follow-up expansion.
- Filtered against existing repo skills and prior discovery posts.