### PR TITLE
Add September 4 discovery skill stubs

### DIFF
--- a/skills/attack-path-stitcher/SKILL.md
+++ b/skills/attack-path-stitcher/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: attack-path-stitcher
+description: Stitch security findings into attack paths, risk narratives, and remediation plans.
+---
+
+# Attack Path Stitcher
+
+Use this skill when combining vulnerability findings, identity permissions, network exposure, and asset context into concrete attack paths.
+
+## Stub Notes
+
+- Source: skills.sh hot list / transilienceai community tools.
+- Suggested coverage: graphing prerequisites, exploit chain plausibility, control gaps, impact, evidence, and prioritized remediation.
+- Suggested setup: document accepted scanner outputs and threat-model assumptions.

--- a/skills/docs-writer/SKILL.md
+++ b/skills/docs-writer/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: docs-writer
+description: Plan, write, and revise developer documentation, READMEs, guides, and references.
+---
+
+# Docs Writer
+
+Use this skill when creating or improving technical documentation for projects, APIs, workflows, setup guides, or user-facing developer materials.
+
+## Stub Notes
+
+- Source: skills.sh hot list / tech-leads-club agent skills.
+- Suggested coverage: audience definition, doc structure, source verification, examples, installation steps, troubleshooting, and review checklist.
+- Suggested setup: document project doc conventions and publishing targets.

--- a/skills/duoduo-channel-admin/SKILL.md
+++ b/skills/duoduo-channel-admin/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: duoduo-channel-admin
+description: Manage Duoduo channels, routing, integrations, permissions, and delivery state.
+---
+
+# Duoduo Channel Admin
+
+Use this skill when configuring or diagnosing Duoduo messaging channels, channel routing, connector state, permissions, or delivery failures.
+
+## Stub Notes
+
+- Source: skills.sh hot list / openduo duoduo skills.
+- Suggested coverage: channel inventory, connection tests, routing rules, auth state, delivery logs, and permission checks.
+- Suggested setup: document Duoduo channel configuration files or admin API endpoints.

--- a/skills/duoduo-loop/SKILL.md
+++ b/skills/duoduo-loop/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: duoduo-loop
+description: Build and monitor Duoduo automation loops with checkpoints, waits, and recovery.
+---
+
+# Duoduo Loop
+
+Use this skill when designing, running, or debugging Duoduo loop-style automations that iterate over tasks, messages, queues, or external events.
+
+## Stub Notes
+
+- Source: skills.sh hot list / openduo duoduo skills.
+- Suggested coverage: loop state, checkpoints, retry policy, stop conditions, rate limits, and observability.
+- Suggested setup: document Duoduo runtime prerequisites and safe dry-run mode.

--- a/skills/duoduo-runtime-admin/SKILL.md
+++ b/skills/duoduo-runtime-admin/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: duoduo-runtime-admin
+description: Administer Duoduo runtime services, processes, configuration, and health checks.
+---
+
+# Duoduo Runtime Admin
+
+Use this skill when operating or debugging a Duoduo runtime, including service health, configuration, deployment state, and background process behavior.
+
+## Stub Notes
+
+- Source: skills.sh hot list / openduo duoduo skills.
+- Suggested coverage: runtime status, logs, configuration inspection, restart workflows, upgrade checks, and recovery steps.
+- Suggested setup: document Duoduo CLI/API authentication and environment layout.

--- a/skills/img2threejs/SKILL.md
+++ b/skills/img2threejs/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: img2threejs
+description: Convert image references into Three.js scenes, assets, geometry plans, and implementation prompts.
+---
+
+# Img2ThreeJS
+
+Use this skill when a user wants to recreate an image, layout, object, or visual concept as an interactive Three.js scene.
+
+## Stub Notes
+
+- Source: skills.sh hot list / img2threejs.
+- Suggested coverage: image analysis, scene decomposition, camera and lighting plan, geometry/material mapping, asset extraction, and render verification.
+- Suggested setup: document supported image inputs and frontend project requirements.

--- a/skills/msw-general/SKILL.md
+++ b/skills/msw-general/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: msw-general
+description: Use Mock Service Worker to mock HTTP APIs in tests, local dev, and demos.
+---
+
+# MSW General
+
+Use this skill when adding or debugging Mock Service Worker handlers for browser, Node.js, integration test, or local development workflows.
+
+## Stub Notes
+
+- Source: skills.sh hot list / msw official skills.
+- Suggested coverage: handler setup, request matching, fixtures, response composition, test integration, and unhandled request policy.
+- Suggested setup: document package manager commands and framework-specific bootstrap files.

