### PR TITLE
Add daily discovery skill stubs for 2026-09-02

### DIFF
--- a/skills/agent-browser-cli/SKILL.md
+++ b/skills/agent-browser-cli/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: agent-browser-cli
+description: Control a headless browser from agent workflows for navigation, forms, snapshots, screenshots, and extraction.
+---
+
+# Agent Browser CLI
+
+Use this skill when a user needs browser automation from a terminal or agent workflow: navigate pages, click elements, fill forms, capture screenshots, inspect accessibility snapshots, or extract structured page state.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`agent-browser`).
+
+## Stub Notes
+
+- Document install and authentication requirements for the chosen browser CLI.
+- Prefer structured selectors or accessibility references over brittle CSS selectors.
+- Include examples for navigate, click, type, screenshot, snapshot, and cleanup.
+- Add safety notes for logged-in sessions, external submissions, and destructive actions.

--- a/skills/atlassian-mcp/SKILL.md
+++ b/skills/atlassian-mcp/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: atlassian-mcp
+description: Search and manage Jira issues and Confluence pages through an Atlassian MCP or API integration.
+---
+
+# Atlassian MCP
+
+Use this skill when work involves Jira tickets, Confluence pages, Atlassian search, issue updates, comments, or cross-linking docs and tasks.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`mcp-atlassian`).
+
+## Stub Notes
+
+- Document MCP server setup, OAuth scopes, and workspace selection.
+- Include Jira search, issue create/update/comment, and Confluence search/read examples.
+- Ask before posting comments or modifying externally visible content.
+- Handle tenant names, project keys, and pagination explicitly.

--- a/skills/browser-use-api/SKILL.md
+++ b/skills/browser-use-api/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: browser-use-api
+description: Run cloud browser automation tasks through Browser Use for scraping, form filling, and web workflows.
+---
+
+# Browser Use API
+
+Use this skill when local browser automation is unavailable or a task benefits from a cloud browser agent that can navigate, extract, and interact with websites.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`browser-use-2`).
+
+## Stub Notes
+
+- Document API key setup and task submission.
+- Include workflows for scrape, fill form, monitor status, and retrieve results.
+- Confirm before actions that submit data, purchase, book, or contact people.
+- Capture run IDs and artifacts for follow-up debugging.

--- a/skills/byterover-headless/SKILL.md
+++ b/skills/byterover-headless/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: byterover-headless
+description: Query and curate ByteRover project knowledge from the command line for persistent agent memory.
+---
+
+# ByteRover Headless
+
+Use this skill when an agent needs to search, store, sync, or curate durable project knowledge through ByteRover without opening a browser UI.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`byterover-headless`).
+
+## Stub Notes
+
+- Capture setup for the ByteRover CLI and required credentials.
+- Show query, curate, push, and pull workflows.
+- Define when to write memory versus when to keep information local to the current task.
+- Include privacy guidance for secrets, customer data, and personal context.

--- a/skills/claude-team/SKILL.md
+++ b/skills/claude-team/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: claude-team
+description: Orchestrate multiple Claude Code workers across worktrees for parallel software development.
+---
+
+# Claude Team
+
+Use this skill when a project needs multiple Claude Code sessions coordinated through worktrees, isolated tasks, and a final integration pass.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`claude-team`).
+
+## Stub Notes
+
+- Document required CLI or MCP server setup.
+- Include task assignment, worker monitoring, and result collection.
+- Use separate branches or worktrees for independent changes.
+- Add final review, tests, and cleanup guidance.

--- a/skills/codex-orchestration/SKILL.md
+++ b/skills/codex-orchestration/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: codex-orchestration
+description: Coordinate parallel Codex workers for research, implementation, review, and verification tasks.
+---
+
+# Codex Orchestration
+
+Use this skill when a task is broad enough to benefit from multiple Codex workers running in parallel with clear ownership and mergeable outputs.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`codex-orchestration`).
+
+## Stub Notes
+
+- Define when to spawn workers and when to keep work in one session.
+- Include worktree, branch, and task handoff patterns.
+- Require concise worker briefs with success criteria and file ownership.
+- Add merge, verification, and conflict-resolution steps.

--- a/skills/codex-quota/SKILL.md
+++ b/skills/codex-quota/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: codex-quota
+description: Inspect local Codex usage and quota signals before starting long or expensive coding-agent work.
+---
+
+# Codex Quota
+
+Use this skill when checking Codex usage, estimating remaining budget, or deciding whether to use local workers or smaller tasks.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`codex-quota`).
+
+## Stub Notes
+
+- Document where Codex usage logs live and how to read them safely.
+- Include daily and weekly quota summaries when available.
+- Suggest lighter execution modes when quota is low.
+- Avoid exposing account tokens or raw private session content.

