### PR TITLE
Add September 5 discovery skill stubs

### DIFF
--- a/skills/answer-overflow-search/SKILL.md
+++ b/skills/answer-overflow-search/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: answer-overflow-search
+description: Search indexed Discord and community Q&A pages for niche developer answers.
+---
+
+# Answer Overflow Search
+
+Use when an issue is likely discussed in Discord, community forums, or support channels rather than formal docs.
+
+## Workflow
+
+1. Start with the exact error message, package name, and version.
+2. Search Answer Overflow and public forum mirrors.
+3. Prefer answers from maintainers or recently confirmed solutions.
+4. Cross-check against official docs before changing code.
+5. Cite the discussion and note uncertainty if the answer is anecdotal.

--- a/skills/bambu-cli/SKILL.md
+++ b/skills/bambu-cli/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: bambu-cli
+description: Operate and troubleshoot Bambu Lab 3D printers from the command line.
+---
+
+# Bambu CLI
+
+Use when checking Bambu printer status, files, AMS state, cameras, jobs, or maintenance commands.
+
+## Workflow
+
+1. Confirm printer identity and whether any command affects hardware.
+2. Read current printer and job state before making changes.
+3. Ask before starting, pausing, stopping, or moving physical hardware.
+4. Capture error codes, logs, temperatures, and filament state.
+5. Prefer reversible diagnostics before corrective actions.

--- a/skills/beeper-multiplatform-messaging/SKILL.md
+++ b/skills/beeper-multiplatform-messaging/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: beeper-multiplatform-messaging
+description: Search, draft, and route messages across Beeper-connected chat networks.
+---
+
+# Beeper Multiplatform Messaging
+
+Use when finding or drafting messages across WhatsApp, Telegram, Signal, Discord, Slack, Instagram, iMessage, or similar channels.
+
+## Workflow
+
+1. Identify the target network, chat, and exact intent.
+2. Search only the minimum relevant message history.
+3. Draft replies for user approval unless explicitly authorized to send.
+4. Preserve platform formatting constraints.
+5. Never share private cross-channel context into group chats.

--- a/skills/daily-review/SKILL.md
+++ b/skills/daily-review/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: daily-review
+description: Review a day's work, messages, meetings, wins, blockers, and follow-up commitments.
+---
+
+# Daily Review
+
+Use for end-of-day summaries, personal operating reviews, and lightweight productivity retrospectives.
+
+## Workflow
+
+1. Gather calendar, messages, tasks, notes, and commits within the requested date range.
+2. Separate completed work, open loops, decisions, and blockers.
+3. Highlight anything that needs follow-up.
+4. Keep private details out of shared channels.
+5. Update memory only for durable decisions or preferences.

--- a/skills/deep-research-agent/SKILL.md
+++ b/skills/deep-research-agent/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: deep-research-agent
+description: Plan and execute multi-step research with source tracking, synthesis, and verification.
+---
+
+# Deep Research Agent
+
+Use when a request needs sustained research across many sources, conflicting evidence, or a written synthesis with citations.
+
+## Workflow
+
+1. Clarify the research question, scope, deadline, and evidence standard.
+2. Break the work into subquestions before browsing or delegating.
+3. Track sources, quotes, dates, and confidence as you go.
+4. Compare claims across primary and secondary sources.
+5. Return a concise synthesis with open questions and next research leads.

--- a/skills/dex-task-tracking/SKILL.md
+++ b/skills/dex-task-tracking/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: dex-task-tracking
+description: Track async tasks, agent dispatches, waits, and follow-ups with Dex-style state.
+---
+
+# Dex Task Tracking
+
+Use when work spans sessions, agents, repositories, or waiting periods and needs explicit state.
+
+## Workflow
+
+1. Create a task with owner, objective, current state, and next check.
+2. Link child tasks, PRs, issues, or messages.
+3. Update state whenever ownership or blockers change.
+4. Close tasks only after verification or explicit cancellation.
+5. Summarize active tasks before handoff.

--- a/skills/event-planner/SKILL.md
+++ b/skills/event-planner/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: event-planner
+description: Plan meals, trips, team outings, and local events using venue and schedule research.
+---
+
+# Event Planner
+
+Use when planning a date, team event, dinner, weekend activity, or itinerary with real venues.
+
+## Workflow
+
+1. Gather location, time window, party size, budget, mobility needs, and preferences.
+2. Check current hours, availability, travel time, and weather when relevant.
+3. Offer a short ranked list with tradeoffs.
+4. Ask before booking, paying, or contacting venues.
+5. Save the final plan only if the user wants it remembered.