--- a/skills/msw-scripting/SKILL.md
+++ b/skills/msw-scripting/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: msw-scripting
+description: Script reusable MSW mock scenarios, fixtures, overrides, and test data flows.
+---
+
+# MSW Scripting
+
+Use this skill when creating programmable mock API scenarios, scripted fixtures, dynamic responses, or reusable test setup around MSW.
+
+## Stub Notes
+
+- Source: skills.sh hot list / msw official skills.
+- Suggested coverage: scenario builders, fixture factories, per-test overrides, lifecycle cleanup, and deterministic mock data.
+- Suggested setup: document test runner integration and conventions for handler organization.

--- a/skills/msw-sprite-ruid/SKILL.md
+++ b/skills/msw-sprite-ruid/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: msw-sprite-ruid
+description: Build MSW-backed sprite/resource identity mocks for stable UI and API tests.
+---
+
+# MSW Sprite RUID
+
+Use this skill when tests need stable resource identifiers, sprite-like fixture collections, or repeatable mocked API entities.
+
+## Stub Notes
+
+- Source: skills.sh hot list / msw official skills.
+- Suggested coverage: deterministic IDs, fixture catalogs, resource aliases, mock lookup helpers, and snapshot-friendly test data.
+- Suggested setup: confirm upstream intent from the full source skill before expanding beyond this stub.

--- a/skills/observability-sre-triage/SKILL.md
+++ b/skills/observability-sre-triage/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: observability-sre-triage
+description: Triage incidents using logs, metrics, traces, alerts, and service health signals.
+---
+
+# Observability SRE Triage
+
+Use this skill when investigating production incidents, service degradation, alert storms, or unclear reliability regressions.
+
+## Stub Notes
+
+- Source: skills.sh hot list / elastic agent skills.
+- Suggested coverage: gather symptoms, query observability tools, form incident hypotheses, identify blast radius, and propose rollback or mitigation steps.
+- Suggested setup: document supported providers such as Elastic, Datadog, Grafana, Honeycomb, OpenTelemetry, and cloud-native monitoring APIs.

--- a/skills/payment-idempotency/SKILL.md
+++ b/skills/payment-idempotency/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: payment-idempotency
+description: Design and audit idempotent payment, checkout, refund, and webhook flows.
+---
+
+# Payment Idempotency
+
+Use this skill when implementing or reviewing payment operations that must be safe across retries, timeouts, duplicated webhooks, or partial failures.
+
+## Stub Notes
+
+- Source: skills.sh hot list / vtex skills.
+- Suggested coverage: idempotency keys, dedupe stores, transaction state machines, retry policy, webhook replay safety, and reconciliation.
+- Suggested setup: document payment provider idempotency APIs and local test fixtures.

--- a/skills/perf-lighthouse/SKILL.md
+++ b/skills/perf-lighthouse/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: perf-lighthouse
+description: Run Lighthouse audits and turn performance, accessibility, SEO, and PWA findings into fixes.
+---
+
+# Perf Lighthouse
+
+Use this skill when auditing a web page or app with Lighthouse, interpreting scores, or implementing focused improvements.
+
+## Stub Notes
+
+- Source: skills.sh hot list / tech-leads-club agent skills.
+- Suggested coverage: local preview setup, mobile/desktop Lighthouse runs, report parsing, priority ranking, and verification after fixes.
+- Suggested setup: document Chrome/Lighthouse CLI requirements and CI-friendly commands.

--- a/skills/rust-skill-creator/SKILL.md
+++ b/skills/rust-skill-creator/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: rust-skill-creator
+description: Create agent skills around Rust crates, CLIs, services, and development workflows.
+---
+
+# Rust Skill Creator
+
+Use this skill when turning a Rust tool, crate, or workflow into an AgentSkill with install notes, command examples, and safety constraints.
+
+## Stub Notes
+
+- Source: skills.sh hot list / actionbook rust skills.
+- Suggested coverage: cargo install/build commands, binary usage, crate docs, examples, test commands, and packaging conventions.
+- Suggested setup: document expected Rust toolchain and repository layout.

--- a/skills/smart-compaction/SKILL.md
+++ b/skills/smart-compaction/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: smart-compaction
+description: Compact long agent context into durable state, summaries, and next-action handoffs.
+---
+
+# Smart Compaction
+
+Use this skill when an agent session is approaching context limits or needs a durable handoff before continuing long-running work.
+
+## Stub Notes
+
+- Source: skills.sh hot list / openduo duoduo skills.
+- Suggested coverage: extract decisions, current state, blockers, commands run, files touched, validation results, and next steps.
+- Suggested setup: document where summaries are saved and how resumed agents should reload them.