--- a/skills/codexmonitor/SKILL.md
+++ b/skills/codexmonitor/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: codexmonitor
+description: List, inspect, and watch local Codex CLI sessions, logs, usage, and active work.
+---
+
+# CodexMonitor
+
+Use this skill when a user wants to inspect current or recent Codex sessions, debug stuck agent runs, summarize logs, or monitor local coding-agent work.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`codexmonitor`).
+
+## Stub Notes
+
+- Document installation and supported Codex log locations.
+- Include list, inspect, watch, and summarize examples.
+- Redact secrets and private transcript fragments by default.
+- Note how this differs from quota-only reporting.

--- a/skills/context7-docs/SKILL.md
+++ b/skills/context7-docs/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: context7-docs
+description: Fetch current library and framework documentation through Context7 before coding against external APIs.
+---
+
+# Context7 Docs
+
+Use this skill when a task depends on current documentation for a library, SDK, framework, or platform API and stale model knowledge would be risky.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`context7`, `context7-2`).
+
+## Stub Notes
+
+- Document how to resolve library IDs and request focused documentation snippets.
+- Prefer official package documentation returned through Context7.
+- Include examples for React, Next.js, Supabase, Stripe, and OpenAI-style docs lookups.
+- Require citations or inline source notes when documentation affects implementation choices.

--- a/skills/git-notes-memory/SKILL.md
+++ b/skills/git-notes-memory/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: git-notes-memory
+description: Store branch-aware project memory in git notes so context can travel with repository history.
+---
+
+# Git Notes Memory
+
+Use this skill when repository-specific decisions, architecture notes, task context, or review learnings should persist alongside git history without modifying source files.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`git-notes-memory`).
+
+## Stub Notes
+
+- Explain git notes namespaces for tasks, decisions, and reviews.
+- Show add, list, search, merge, fetch, and push operations.
+- Include branch-aware memory lookup before implementation.
+- Warn about private metadata in shared repositories.

--- a/skills/gno-search/SKILL.md
+++ b/skills/gno-search/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: gno-search
+description: Index and search local documents, notes, and knowledge bases with BM25, vector, or hybrid retrieval.
+---
+
+# Gno Search
+
+Use this skill when a user asks to find information across local files, notes, docs, or knowledge bases and needs cited answers.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`gno`).
+
+## Stub Notes
+
+- Document indexing commands and supported file types.
+- Show keyword, semantic, hybrid, and cited-answer queries.
+- Include stale-index checks before relying on results.
+- Respect workspace and privacy boundaries.

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: llm-council
+description: Ask multiple LLM or coding-agent personas for independent plans, critiques, and implementation reviews.
+---
+
+# LLM Council
+
+Use this skill when a decision benefits from independent model perspectives: architecture options, product tradeoffs, code-review risk, migration plans, or debugging hypotheses.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`llm-council`, `council`).
+
+## Stub Notes
+
+- Define council member roles and when to anonymize responses.
+- Require a clear question, constraints, and scoring rubric.
+- Summarize consensus, disagreement, and recommended next action.
+- Avoid using councils for simple tasks where overhead adds little value.

--- a/skills/memory-hygiene/SKILL.md
+++ b/skills/memory-hygiene/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: memory-hygiene
+description: Audit, deduplicate, compact, and repair agent memory files and vector indexes.
+---
+
+# Memory Hygiene
+
+Use this skill when memory recall is noisy, outdated, duplicated, missing important facts, or consuming too much context.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`memory-hygiene`).
+
+## Stub Notes
+
+- Define review cadence and safe scopes for memory cleanup.
+- Separate raw daily logs from curated long-term memory.
+- Preserve sources when distilling facts.
+- Include checks for stale preferences, completed todos, and private data that should not be shared.

--- a/skills/ontology-memory/SKILL.md
+++ b/skills/ontology-memory/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ontology-memory
+description: Maintain typed entities and relationships for agent memory using an ontology or lightweight knowledge graph.
+---
+
+# Ontology Memory
+
+Use this skill when an agent needs structured memory for people, projects, tasks, events, documents, decisions, and relationships rather than untyped notes.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`ontology`).
+
+## Stub Notes
+
+- Define entity types, relationship types, and required fields.
+- Show create, update, query, and merge operations.
+- Include guardrails for uncertain facts and conflicting observations.
+- Explain how ontology memory should complement daily notes and long-term memory.