--- a/skills/focus-deep-work/SKILL.md
+++ b/skills/focus-deep-work/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: focus-deep-work
+description: Plan focus sessions, reduce distractions, and track deep-work outcomes.
+---
+
+# Focus Deep Work
+
+Use when the user wants a structured focus block, distraction triage, or a realistic plan for uninterrupted work.
+
+## Workflow
+
+1. Pick one concrete outcome for the session.
+2. Break it into visible checkpoints.
+3. Remove or defer obvious interruptions.
+4. Check in only at agreed moments.
+5. Capture blockers and unfinished follow-ups at the end.

--- a/skills/ga4-analytics/SKILL.md
+++ b/skills/ga4-analytics/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: ga4-analytics
+description: Query and interpret Google Analytics 4, Search Console, and indexing signals.
+---
+
+# GA4 Analytics
+
+Use when analyzing website traffic, acquisition, conversions, pages, search queries, or SEO performance.
+
+## Workflow
+
+1. Confirm property, date range, segment, and business question.
+2. Pull GA4 metrics with dimensions that answer the question directly.
+3. Cross-check search visibility in Google Search Console when relevant.
+4. Explain anomalies with possible causes and needed follow-up data.
+5. Keep dashboards and reports reproducible.

--- a/skills/gemini-computer-use/SKILL.md
+++ b/skills/gemini-computer-use/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: gemini-computer-use
+description: Build and run Gemini Computer Use browser-control workflows with screenshots and Playwright.
+---
+
+# Gemini Computer Use
+
+Use when a browser task benefits from Gemini Computer Use, visual understanding, or screenshot-driven control.
+
+## Workflow
+
+1. Define the target site, credentials boundary, and success condition.
+2. Use Playwright or the available browser driver to capture state.
+3. Feed only necessary screenshots and context to the computer-use model.
+4. Verify final page state independently.
+5. Avoid entering credentials or taking external actions without approval.

--- a/skills/grocery-meal-planner/SKILL.md
+++ b/skills/grocery-meal-planner/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: grocery-meal-planner
+description: Build grocery lists, meal plans, pantry checks, and recipe-based shopping workflows.
+---
+
+# Grocery Meal Planner
+
+Use when the user wants meal planning, grocery lists, pantry-aware recipes, or cooking prep.
+
+## Workflow
+
+1. Gather dietary constraints, servings, budget, stores, and time available.
+2. Reuse pantry items before suggesting purchases.
+3. Group groceries by store section.
+4. Include prep steps only when they reduce friction.
+5. Avoid storing health or diet details unless explicitly asked.

--- a/skills/memory-manager/SKILL.md
+++ b/skills/memory-manager/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: memory-manager
+description: Inspect, snapshot, compact, and restore agent memory across files and indexed stores.
+---
+
+# Memory Manager
+
+Use when memory is bloated, stale, missing, duplicated, or needs a durable snapshot before a long task.
+
+## Workflow
+
+1. Identify the active memory surfaces and their visibility boundaries.
+2. Search before reading broad private memory files.
+3. Preserve exact source lines for important facts.
+4. Compact repeated or obsolete details into curated memory.
+5. Record what changed and why.

--- a/skills/model-router/SKILL.md
+++ b/skills/model-router/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: model-router
+description: Choose models and providers by task complexity, latency, cost, context, and tool needs.
+---
+
+# Model Router
+
+Use when selecting between LLM providers, local models, coding agents, or specialized inference endpoints.
+
+## Workflow
+
+1. Classify the task by risk, context length, tool requirements, and expected output.
+2. Check current model availability and known limits.
+3. Prefer the cheapest model that can meet the quality bar.
+4. Escalate for high-stakes, long-context, or tool-heavy work.
+5. Log routing lessons when the choice was notably good or bad.

--- a/skills/notebook-knowledge-base/SKILL.md
+++ b/skills/notebook-knowledge-base/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: notebook-knowledge-base
+description: Manage a local-first markdown/YAML notebook for ideas, projects, tasks, and references.
+---
+
+# Notebook Knowledge Base
+
+Use when creating or maintaining a local note system with structured metadata and agent-readable text.
+
+## Workflow
+
+1. Decide the object type: note, project, task, person, resource, or decision.
+2. Use stable filenames and lightweight frontmatter.
+3. Link related notes instead of copying large passages.
+4. Keep private notes out of shared outputs.
+5. Add retrieval hints for future searches.

