### PR TITLE
Add daily discovery skill stubs

### DIFF
--- a/skills/clerk-nextjs-patterns/SKILL.md
+++ b/skills/clerk-nextjs-patterns/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: clerk-nextjs-patterns
+description: Apply Clerk patterns in Next.js apps. Use for App Router auth, server components, route protection, and user/session access.
+---
+
+# Clerk Next.js Patterns
+
+Stub for a future Orthogonal skill.
+
+Use this skill when a Next.js task needs Clerk-aware routing, server/client auth boundaries, protected pages, organization support, or session/user data access.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/clerk-setup/SKILL.md
+++ b/skills/clerk-setup/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: clerk-setup
+description: Set up Clerk authentication in web apps. Use when adding Clerk, configuring env vars, middleware, providers, or auth routes.
+---
+
+# Clerk Setup
+
+Stub for a future Orthogonal skill.
+
+Use this skill when a task involves installing Clerk, wiring environment variables, configuring middleware, or verifying that sign-in/sign-up flows are correctly mounted.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/clerk-testing/SKILL.md
+++ b/skills/clerk-testing/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: clerk-testing
+description: Test Clerk-backed auth flows. Use for mocks, fixtures, protected-route tests, webhook tests, and auth state setup.
+---
+
+# Clerk Testing
+
+Stub for a future Orthogonal skill.
+
+Use this skill when writing unit, integration, or end-to-end tests around Clerk authentication, authorization, user metadata, sessions, or webhook event handling.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/clerk-webhooks/SKILL.md
+++ b/skills/clerk-webhooks/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: clerk-webhooks
+description: Build and debug Clerk webhooks. Use for user/org sync, signature verification, idempotency, retries, and event handlers.
+---
+
+# Clerk Webhooks
+
+Stub for a future Orthogonal skill.
+
+Use this skill when implementing Clerk webhook receivers, syncing identities into an app database, verifying signatures, or making webhook processing idempotent.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/convex-auth/SKILL.md
+++ b/skills/convex-auth/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: convex-auth
+description: Implement authentication with Convex. Use for auth providers, identity mapping, permissions, and protected Convex functions.
+---
+
+# Convex Auth
+
+Stub for a future Orthogonal skill.
+
+Use this skill when connecting authentication providers to Convex, mapping users to application records, or enforcing permissions in queries and mutations.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/convex-backup/SKILL.md
+++ b/skills/convex-backup/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: convex-backup
+description: Plan Convex backup and restore workflows. Use for exports, recovery checks, migrations, and data safety reviews.
+---
+
+# Convex Backup
+
+Stub for a future Orthogonal skill.
+
+Use this skill when a Convex app needs export, backup, restore, disaster recovery, migration rehearsal, or data retention guidance.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/convex-crons/SKILL.md
+++ b/skills/convex-crons/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: convex-crons
+description: Build scheduled work in Convex. Use for cron jobs, periodic maintenance, retries, and background workflows.
+---
+
+# Convex Crons
+
+Stub for a future Orthogonal skill.
+
+Use this skill when adding or reviewing scheduled Convex work, background maintenance, retry loops, cleanup tasks, or time-based application behavior.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/convex-deploy-guard/SKILL.md
+++ b/skills/convex-deploy-guard/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: convex-deploy-guard
+description: Guard Convex deployments. Use for schema migration safety, env checks, deploy readiness, and production risk review.
+---
+
+# Convex Deploy Guard
+
+Stub for a future Orthogonal skill.
+
+Use this skill before deploying Convex changes that affect schema, indexes, auth, environment variables, background jobs, or production data.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/convex-design/SKILL.md
+++ b/skills/convex-design/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: convex-design
+description: Design Convex data models and functions. Use for schema shape, queries, mutations, indexes, and reactive app architecture.
+---
+
+# Convex Design
+
+Stub for a future Orthogonal skill.
+
+Use this skill when planning Convex schemas, query/mutation boundaries, indexes, server functions, and data flows for reactive applications.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/expo-dev-client/SKILL.md
+++ b/skills/expo-dev-client/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: expo-dev-client
+description: Work with Expo development builds. Use for dev clients, native modules, EAS builds, config plugins, and simulator/device testing.
+---
+
+# Expo Dev Client
+
+Stub for a future Orthogonal skill.
+
+Use this skill when an Expo app needs development builds, custom native modules, config plugins, EAS workflows, or device/simulator debugging.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/expo-router/SKILL.md
+++ b/skills/expo-router/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: expo-router
+description: Build Expo Router apps. Use for file-based navigation, layouts, route groups, deep links, tabs, stacks, and mobile routing issues.
+---
+
+# Expo Router
+
+Stub for a future Orthogonal skill.
+
+Use this skill when implementing or debugging Expo Router navigation, layouts, nested stacks, tab groups, deep links, modal routes, or route params.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/fastify-best-practices/SKILL.md
+++ b/skills/fastify-best-practices/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: fastify-best-practices
+description: Build and review Fastify services. Use for plugins, schemas, lifecycle hooks, performance, testing, and production hardening.
+---
+
+# Fastify Best Practices
+
+Stub for a future Orthogonal skill.
+
+Use this skill when implementing or reviewing Fastify APIs, plugin structure, JSON schemas, validation, lifecycle hooks, tests, or service hardening.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/gsap-performance/SKILL.md
+++ b/skills/gsap-performance/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: gsap-performance
+description: Optimize GSAP animation performance. Use for timeline profiling, layout thrash, scroll jank, GPU hints, and mobile smoothness.
+---
+
+# GSAP Performance
+
+Stub for a future Orthogonal skill.
+
+Use this skill when GSAP animations are janky, expensive, layout-heavy, or need profiling and tuning across desktop and mobile browsers.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/gsap-scrolltrigger/SKILL.md
+++ b/skills/gsap-scrolltrigger/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: gsap-scrolltrigger
+description: Build GSAP ScrollTrigger interactions. Use for scroll timelines, pins, refresh behavior, responsive triggers, and debugging.
+---
+
+# GSAP ScrollTrigger
+
+Stub for a future Orthogonal skill.
+
+Use this skill when building or debugging ScrollTrigger timelines, pinned sections, responsive scroll interactions, trigger refreshes, or scroll-based animation state.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/interface-review/SKILL.md
+++ b/skills/interface-review/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: interface-review
+description: Review UI interfaces for clarity and usability. Use for visual hierarchy, content fit, interaction states, and responsive issues.
+---
+
+# Interface Review
+
+Stub for a future Orthogonal skill.
+
+Use this skill when reviewing application screens for usability, visual hierarchy, layout fit, interactive states, accessibility signals, and responsive polish.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: mcp-builder
+description: Build MCP servers and tools. Use for tool schemas, transports, auth, resource design, testing, and packaging Model Context Protocol integrations.
+---
+
+# MCP Builder
+
+Stub for a future Orthogonal skill.
+
+Use this skill when designing, implementing, testing, or packaging a Model Context Protocol server, tool set, resource surface, or integration transport.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/neon-ai-gateway/SKILL.md
+++ b/skills/neon-ai-gateway/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: neon-ai-gateway
+description: Use Neon AI Gateway with Postgres apps. Use for SQL-aware AI workflows, connection setup, auth, and usage review.
+---
+
+# Neon AI Gateway
+
+Stub for a future Orthogonal skill.
+
+Use this skill when integrating Neon-hosted Postgres with AI workflows, database-aware agents, credentials, connection routing, or usage checks.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/neon-postgres-branches/SKILL.md
+++ b/skills/neon-postgres-branches/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: neon-postgres-branches
+description: Manage Neon Postgres branches. Use for preview databases, branch creation, migrations, resets, and safe review environments.
+---
+
+# Neon Postgres Branches
+
+Stub for a future Orthogonal skill.
+
+Use this skill when working with Neon branching for previews, migrations, isolated experiments, CI databases, or production-safe review workflows.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/playwright-best-practices/SKILL.md
+++ b/skills/playwright-best-practices/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: playwright-best-practices
+description: Write reliable Playwright tests. Use for selectors, fixtures, retries, traces, CI stability, and flake triage.
+---
+
+# Playwright Best Practices
+
+Stub for a future Orthogonal skill.
+
+Use this skill when designing Playwright suites, choosing locators, debugging flaky tests, collecting traces, or improving CI browser-test reliability.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.

--- a/skills/stripe-best-practices/SKILL.md
+++ b/skills/stripe-best-practices/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: stripe-best-practices
+description: Build Stripe integrations safely. Use for checkout, webhooks, idempotency, subscriptions, refunds, and payment-state audits.
+---
+
+# Stripe Best Practices
+
+Stub for a future Orthogonal skill.
+
+Use this skill when implementing Stripe Checkout, Billing, webhooks, idempotent payment flows, refunds, customer portals, or payment-state reconciliation.
+
+## Source
+
+Discovered from `skills.sh` and `sundial-org/awesome-openclaw-skills`.


### PR DESCRIPTION
Adds 20 SKILL.md stubs from the September 6 daily skills discovery run.\n\nSources reviewed:\n- skills.sh\n- skills.sh/trending\n- sundial-org/awesome-openclaw-skills\n- current orthogonal-sh/skills main\n- local discovery post history