--- a/skills/roadrunner-beeper/SKILL.md
+++ b/skills/roadrunner-beeper/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: roadrunner-beeper
+description: Search and manage Beeper Desktop chats, messages, reminders, and cross-platform messaging from a CLI.
+---
+
+# Roadrunner Beeper
+
+Use this skill when a user wants to search Beeper chats, inspect recent messages, draft replies, or manage reminders across connected messaging services.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`roadrunner`).
+
+## Stub Notes
+
+- Document Beeper Desktop prerequisites and local API availability.
+- Include search, read, draft, send, and reminder examples.
+- Ask before sending messages or making externally visible changes.
+- Treat group chats and private messages with explicit privacy safeguards.

--- a/skills/rssaurus-cli/SKILL.md
+++ b/skills/rssaurus-cli/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: rssaurus-cli
+description: Read, search, and triage RSS feeds and feed items from the terminal using RSSaurus.
+---
+
+# RSSaurus CLI
+
+Use this skill when a user wants agent-friendly RSS feed reading, monitoring, summarization, or link triage from the command line.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`rssaurus-cli`).
+
+## Stub Notes
+
+- Document authentication, feed listing, item search, and item URL output.
+- Include workflows for daily digests, topic monitoring, and source curation.
+- Track read/unread state when the CLI supports it.
+- Prefer concise summaries with source URLs for follow-up reading.

--- a/skills/supermemory/SKILL.md
+++ b/skills/supermemory/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: supermemory
+description: Store, search, and chat with long-lived knowledge through the Supermemory API.
+---
+
+# Supermemory
+
+Use this skill when a user wants an agent-accessible knowledge base for saved pages, notes, documents, messages, or prior research.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`supermemory`).
+
+## Stub Notes
+
+- Document API key setup, collection design, and content ingestion.
+- Show add, search, retrieve, and chat workflows.
+- Include retention and deletion guidance.
+- Warn before uploading sensitive or private material.

--- a/skills/ticktick-cli/SKILL.md
+++ b/skills/ticktick-cli/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ticktick-cli
+description: Manage TickTick tasks, projects, due dates, priorities, and completion from the command line.
+---
+
+# TickTick CLI
+
+Use this skill when a user wants to create, list, update, complete, or organize TickTick tasks through an agent or terminal workflow.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`ticktick`).
+
+## Stub Notes
+
+- Document OAuth setup and token storage.
+- Include list, add, edit, complete, project, label, and due-date examples.
+- Handle pagination and rate limits.
+- Confirm before deleting tasks or changing many tasks at once.

--- a/skills/todoist-cli/SKILL.md
+++ b/skills/todoist-cli/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: todoist-cli
+description: Manage Todoist projects, tasks, labels, filters, due dates, and completion from agent workflows.
+---
+
+# Todoist CLI
+
+Use this skill when a user asks to add, list, reschedule, complete, search, or reorganize Todoist tasks.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`todoist-2`).
+
+## Stub Notes
+
+- Document authentication and default project selection.
+- Include examples for inbox capture, today view, labels, priorities, and recurring due dates.
+- Confirm before bulk edits or destructive deletes.
+- Preserve user wording when creating personal tasks.

--- a/skills/web-perf-audit/SKILL.md
+++ b/skills/web-perf-audit/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: web-perf-audit
+description: Audit website Core Web Vitals, network waterfalls, render blocking, caching, and interaction latency.
+---
+
+# Web Perf Audit
+
+Use this skill when asked to diagnose slow pages, measure Core Web Vitals, compare before and after performance, or produce actionable frontend performance fixes.
+
+Discovery source: skills.sh / sundial-org awesome-openclaw-skills (`web-perf`).
+
+## Stub Notes
+
+- Include Lighthouse, Chrome DevTools, and WebPageTest-style workflows where available.
+- Capture LCP, CLS, INP, TTFB, resource waterfalls, and CPU bottlenecks.
+- Separate measurement findings from implementation recommendations.
+- Verify fixes with repeat runs and stable network/device settings.


### PR DESCRIPTION
## Summary

Adds 20 SKILL.md stubs discovered from skills.sh and sundial-org/awesome-openclaw-skills for the 2026-09-02 daily discovery batch.

## Added stubs

- agent-browser-cli
- byterover-headless
- context7-docs
- ontology-memory
- codex-orchestration
- memory-hygiene
- claude-team
- supermemory
- git-notes-memory
- llm-council
- codex-quota
- gno-search
- ticktick-cli
- todoist-cli
- web-perf-audit
- atlassian-mcp
- codexmonitor
- roadrunner-beeper
- browser-use-api
- rssaurus-cli

## Verification

- Ran git diff --check