--- a/skills/vtex-io-app-contract/SKILL.md
+++ b/skills/vtex-io-app-contract/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: vtex-io-app-contract
+description: Review VTEX IO app contracts, manifests, dependencies, builders, and public APIs.
+---
+
+# VTEX IO App Contract
+
+Use this skill when changing VTEX IO manifests, app dependencies, builders, peer dependencies, or public integration contracts.
+
+## Stub Notes
+
+- Source: skills.sh hot list / vtex skills.
+- Suggested coverage: manifest review, builder compatibility, exported interfaces, dependency constraints, versioning, and release impact.
+- Suggested setup: document VTEX IO manifest conventions and workspace validation commands.

--- a/skills/vtex-io-auth-tokens-and-context/SKILL.md
+++ b/skills/vtex-io-auth-tokens-and-context/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: vtex-io-auth-tokens-and-context
+description: Manage VTEX IO auth tokens, request context, identities, and permission issues.
+---
+
+# VTEX IO Auth Tokens And Context
+
+Use this skill when a VTEX IO app has authentication, authorization, token, account, workspace, or request-context problems.
+
+## Stub Notes
+
+- Source: skills.sh hot list / vtex skills.
+- Suggested coverage: app tokens, user tokens, context propagation, permission scopes, workspace/account mismatches, and safe credential handling.
+- Suggested setup: document VTEX CLI login, token inspection commands, and secrets practices.

--- a/skills/vtex-io-events-and-workers/SKILL.md
+++ b/skills/vtex-io-events-and-workers/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: vtex-io-events-and-workers
+description: Build and debug VTEX IO events, workers, queues, handlers, and async flows.
+---
+
+# VTEX IO Events And Workers
+
+Use this skill when working with VTEX IO asynchronous event processing, background workers, event handlers, queues, or related app lifecycle tasks.
+
+## Stub Notes
+
+- Source: skills.sh hot list / vtex skills.
+- Suggested coverage: event subscriptions, handler implementation, worker deployment, retries, logging, and common failure modes.
+- Suggested setup: document VTEX CLI, workspace authentication, app manifest requirements, and local testing commands.

--- a/skills/vtex-io-masterdata/SKILL.md
+++ b/skills/vtex-io-masterdata/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: vtex-io-masterdata
+description: Work with VTEX Master Data schemas, documents, queries, indexes, and APIs.
+---
+
+# VTEX IO Master Data
+
+Use this skill when building, querying, migrating, or debugging VTEX Master Data integrations.
+
+## Stub Notes
+
+- Source: skills.sh hot list / vtex skills.
+- Suggested coverage: data entities, schemas, document CRUD, search queries, index configuration, pagination, and data migration safety.
+- Suggested setup: document VTEX account credentials, app keys, API tokens, and sandbox/test workspace guidance.

--- a/skills/vtex-io-messages-and-i18n/SKILL.md
+++ b/skills/vtex-io-messages-and-i18n/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: vtex-io-messages-and-i18n
+description: Handle VTEX IO messages, translations, locales, and internationalization.
+---
+
+# VTEX IO Messages And I18n
+
+Use this skill when adding or debugging localized messages, translation files, locale fallbacks, or storefront copy in VTEX IO apps.
+
+## Stub Notes
+
+- Source: skills.sh hot list / vtex skills.
+- Suggested coverage: message keys, locale files, fallbacks, interpolation, translation validation, and release checks.
+- Suggested setup: document app structure, locale naming, and VTEX IO build/test commands.

--- a/skills/vtex-io-observability-and-ops/SKILL.md
+++ b/skills/vtex-io-observability-and-ops/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: vtex-io-observability-and-ops
+description: Operate VTEX IO apps with logs, metrics, release checks, and incident workflows.
+---
+
+# VTEX IO Observability And Ops
+
+Use this skill when diagnosing VTEX IO app health, deployment regressions, runtime errors, or operational readiness.
+
+## Stub Notes
+
+- Source: skills.sh hot list / vtex skills.
+- Suggested coverage: logs, traces, service status, workspace checks, dependency issues, deployment rollback, and escalation notes.
+- Suggested setup: document VTEX CLI authentication, org/workspace context, and available observability endpoints.


### PR DESCRIPTION
## Summary\n- Add 20 SKILL.md stubs from the September 4 daily discovery scan.\n- Cover skills.sh hot items across observability, VTEX IO, MSW, Duoduo, Lighthouse, docs, Rust, security, and Three.js workflows.\n\n## Sources\n- https://www.skills.sh/hot\n- https://github.com/sundial-org/awesome-openclaw-skills\n- Existing orthogonal-sh/skills directory checked for duplicates.\n\n## Testing\n- Checked new skill names for duplicate frontmatter names.