--- a/skills/para-second-brain/SKILL.md
+++ b/skills/para-second-brain/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: para-second-brain
+description: Organize notes and knowledge into Projects, Areas, Resources, and Archives.
+---
+
+# PARA Second Brain
+
+Use when creating or reorganizing a durable knowledge system, personal wiki, or agent-readable note structure.
+
+## Workflow
+
+1. Separate active projects from ongoing areas, reusable resources, and archived material.
+2. Prefer links, tags, and indexes over duplicating content.
+3. Keep private or sensitive material scoped to the right workspace.
+4. Add retrieval examples for common future questions.
+5. Schedule light maintenance only when useful.

--- a/skills/perry-coding-agents/SKILL.md
+++ b/skills/perry-coding-agents/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: perry-coding-agents
+description: Dispatch coding work to Perry or similar isolated coding-agent workspaces.
+---
+
+# Perry Coding Agents
+
+Use when a coding task should run in a separate workspace with clear assignment, review, and merge boundaries.
+
+## Workflow
+
+1. Write a self-contained task brief with repo, branch, constraints, and verification.
+2. Spawn or select the target Perry workspace.
+3. Monitor progress without micromanaging implementation details.
+4. Review diffs, tests, and final notes before accepting work.
+5. Preserve user changes and avoid cross-workspace confusion.

--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: planning-with-files
+description: Keep complex plans, findings, and progress in durable files during long tasks.
+---
+
+# Planning With Files
+
+Use for long-running or multi-session tasks where plan state must survive context loss.
+
+## Workflow
+
+1. Create or update a task plan file in the project workspace.
+2. Keep findings, decisions, and progress separate enough to scan.
+3. Update statuses as work completes.
+4. Treat the files as coordination artifacts, not private memory dumps.
+5. Summarize the current state before handing off or pausing.

--- a/skills/proxmox-admin/SKILL.md
+++ b/skills/proxmox-admin/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: proxmox-admin
+description: Manage Proxmox nodes, VMs, containers, storage, snapshots, and cluster health.
+---
+
+# Proxmox Admin
+
+Use for Proxmox VE inventory, health checks, VM/LXC lifecycle, snapshots, backups, and resource troubleshooting.
+
+## Workflow
+
+1. Inspect cluster, node, and storage health first.
+2. Identify the exact VM or container before lifecycle commands.
+3. Prefer snapshots or backups before risky changes.
+4. Ask before stopping, deleting, resizing, or migrating workloads.
+5. Report task IDs and final resource state.

--- a/skills/reflective-agent/SKILL.md
+++ b/skills/reflective-agent/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: reflective-agent
+description: Turn corrections, failures, and repeated wins into durable agent behavior updates.
+---
+
+# Reflective Agent
+
+Use after a mistake, correction, surprising success, or repeated workflow pattern that should influence future behavior.
+
+## Workflow
+
+1. Capture the event in neutral, concrete terms.
+2. Identify the behavior that should change or be reinforced.
+3. Decide whether the learning belongs in memory, workspace instructions, or a skill.
+4. Keep the update narrow and testable.
+5. Tell the user when durable behavior has changed.

--- a/skills/skilllens-audit/SKILL.md
+++ b/skills/skilllens-audit/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: skilllens-audit
+description: Audit local agent skills for trigger clarity, safety, packaging, and prompt-injection risk.
+---
+
+# SkillLens Audit
+
+Use when reviewing installed or proposed agent skills for safety, maintainability, and usefulness.
+
+## Workflow
+
+1. Inventory skill locations, manifests, and referenced assets.
+2. Check trigger specificity, permissions, external actions, and private-data handling.
+3. Flag hidden instructions, broad authority, and unsafe shell patterns.
+4. Recommend small fixes before large rewrites.
+5. Produce a findings-first report with file references.


### PR DESCRIPTION
Adds 20 SKILL.md stubs from the September 5 daily discovery pass.\n\nSources checked:\n- skills.sh and skills.sh/hot\n- sundial-org/awesome-openclaw-skills\n- current orthogonal-sh/skills main\n- memory/discovery-posts.md\n\nThe picks avoid the names already tracked in previous discovery posts.